### PR TITLE
New requirements for normalization of domain names

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -13,6 +13,7 @@ use File::Slurp qw(append_file);
 use Zonemaster::LDNS;
 use Net::IP::XS qw(:PROC);
 use HTML::Entities;
+use Data::Dumper;
 
 # Zonemaster Modules
 use Zonemaster::Engine;
@@ -290,10 +291,12 @@ sub start_domain_test {
     my $result = 0;
 
     $params->{domain} =~ s/^\.// unless ( !$params->{domain} || $params->{domain} eq '.' );
+    $params->{domain} .= '.' if '.' ne substr $params->{domain}, -1;
+
     my $syntax_result = $self->validate_syntax( $params );
     die "$syntax_result->{message} \n" unless ( $syntax_result && $syntax_result->{status} eq 'ok' );
 
-    die "No domain in parameters\n" unless ( $params->{domain} );
+    die "No domain in parameters\n" unless ( $params->{domain} ); #Dead code ?
     
     if ($params->{config}) {
         $params->{config} =~ s/[^\w_]//isg;

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -214,11 +214,12 @@ sub to_idn {
     my ( $self, $str ) = @_;
 
     if ( $str =~ m/^[[:ascii:]]+$/ ) {
+        $str = lc $str;
         return $str;
     }
 
     if ( Zonemaster::LDNS::has_idn() ) {
-        return Zonemaster::LDNS::to_idn( $str );
+        return lc Zonemaster::LDNS::to_idn( $str );
     }
     else {
         warn __( "Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII names correctly." );


### PR DESCRIPTION
- Trailing dot MUST be appended if it's missing. (RPCAPI)
- Upper case characters in ASCII labels MUST be converted into lower case. (TestAgent)

fix issue #414 