### PR TITLE
Fix code part of issue #405 - use the new profiles feature of the Zonemaster-Engine

### DIFF
--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -24,21 +24,14 @@ else {
 
 =cut
 
-sub new {
+sub load_config {
     my ( $class, $params ) = @_;
     my $self = {};
     
-    $self->{cfg} = _load_config();
+    $self->{cfg} = Config::IniFiles->new( -file => $path );
+    die "UNABLE TO LOAD $path ERRORS:[".join('; ', @Config::IniFiles::errors)."] \n" unless ( $self->{cfg} );
     bless( $self, $class );
     return $self;
-}
-
-
-sub _load_config {
-    my $cfg = Config::IniFiles->new( -file => $path );
-    die "UNABLE TO LOAD $path ERRORS:[".join('; ', @Config::IniFiles::errors)."] \n" unless ( $cfg );
-
-    return $cfg;
 }
 
 sub BackendDBType {
@@ -160,17 +153,17 @@ sub force_hash_id_use_in_API_starting_from_id {
 }
 
 sub ReadProfilesInfo {
-	my ($self) = @_;
-	
-	my $profiles;
-	foreach my $public_profile ($self->{cfg}->Parameters('PUBLIC PROFILES')) {
-		$profiles->{lc($public_profile)}->{type} = 'public';
-		$profiles->{lc($public_profile)}->{profile_file_name} = $self->{cfg}->val('PUBLIC PROFILES', $public_profile);
+    my ($self) = @_;
+    
+    my $profiles;
+    foreach my $public_profile ($self->{cfg}->Parameters('PUBLIC PROFILES')) {
+        $profiles->{lc($public_profile)}->{type} = 'public';
+        $profiles->{lc($public_profile)}->{profile_file_name} = $self->{cfg}->val('PUBLIC PROFILES', $public_profile);
     }
 
-	foreach my $public_profile ($self->{cfg}->Parameters('PRIVATE PROFILES')) {
-		$profiles->{lc($public_profile)}->{type} = 'private';
-		$profiles->{lc($public_profile)}->{profile_file_name} = $self->{cfg}->val('PRIVATE PROFILES', $public_profile);
+    foreach my $private_profile ($self->{cfg}->Parameters('PRIVATE PROFILES')) {
+        $profiles->{lc($private_profile)}->{type} = 'private';
+        $profiles->{lc($private_profile)}->{profile_file_name} = $self->{cfg}->val('PRIVATE PROFILES', $private_profile);
     }
     
     return $profiles;
@@ -193,7 +186,7 @@ The adapter connects to the database before it is returned.
 =head3 INPUT
 
 The database adapter class is selected based on the return value
-of L<Zonemaster::Backend::Config->new()->BackendDBType()>. The database
+of L<Zonemaster::Backend::Config->load_config()->BackendDBType()>. The database
 adapter class constructor is called without arguments and is expected
 to configure itself according to available global configuration.
 
@@ -219,7 +212,7 @@ A configured L<Zonemaster::Backend::DB> object.
 
 sub new_DB {
     # Get DB type from config
-    my $dbtype = Zonemaster::Backend::Config->new()->BackendDBType();
+    my $dbtype = Zonemaster::Backend::Config->load_config()->BackendDBType();
     if (!defined $dbtype) {
         die "Unrecognized DB.engine in backend config";
     }

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -24,6 +24,16 @@ else {
 
 =cut
 
+sub new {
+    my ( $class, $params ) = @_;
+    my $self = {};
+    
+    $self->{cfg} = _load_config();
+    bless( $self, $class );
+    return $self;
+}
+
+
 sub _load_config {
     my $cfg = Config::IniFiles->new( -file => $path );
     die "UNABLE TO LOAD $path ERRORS:[".join('; ', @Config::IniFiles::errors)."] \n" unless ( $cfg );
@@ -32,17 +42,17 @@ sub _load_config {
 }
 
 sub BackendDBType {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
     my $result;
 
-    if ( lc( $cfg->val( 'DB', 'engine' ) ) eq 'sqlite' ) {
+    if ( lc( $self->{cfg}->val( 'DB', 'engine' ) ) eq 'sqlite' ) {
         $result = 'SQLite';
     }
-    elsif ( lc( $cfg->val( 'DB', 'engine' ) ) eq 'postgresql' ) {
+    elsif ( lc( $self->{cfg}->val( 'DB', 'engine' ) ) eq 'postgresql' ) {
         $result = 'PostgreSQL';
     }
-    elsif ( lc( $cfg->val( 'DB', 'engine' ) ) eq 'mysql' ) {
+    elsif ( lc( $self->{cfg}->val( 'DB', 'engine' ) ) eq 'mysql' ) {
         $result = 'MySQL';
     }
 
@@ -50,125 +60,126 @@ sub BackendDBType {
 }
 
 sub DB_user {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    return $cfg->val( 'DB', 'user' );
+    return $self->{cfg}->val( 'DB', 'user' );
 }
 
 sub DB_password {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    return $cfg->val( 'DB', 'password' );
+    return $self->{cfg}->val( 'DB', 'password' );
 }
 
 sub DB_name {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    return $cfg->val( 'DB', 'database_name' );
+    return $self->{cfg}->val( 'DB', 'database_name' );
 }
 
 sub DB_connection_string {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    my $db_engine = $_[1] || $cfg->val( 'DB', 'engine' );
+    my $db_engine = $_[1] || $self->{cfg}->val( 'DB', 'engine' );
 
     my $result;
 
     if ( lc( $db_engine ) eq 'sqlite' ) {
-        $result = sprintf('DBI:SQLite:dbname=%s', $cfg->val( 'DB', 'database_name' ));
+        $result = sprintf('DBI:SQLite:dbname=%s', $self->{cfg}->val( 'DB', 'database_name' ));
     }
     elsif ( lc( $db_engine ) eq 'postgresql' ) {
-        $result = sprintf('DBI:Pg:database=%s;host=%s', $cfg->val( 'DB', 'database_name' ), $cfg->val( 'DB', 'database_host' ));
+        $result = sprintf('DBI:Pg:database=%s;host=%s', $self->{cfg}->val( 'DB', 'database_name' ), $self->{cfg}->val( 'DB', 'database_host' ));
     }
     elsif ( lc( $db_engine ) eq 'mysql' ) {
-        $result = sprintf('DBI:mysql:database=%s;host=%s', $cfg->val( 'DB', 'database_name' ), $cfg->val( 'DB', 'database_host' ));
+        $result = sprintf('DBI:mysql:database=%s;host=%s', $self->{cfg}->val( 'DB', 'database_name' ), $self->{cfg}->val( 'DB', 'database_host' ));
     }
 
     return $result;
 }
 
 sub LogDir {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    return $cfg->val( 'LOG', 'log_dir' );
+    return $self->{cfg}->val( 'LOG', 'log_dir' );
 }
 
 sub PerlIntereter {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    return $cfg->val( 'PERL', 'interpreter' );
+    return $self->{cfg}->val( 'PERL', 'interpreter' );
 }
 
 sub PollingInterval {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    return $cfg->val( 'DB', 'polling_interval' );
+    return $self->{cfg}->val( 'DB', 'polling_interval' );
 }
 
 sub MaxZonemasterExecutionTime {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    return $cfg->val( 'ZONEMASTER', 'max_zonemaster_execution_time' );
+    return $self->{cfg}->val( 'ZONEMASTER', 'max_zonemaster_execution_time' );
 }
 
 sub NumberOfProcessesForFrontendTesting {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    my $nb = $cfg->val( 'ZONEMASTER', 'number_of_professes_for_frontend_testing' );
-    $nb = $cfg->val( 'ZONEMASTER', 'number_of_processes_for_frontend_testing' ) unless ($nb);
+    my $nb = $self->{cfg}->val( 'ZONEMASTER', 'number_of_professes_for_frontend_testing' );
+    $nb = $self->{cfg}->val( 'ZONEMASTER', 'number_of_processes_for_frontend_testing' ) unless ($nb);
     
     return $nb;
 }
 
 sub NumberOfProcessesForBatchTesting {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    my $nb = $cfg->val( 'ZONEMASTER', 'number_of_professes_for_batch_testing' );
-    $nb = $cfg->val( 'ZONEMASTER', 'number_of_processes_for_batch_testing' ) unless ($nb);
+    my $nb = $self->{cfg}->val( 'ZONEMASTER', 'number_of_professes_for_batch_testing' );
+    $nb = $self->{cfg}->val( 'ZONEMASTER', 'number_of_processes_for_batch_testing' ) unless ($nb);
     
     return $nb;
 }
 
 sub Maxmind_ISP_DB_File {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    return $cfg->val( 'GEOLOCATION', 'maxmind_isp_db_file' );
+    return $self->{cfg}->val( 'GEOLOCATION', 'maxmind_isp_db_file' );
 }
 
 sub Maxmind_City_DB_File {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    return $cfg->val( 'GEOLOCATION', 'maxmind_city_db_file' );
+    return $self->{cfg}->val( 'GEOLOCATION', 'maxmind_city_db_file' );
 }
 
 sub force_hash_id_use_in_API_starting_from_id {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    my $val = $cfg->val( 'ZONEMASTER', 'force_hash_id_use_in_API_starting_from_id' );
+    my $val = $self->{cfg}->val( 'ZONEMASTER', 'force_hash_id_use_in_API_starting_from_id' );
 
     return ($val)?($val):(0);
 }
 
-sub CustomProfilesPath {
-    my $cfg = _load_config();
-
-    my $value  = $cfg->val( 'ZONEMASTER', 'cutom_profiles_path' );
-    $value  = $cfg->val( 'ZONEMASTER', 'custom_profiles_path' ) unless ($value);
-    return $value;
-}
-
-sub GetCustomConfigParameter {
-	my ($slef, $section, $param_name) = @_;
+sub ReadProfilesInfo {
+	my ($self) = @_;
 	
-    my $cfg = _load_config();
+	my $profiles;
+	foreach my $public_profile ($self->{cfg}->Parameters('PUBLIC PROFILES')) {
+		$profiles->{lc($public_profile)}->{type} = 'public';
+		$profiles->{lc($public_profile)}->{profile_file_name} = $self->{cfg}->val('PUBLIC PROFILES', $public_profile);
+    }
 
-    return $cfg->val( $section, $param_name );
+	foreach my $public_profile ($self->{cfg}->Parameters('PRIVATE PROFILES')) {
+		$profiles->{lc($public_profile)}->{type} = 'private';
+		$profiles->{lc($public_profile)}->{profile_file_name} = $self->{cfg}->val('PRIVATE PROFILES', $public_profile);
+    }
+    
+    return $profiles;
 }
 
 sub lock_on_queue {
-    my $cfg = _load_config();
+    my ($self) = @_;
 
-    my $val = $cfg->val( 'ZONEMASTER', 'lock_on_queue' );
+    my $val = $self->{cfg}->val( 'ZONEMASTER', 'lock_on_queue' );
 
     return $val;
 }
@@ -182,7 +193,7 @@ The adapter connects to the database before it is returned.
 =head3 INPUT
 
 The database adapter class is selected based on the return value
-of L<Zonemaster::Backend::Config->BackendDBType()>. The database
+of L<Zonemaster::Backend::Config->new()->BackendDBType()>. The database
 adapter class constructor is called without arguments and is expected
 to configure itself according to available global configuration.
 
@@ -208,7 +219,7 @@ A configured L<Zonemaster::Backend::DB> object.
 
 sub new_DB {
     # Get DB type from config
-    my $dbtype = Zonemaster::Backend::Config->BackendDBType();
+    my $dbtype = Zonemaster::Backend::Config->new()->BackendDBType();
     if (!defined $dbtype) {
         die "Unrecognized DB.engine in backend config";
     }

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -169,6 +169,18 @@ sub ReadProfilesInfo {
     return $profiles;
 }
 
+sub ListPublicProfiles {
+    my ($self) = @_;
+    
+    my $profiles = [];
+    foreach my $public_profile ($self->{cfg}->Parameters('PUBLIC PROFILES')) {
+        $profiles->{lc($public_profile)}->{type} = 'public';
+        $profiles->{lc($public_profile)}->{profile_file_name} = $self->{cfg}->val('PUBLIC PROFILES', $public_profile);
+    }
+
+    return @$profiles;
+}
+
 sub lock_on_queue {
     my ($self) = @_;
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -103,7 +103,7 @@ sub LogDir {
     return $self->{cfg}->val( 'LOG', 'log_dir' );
 }
 
-sub PerlIntereter {
+sub PerlInterpreter {
     my ($self) = @_;
 
     return $self->{cfg}->val( 'PERL', 'interpreter' );

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -172,13 +172,13 @@ sub ReadProfilesInfo {
 sub ListPublicProfiles {
     my ($self) = @_;
     
-    my $profiles = [];
+    my $profiles;
     foreach my $public_profile ($self->{cfg}->Parameters('PUBLIC PROFILES')) {
         $profiles->{lc($public_profile)}->{type} = 'public';
         $profiles->{lc($public_profile)}->{profile_file_name} = $self->{cfg}->val('PUBLIC PROFILES', $public_profile);
     }
 
-    return @$profiles;
+    return keys %$profiles;
 }
 
 sub lock_on_queue {

--- a/lib/Zonemaster/Backend/Config/DCPlugin.pm
+++ b/lib/Zonemaster/Backend/Config/DCPlugin.pm
@@ -95,7 +95,7 @@ Loads, validates and sanity-checks the backend configuration.
 =cut
 
 sub _do_load_config {
-    %config = ( db => Zonemaster::Backend::Config->new_DB() );
+    %config = ( db => Zonemaster::Backend::Config->new()->new_DB() );
 }
 
 1;

--- a/lib/Zonemaster/Backend/Config/DCPlugin.pm
+++ b/lib/Zonemaster/Backend/Config/DCPlugin.pm
@@ -95,7 +95,7 @@ Loads, validates and sanity-checks the backend configuration.
 =cut
 
 sub _do_load_config {
-    %config = ( db => Zonemaster::Backend::Config->new()->new_DB() );
+    %config = ( db => Zonemaster::Backend::Config->load_config()->new_DB() );
 }
 
 1;

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -42,7 +42,7 @@ sub _get_allowed_id_field_name {
 		$id_field = 'hash_id';
     }
     else {
-		if ($test_id <= Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id()) {
+		if ($test_id <= Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id()) {
 			$id_field = 'id';
 		}
 		else {
@@ -60,7 +60,7 @@ sub get_test_request {
     
     
     my ( $id, $hash_id );
-    my $lock_on_queue = Zonemaster::Backend::Config->new()->lock_on_queue();
+    my $lock_on_queue = Zonemaster::Backend::Config->load_config()->lock_on_queue();
 	if ( defined $lock_on_queue ) {
 		( $id, $hash_id ) = $dbh->selectrow_array( qq[ SELECT id, hash_id FROM test_results WHERE progress=0 AND queue=? ORDER BY priority DESC, id ASC LIMIT 1 ], undef, $lock_on_queue );
 	}
@@ -71,7 +71,7 @@ sub get_test_request {
     if ($id) {
 		$dbh->do( q[UPDATE test_results SET progress=1 WHERE id=?], undef, $id );
 
-		if ( $id > Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id() ) {
+		if ( $id > Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id() ) {
 			$result_id = $hash_id;
 		}
 		else {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -42,7 +42,7 @@ sub _get_allowed_id_field_name {
 		$id_field = 'hash_id';
     }
     else {
-		if ($test_id <= Zonemaster::Backend::Config->force_hash_id_use_in_API_starting_from_id()) {
+		if ($test_id <= Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id()) {
 			$id_field = 'id';
 		}
 		else {
@@ -60,7 +60,7 @@ sub get_test_request {
     
     
     my ( $id, $hash_id );
-    my $lock_on_queue = Zonemaster::Backend::Config->lock_on_queue();
+    my $lock_on_queue = Zonemaster::Backend::Config->new()->lock_on_queue();
 	if ( defined $lock_on_queue ) {
 		( $id, $hash_id ) = $dbh->selectrow_array( qq[ SELECT id, hash_id FROM test_results WHERE progress=0 AND queue=? ORDER BY priority DESC, id ASC LIMIT 1 ], undef, $lock_on_queue );
 	}
@@ -71,7 +71,7 @@ sub get_test_request {
     if ($id) {
 		$dbh->do( q[UPDATE test_results SET progress=1 WHERE id=?], undef, $id );
 
-		if ( $id > Zonemaster::Backend::Config->force_hash_id_use_in_API_starting_from_id() ) {
+		if ( $id > Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id() ) {
 			$result_id = $hash_id;
 		}
 		else {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -19,10 +19,10 @@ has 'dbhandle' => (
     isa => 'DBI::db',
 );
 
-my $connection_string   = Zonemaster::Backend::Config->DB_connection_string( 'mysql' );
+my $connection_string   = Zonemaster::Backend::Config->new()->DB_connection_string( 'mysql' );
 my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-my $connection_user     = Zonemaster::Backend::Config->DB_user();
-my $connection_password = Zonemaster::Backend::Config->DB_password();
+my $connection_user     = Zonemaster::Backend::Config->new()->DB_user();
+my $connection_password = Zonemaster::Backend::Config->new()->DB_password();
 
 sub dbh {
     my ( $self ) = @_;
@@ -123,7 +123,7 @@ SELECT id, hash_id FROM test_results WHERE params_deterministic_hash = ? AND (TO
 
         if ( $recent_id ) {
             # A recent entry exists, so return its id
-            if ( $recent_id > Zonemaster::Backend::Config->force_hash_id_use_in_API_starting_from_id() ) {
+            if ( $recent_id > Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id() ) {
                 $result_id = $recent_hash_id;
             }
             else {
@@ -148,7 +148,7 @@ SELECT id, hash_id FROM test_results WHERE params_deterministic_hash = ? AND (TO
             my ( $id, $hash_id ) = $dbh->selectrow_array(
                 "SELECT id, hash_id FROM test_results WHERE params_deterministic_hash='$test_params_deterministic_hash' ORDER BY id DESC LIMIT 1" );
                 
-            if ( $id > Zonemaster::Backend::Config->force_hash_id_use_in_API_starting_from_id() ) {
+            if ( $id > Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id() ) {
                 $result_id = $hash_id;
             }
             else {
@@ -222,7 +222,7 @@ sub get_test_history {
     my @results;
     my $sth = {};
 
-    my $use_hash_id_from_id = Zonemaster::Backend::Config->force_hash_id_use_in_API_starting_from_id();
+    my $use_hash_id_from_id = Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id();
 
     my $undelegated = "";
     if ($p->{filter} eq "old_behavior" ) {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -19,10 +19,10 @@ has 'dbhandle' => (
     isa => 'DBI::db',
 );
 
-my $connection_string   = Zonemaster::Backend::Config->new()->DB_connection_string( 'mysql' );
+my $connection_string   = Zonemaster::Backend::Config->load_config()->DB_connection_string( 'mysql' );
 my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-my $connection_user     = Zonemaster::Backend::Config->new()->DB_user();
-my $connection_password = Zonemaster::Backend::Config->new()->DB_password();
+my $connection_user     = Zonemaster::Backend::Config->load_config()->DB_user();
+my $connection_password = Zonemaster::Backend::Config->load_config()->DB_password();
 
 sub dbh {
     my ( $self ) = @_;
@@ -123,7 +123,7 @@ SELECT id, hash_id FROM test_results WHERE params_deterministic_hash = ? AND (TO
 
         if ( $recent_id ) {
             # A recent entry exists, so return its id
-            if ( $recent_id > Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id() ) {
+            if ( $recent_id > Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id() ) {
                 $result_id = $recent_hash_id;
             }
             else {
@@ -148,7 +148,7 @@ SELECT id, hash_id FROM test_results WHERE params_deterministic_hash = ? AND (TO
             my ( $id, $hash_id ) = $dbh->selectrow_array(
                 "SELECT id, hash_id FROM test_results WHERE params_deterministic_hash='$test_params_deterministic_hash' ORDER BY id DESC LIMIT 1" );
                 
-            if ( $id > Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id() ) {
+            if ( $id > Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id() ) {
                 $result_id = $hash_id;
             }
             else {
@@ -222,7 +222,7 @@ sub get_test_history {
     my @results;
     my $sth = {};
 
-    my $use_hash_id_from_id = Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id();
+    my $use_hash_id_from_id = Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id();
 
     my $undelegated = "";
     if ($p->{filter} eq "old_behavior" ) {

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -20,10 +20,10 @@ has 'dbhandle' => (
     isa => 'DBI::db',
 );
 
-my $connection_string   = Zonemaster::Backend::Config->new()->DB_connection_string( 'postgresql' );
+my $connection_string   = Zonemaster::Backend::Config->load_config()->DB_connection_string( 'postgresql' );
 my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-my $connection_user     = Zonemaster::Backend::Config->new()->DB_user();
-my $connection_password = Zonemaster::Backend::Config->new()->DB_password();
+my $connection_user     = Zonemaster::Backend::Config->load_config()->DB_user();
+my $connection_password = Zonemaster::Backend::Config->load_config()->DB_password();
 
 sub dbh {
     my ( $self ) = @_;
@@ -145,7 +145,7 @@ sub create_new_test {
     my ( $id, $hash_id ) = $dbh->selectrow_array(
         "SELECT id, hash_id FROM test_results WHERE params_deterministic_hash='$test_params_deterministic_hash' ORDER BY id DESC LIMIT 1" );
         
-    if ( $id > Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id() ) {
+    if ( $id > Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id() ) {
         $result = $hash_id;
     }
     else {
@@ -195,7 +195,7 @@ sub get_test_history {
 
     my $dbh = $self->dbh;
 
-    my $use_hash_id_from_id = Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id();
+    my $use_hash_id_from_id = Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id();
     my $undelegated = "";
     if ($p->{filter} eq "old_behavior" ) {
         $undelegated = (defined $p->{frontend_params}->{nameservers})

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -20,10 +20,10 @@ has 'dbhandle' => (
     isa => 'DBI::db',
 );
 
-my $connection_string   = Zonemaster::Backend::Config->DB_connection_string( 'postgresql' );
+my $connection_string   = Zonemaster::Backend::Config->new()->DB_connection_string( 'postgresql' );
 my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-my $connection_user     = Zonemaster::Backend::Config->DB_user();
-my $connection_password = Zonemaster::Backend::Config->DB_password();
+my $connection_user     = Zonemaster::Backend::Config->new()->DB_user();
+my $connection_password = Zonemaster::Backend::Config->new()->DB_password();
 
 sub dbh {
     my ( $self ) = @_;
@@ -34,6 +34,7 @@ sub dbh {
     }
     else {
         $dbh = DBI->connect( $connection_string, $connection_user, $connection_password, $connection_args );
+        $dbh->{InactiveDestroy} = 1;
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );
         return $dbh;
@@ -144,7 +145,7 @@ sub create_new_test {
     my ( $id, $hash_id ) = $dbh->selectrow_array(
         "SELECT id, hash_id FROM test_results WHERE params_deterministic_hash='$test_params_deterministic_hash' ORDER BY id DESC LIMIT 1" );
         
-    if ( $id > Zonemaster::Backend::Config->force_hash_id_use_in_API_starting_from_id() ) {
+    if ( $id > Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id() ) {
         $result = $hash_id;
     }
     else {
@@ -194,7 +195,7 @@ sub get_test_history {
 
     my $dbh = $self->dbh;
 
-    my $use_hash_id_from_id = Zonemaster::Backend::Config->force_hash_id_use_in_API_starting_from_id();
+    my $use_hash_id_from_id = Zonemaster::Backend::Config->new()->force_hash_id_use_in_API_starting_from_id();
     my $undelegated = "";
     if ($p->{filter} eq "old_behavior" ) {
         $undelegated = (defined $p->{frontend_params}->{nameservers})

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -13,7 +13,7 @@ use Zonemaster::Backend::Config;
 
 with 'Zonemaster::Backend::DB';
 
-my $connection_string = Zonemaster::Backend::Config->DB_connection_string( 'sqlite' );
+my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string( 'sqlite' );
 
 has 'dbh' => (
     is      => 'ro',

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -13,7 +13,7 @@ use Zonemaster::Backend::Config;
 
 with 'Zonemaster::Backend::DB';
 
-my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string( 'sqlite' );
+my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string( 'sqlite' );
 
 has 'dbh' => (
     is      => 'ro',

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -45,7 +45,7 @@ sub new {
     }
     else {
         eval {
-            my $backend_module = "Zonemaster::Backend::DB::" . Zonemaster::Backend::Config->BackendDBType();
+            my $backend_module = "Zonemaster::Backend::DB::" . Zonemaster::Backend::Config->new()->BackendDBType();
             eval "require $backend_module";
             die "$@ \n" if $@;
             $self->{db} = $backend_module->new();
@@ -348,7 +348,7 @@ sub start_domain_test {
 
     if ($params->{config}) {
         $params->{config} =~ s/[^\w_]//isg;
-        die "Unknown test configuration: [$params->{config}]\n" unless ( Zonemaster::Backend::Config->GetCustomConfigParameter('ZONEMASTER', $params->{config}) );
+        die "Unknown test configuration: [$params->{config}]\n" unless ( Zonemaster::Backend::Config->new()->GetCustomConfigParameter('ZONEMASTER', $params->{config}) );
     }
 
     $result = $self->{db}->create_new_test( $params->{domain}, $params, 10 );

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -45,7 +45,7 @@ sub new {
     }
     else {
         eval {
-            my $backend_module = "Zonemaster::Backend::DB::" . Zonemaster::Backend::Config->new()->BackendDBType();
+            my $backend_module = "Zonemaster::Backend::DB::" . Zonemaster::Backend::Config->load_config()->BackendDBType();
             eval "require $backend_module";
             die "$@ \n" if $@;
             $self->{db} = $backend_module->new();
@@ -348,7 +348,7 @@ sub start_domain_test {
 
     if ($params->{config}) {
         $params->{config} =~ s/[^\w_]//isg;
-        die "Unknown test configuration: [$params->{config}]\n" unless ( Zonemaster::Backend::Config->new()->GetCustomConfigParameter('ZONEMASTER', $params->{config}) );
+        die "Unknown test configuration: [$params->{config}]\n" unless ( Zonemaster::Backend::Config->load_config()->GetCustomConfigParameter('ZONEMASTER', $params->{config}) );
     }
 
     $result = $self->{db}->create_new_test( $params->{domain}, $params, 10 );

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -71,13 +71,12 @@ sub run {
     }
     $domain = $self->to_idn( $domain );
 
-    if (defined $params->{ipv4} || defined $params->{ipv6}) {
+    if (defined $params->{ipv4}) {
         Zonemaster::Engine::Profile->effective->set( q{net.ipv4}, ( $params->{ipv4} ) ? ( 1 ) : ( 0 ) );
-        Zonemaster::Engine::Profile->effective->set( q{net.ipv6}, ( $params->{ipv6} ) ? ( 1 ) : ( 0 ) );
     }
-    else {
-        Zonemaster::Engine::Profile->effective->set( q{net.ipv4}, 1 );
-        Zonemaster::Engine::Profile->effective->set( q{net.ipv6}, 1 );
+
+    if (defined $params->{ipv6}) {
+        Zonemaster::Engine::Profile->effective->set( q{net.ipv6}, ( $params->{ipv6} ) ? ( 1 ) : ( 0 ) );
     }
 
     # used for progress indicator
@@ -143,7 +142,7 @@ sub run {
             Zonemaster::Engine::Profile->effective->merge( $profile );
         }
         else {
-            die "Can't load profile: [$params->{profile}]" if ($params->{profile} ne 'default')
+            die "The profile [$params->{profile}] is not defined in the backend_config ini file" if ($params->{profile} ne 'default')
         }
     }
 

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -8,6 +8,7 @@ use 5.14.2;
 use DBI qw(:utils);
 use JSON::PP;
 use Scalar::Util qw( blessed );
+use File::Slurp;
 
 use Zonemaster::LDNS;
 
@@ -19,14 +20,25 @@ sub new {
     my ( $class, $params ) = @_;
     my $self = {};
 
+    if ( $params && $params->{config} ) {
+        $self->{config} = $params->{config};
+    }
+
     if ( $params && $params->{db} ) {
         eval "require $params->{db}";
         $self->{db} = "$params->{db}"->new();
     }
     else {
-        my $backend_module = "Zonemaster::Backend::DB::" . Zonemaster::Backend::Config->BackendDBType();
+        my $backend_module = "Zonemaster::Backend::DB::" . $self->{config}->BackendDBType();
         eval "require $backend_module";
         $self->{db} = $backend_module->new();
+    }
+        
+    $self->{profiles} = $self->{config}->ReadProfilesInfo();
+    foreach my $profile (keys %{$self->{profiles}}) {
+        my $json = read_file( $self->{profiles}->{$profile}->{profile_file_name}, err_mode => 'croak' );
+        $self->{profiles}->{$profile}->{zm_profile} = Zonemaster::Engine::Profile->from_json( $json );
+        die "default profile cannot be private" if ($profile eq 'default' && $self->{profiles}->{$profile}->{type} eq 'private')
     }
 
     bless( $self, $class );
@@ -60,12 +72,12 @@ sub run {
     $domain = $self->to_idn( $domain );
 
     if (defined $params->{ipv4} || defined $params->{ipv6}) {
-        Zonemaster::Engine->config->get->{net}{ipv4} = ( $params->{ipv4} ) ? ( 1 ) : ( 0 );
-        Zonemaster::Engine->config->get->{net}{ipv6} = ( $params->{ipv6} ) ? ( 1 ) : ( 0 );
+        Zonemaster::Engine::Profile->effective->set( q{net.ipv4}, ( $params->{ipv4} ) ? ( 1 ) : ( 0 ) );
+        Zonemaster::Engine::Profile->effective->set( q{net.ipv6}, ( $params->{ipv4} ) ? ( 1 ) : ( 0 ) );
     }
     else {
-        Zonemaster::Engine->config->get->{net}{ipv4} = 1;
-        Zonemaster::Engine->config->get->{net}{ipv6} = 1;
+        Zonemaster::Engine::Profile->effective->set( q{net.ipv4}, 1 );
+        Zonemaster::Engine::Profile->effective->set( q{net.ipv6}, 1 );
     }
 
     # used for progress indicator
@@ -124,29 +136,14 @@ sub run {
 
     # If the profile parameter has been set in the API, then load a profile
     if ( $params->{profile} ) {
-        if ( $params->{profile} eq 'test_profile_1' and Zonemaster::Backend::Config->CustomProfilesPath()) {
-            # The config has defined an alternative profile and "test_profile_1" has been set.
-            Zonemaster::Engine->config->load_policy_file( Zonemaster::Backend::Config->CustomProfilesPath() . '/policy.json' );
-        }
-        else { # The profile parameter has been set to something else or alternative profile is not defined
-            Zonemaster::Engine->config->load_policy_file( 'policy.json' );
-        }
-    # It will be silently ignored if the file does not exist.
-    }
-
-
-    if ( $params->{config} ) {
-        my $config_file_path = Zonemaster::Backend::Config->GetCustomConfigParameter('ZONEMASTER', $params->{config});
-        if ($config_file_path) {
-            if (-e $config_file_path) {
-                Zonemaster::Engine->config->load_config_file( $config_file_path );
-            }
-            else {
-                die "The file specified by the config parameter value: [$params->{config}] doesn't exist";
-            }
+        $params->{profile} = lc($params->{profile});
+        if (defined $self->{profiles}->{$params->{profile}} && $self->{profiles}->{$params->{profile}}->{zm_profile}) { 
+            my $profile = Zonemaster::Engine::Profile->default;
+            $profile->merge( $self->{profiles}->{$params->{profile}}->{zm_profile} );
+            Zonemaster::Engine::Profile->effective->merge( $profile );
         }
         else {
-            die "Unknown test configuration: [$params->{config}]\n"
+            die "Can't load prfile: [$params->{profile}]" if ($params->{profile} ne 'default')
         }
     }
 

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -73,7 +73,7 @@ sub run {
 
     if (defined $params->{ipv4} || defined $params->{ipv6}) {
         Zonemaster::Engine::Profile->effective->set( q{net.ipv4}, ( $params->{ipv4} ) ? ( 1 ) : ( 0 ) );
-        Zonemaster::Engine::Profile->effective->set( q{net.ipv6}, ( $params->{ipv4} ) ? ( 1 ) : ( 0 ) );
+        Zonemaster::Engine::Profile->effective->set( q{net.ipv6}, ( $params->{ipv6} ) ? ( 1 ) : ( 0 ) );
     }
     else {
         Zonemaster::Engine::Profile->effective->set( q{net.ipv4}, 1 );
@@ -143,7 +143,7 @@ sub run {
             Zonemaster::Engine::Profile->effective->merge( $profile );
         }
         else {
-            die "Can't load prfile: [$params->{profile}]" if ($params->{profile} ne 'default')
+            die "Can't load profile: [$params->{profile}]" if ($params->{profile} ne 'default')
         }
     }
 

--- a/script/create_db_mysql.pl
+++ b/script/create_db_mysql.pl
@@ -8,11 +8,11 @@ use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->new()->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->new()->DB_user();
-my $db_password = Zonemaster::Backend::Config->new()->DB_password();
-my $db_name = Zonemaster::Backend::Config->new()->DB_name();
-my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string();
+die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'mysql');
+my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
+my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
+my $db_name = Zonemaster::Backend::Config->load_config()->DB_name();
+my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
 
 my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
 

--- a/script/create_db_mysql.pl
+++ b/script/create_db_mysql.pl
@@ -8,11 +8,11 @@ use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->DB_user();
-my $db_password = Zonemaster::Backend::Config->DB_password();
-my $db_name = Zonemaster::Backend::Config->DB_name();
-my $connection_string = Zonemaster::Backend::Config->DB_connection_string();
+die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->new()->BackendDBType()) eq 'mysql');
+my $db_user = Zonemaster::Backend::Config->new()->DB_user();
+my $db_password = Zonemaster::Backend::Config->new()->DB_password();
+my $db_name = Zonemaster::Backend::Config->new()->DB_name();
+my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string();
 
 my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
 

--- a/script/create_db_postgresql_9.3.pl
+++ b/script/create_db_postgresql_9.3.pl
@@ -8,10 +8,10 @@ use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
 
-die "The configuration file does not contain the PostgreSQL backend" unless (lc(Zonemaster::Backend::Config->new()->BackendDBType()) eq 'postgresql');
-my $db_user = Zonemaster::Backend::Config->new()->DB_user();
-my $db_password = Zonemaster::Backend::Config->new()->DB_password();
-my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string();
+die "The configuration file does not contain the PostgreSQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'postgresql');
+my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
+my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
+my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
 
 my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
 

--- a/script/create_db_postgresql_9.3.pl
+++ b/script/create_db_postgresql_9.3.pl
@@ -8,10 +8,10 @@ use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
 
-die "The configuration file does not contain the PostgreSQL backend" unless (lc(Zonemaster::Backend::Config->BackendDBType()) eq 'postgresql');
-my $db_user = Zonemaster::Backend::Config->DB_user();
-my $db_password = Zonemaster::Backend::Config->DB_password();
-my $connection_string = Zonemaster::Backend::Config->DB_connection_string();
+die "The configuration file does not contain the PostgreSQL backend" unless (lc(Zonemaster::Backend::Config->new()->BackendDBType()) eq 'postgresql');
+my $db_user = Zonemaster::Backend::Config->new()->DB_user();
+my $db_password = Zonemaster::Backend::Config->new()->DB_password();
+my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string();
 
 my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
 

--- a/script/crontab_job_runner/execute_tests.pl
+++ b/script/crontab_job_runner/execute_tests.pl
@@ -40,15 +40,15 @@ unshift(@INC, $PROJECT_BASE_DIR);
 ###################################################################
 
 my $JOB_RUNNER_DIR = $PROD_DIR."zonemaster-backend/script/crontab_job_runner/";
-my $LOG_DIR = Zonemaster::Backend::Config->LogDir();
-my $perl_command = Zonemaster::Backend::Config->PerlIntereter();
-my $polling_interval = Zonemaster::Backend::Config->PollingInterval();
-my $zonemaster_timeout_interval = Zonemaster::Backend::Config->MaxZonemasterExecutionTime();
-my $frontend_slots = Zonemaster::Backend::Config->NumberOfProcessesForFrontendTesting();
-my $batch_slots = Zonemaster::Backend::Config->NumberOfProcessesForBatchTesting();
+my $LOG_DIR = Zonemaster::Backend::Config->new()->LogDir();
+my $perl_command = Zonemaster::Backend::Config->new()->PerlIntereter();
+my $polling_interval = Zonemaster::Backend::Config->new()->PollingInterval();
+my $zonemaster_timeout_interval = Zonemaster::Backend::Config->new()->MaxZonemasterExecutionTime();
+my $frontend_slots = Zonemaster::Backend::Config->new()->NumberOfProcessesForFrontendTesting();
+my $batch_slots = Zonemaster::Backend::Config->new()->NumberOfProcessesForBatchTesting();
 
-my $connection_string = Zonemaster::Backend::Config->DB_connection_string();
-my $dbh = DBI->connect($connection_string, Zonemaster::Backend::Config->DB_user(), Zonemaster::Backend::Config->DB_password(), {RaiseError => 1, AutoCommit => 1});
+my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string();
+my $dbh = DBI->connect($connection_string, Zonemaster::Backend::Config->new()->DB_user(), Zonemaster::Backend::Config->new()->DB_password(), {RaiseError => 1, AutoCommit => 1});
 
 
 sub clean_hung_processes {

--- a/script/crontab_job_runner/execute_tests.pl
+++ b/script/crontab_job_runner/execute_tests.pl
@@ -41,7 +41,7 @@ unshift(@INC, $PROJECT_BASE_DIR);
 
 my $JOB_RUNNER_DIR = $PROD_DIR."zonemaster-backend/script/crontab_job_runner/";
 my $LOG_DIR = Zonemaster::Backend::Config->new()->LogDir();
-my $perl_command = Zonemaster::Backend::Config->new()->PerlIntereter();
+my $perl_command = Zonemaster::Backend::Config->new()->PerlInterpreter();
 my $polling_interval = Zonemaster::Backend::Config->new()->PollingInterval();
 my $zonemaster_timeout_interval = Zonemaster::Backend::Config->new()->MaxZonemasterExecutionTime();
 my $frontend_slots = Zonemaster::Backend::Config->new()->NumberOfProcessesForFrontendTesting();

--- a/script/crontab_job_runner/execute_tests.pl
+++ b/script/crontab_job_runner/execute_tests.pl
@@ -40,15 +40,15 @@ unshift(@INC, $PROJECT_BASE_DIR);
 ###################################################################
 
 my $JOB_RUNNER_DIR = $PROD_DIR."zonemaster-backend/script/crontab_job_runner/";
-my $LOG_DIR = Zonemaster::Backend::Config->new()->LogDir();
-my $perl_command = Zonemaster::Backend::Config->new()->PerlInterpreter();
-my $polling_interval = Zonemaster::Backend::Config->new()->PollingInterval();
-my $zonemaster_timeout_interval = Zonemaster::Backend::Config->new()->MaxZonemasterExecutionTime();
-my $frontend_slots = Zonemaster::Backend::Config->new()->NumberOfProcessesForFrontendTesting();
-my $batch_slots = Zonemaster::Backend::Config->new()->NumberOfProcessesForBatchTesting();
+my $LOG_DIR = Zonemaster::Backend::Config->load_config()->LogDir();
+my $perl_command = Zonemaster::Backend::Config->load_config()->PerlInterpreter();
+my $polling_interval = Zonemaster::Backend::Config->load_config()->PollingInterval();
+my $zonemaster_timeout_interval = Zonemaster::Backend::Config->load_config()->MaxZonemasterExecutionTime();
+my $frontend_slots = Zonemaster::Backend::Config->load_config()->NumberOfProcessesForFrontendTesting();
+my $batch_slots = Zonemaster::Backend::Config->load_config()->NumberOfProcessesForBatchTesting();
 
-my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string();
-my $dbh = DBI->connect($connection_string, Zonemaster::Backend::Config->new()->DB_user(), Zonemaster::Backend::Config->new()->DB_password(), {RaiseError => 1, AutoCommit => 1});
+my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
+my $dbh = DBI->connect($connection_string, Zonemaster::Backend::Config->load_config()->DB_user(), Zonemaster::Backend::Config->load_config()->DB_password(), {RaiseError => 1, AutoCommit => 1});
 
 
 sub clean_hung_processes {

--- a/script/patch_db_mysql_for_backend_DB_version_lower_than_1.0.3.pl
+++ b/script/patch_db_mysql_for_backend_DB_version_lower_than_1.0.3.pl
@@ -8,11 +8,11 @@ use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->new()->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->new()->DB_user();
-my $db_password = Zonemaster::Backend::Config->new()->DB_password();
-my $db_name = Zonemaster::Backend::Config->new()->DB_name();
-my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string();
+die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'mysql');
+my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
+my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
+my $db_name = Zonemaster::Backend::Config->load_config()->DB_name();
+my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
 
 my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
 

--- a/script/patch_db_mysql_for_backend_DB_version_lower_than_1.0.3.pl
+++ b/script/patch_db_mysql_for_backend_DB_version_lower_than_1.0.3.pl
@@ -8,11 +8,11 @@ use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->DB_user();
-my $db_password = Zonemaster::Backend::Config->DB_password();
-my $db_name = Zonemaster::Backend::Config->DB_name();
-my $connection_string = Zonemaster::Backend::Config->DB_connection_string();
+die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->new()->BackendDBType()) eq 'mysql');
+my $db_user = Zonemaster::Backend::Config->new()->DB_user();
+my $db_password = Zonemaster::Backend::Config->new()->DB_password();
+my $db_name = Zonemaster::Backend::Config->new()->DB_name();
+my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string();
 
 my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
 

--- a/script/patch_db_postgresq_for_backend_DB_version_lower_than_1.0.3.pl
+++ b/script/patch_db_postgresq_for_backend_DB_version_lower_than_1.0.3.pl
@@ -8,11 +8,11 @@ use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->new()->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->new()->DB_user();
-my $db_password = Zonemaster::Backend::Config->new()->DB_password();
-my $db_name = Zonemaster::Backend::Config->new()->DB_name();
-my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string();
+die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'mysql');
+my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
+my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
+my $db_name = Zonemaster::Backend::Config->load_config()->DB_name();
+my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
 
 my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
 

--- a/script/patch_db_postgresq_for_backend_DB_version_lower_than_1.0.3.pl
+++ b/script/patch_db_postgresq_for_backend_DB_version_lower_than_1.0.3.pl
@@ -8,11 +8,11 @@ use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->DB_user();
-my $db_password = Zonemaster::Backend::Config->DB_password();
-my $db_name = Zonemaster::Backend::Config->DB_name();
-my $connection_string = Zonemaster::Backend::Config->DB_connection_string();
+die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->new()->BackendDBType()) eq 'mysql');
+my $db_user = Zonemaster::Backend::Config->new()->DB_user();
+my $db_password = Zonemaster::Backend::Config->new()->DB_password();
+my $db_name = Zonemaster::Backend::Config->new()->DB_name();
+my $connection_string = Zonemaster::Backend::Config->new()->DB_connection_string();
 
 my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
 

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -20,6 +20,7 @@ BEGIN {
 	$ENV{PERL_JSON_BACKEND} = 'JSON::PP';
 }
 
+# Enable immediate flush to stdout and stderr
 $|++;
 
 ###
@@ -37,7 +38,7 @@ GetOptions(
 $pidfile //= '/tmp/zonemaster_backend_testagent.pid';
 
 # Yes, the method names are spelled like that.
-my $config = Zonemaster::Backend::Config->new();
+my $config = Zonemaster::Backend::Config->load_config();
 my $maximum_processes = 
   $config->NumberOfProcessesForFrontendTesting() +
   $config->NumberOfProcessesForBatchTesting();
@@ -87,6 +88,8 @@ sub main {
     my $self = shift;
 
     my $db = $self->config->{db};
+    
+    # Atempt a creation of a dummy instance of a TestAgent to catch possible Zonemaster-Engine profile files misconfigurations early
     Zonemaster::Backend::TestAgent->new({ config => $config });
 
     while ( 1 ) {

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -20,6 +20,8 @@ BEGIN {
 	$ENV{PERL_JSON_BACKEND} = 'JSON::PP';
 }
 
+$|++;
+
 ###
 ### More global variables, and initialization.
 ###
@@ -35,12 +37,13 @@ GetOptions(
 $pidfile //= '/tmp/zonemaster_backend_testagent.pid';
 
 # Yes, the method names are spelled like that.
-my $maximum_processes =
-  Zonemaster::Backend::Config->NumberOfProcessesForFrontendTesting() +
-  Zonemaster::Backend::Config->NumberOfProcessesForBatchTesting();
+my $config = Zonemaster::Backend::Config->new();
+my $maximum_processes = 
+  $config->NumberOfProcessesForFrontendTesting() +
+  $config->NumberOfProcessesForBatchTesting();
 
-my $delay   = Zonemaster::Backend::Config->PollingInterval();
-my $timeout = Zonemaster::Backend::Config->MaxZonemasterExecutionTime();
+my $delay   = $config->PollingInterval();
+my $timeout = $config->MaxZonemasterExecutionTime();
 
 my $pm = Parallel::ForkManager->new( $maximum_processes );
 $pm->set_waitpid_blocking_sleep( 0 ) if $pm->can('set_waitpid_blocking_sleep');
@@ -84,6 +87,7 @@ sub main {
     my $self = shift;
 
     my $db = $self->config->{db};
+    Zonemaster::Backend::TestAgent->new({ config => $config });
 
     while ( 1 ) {
         my $id = $db->get_test_request();
@@ -91,7 +95,7 @@ sub main {
         if ( $id ) {
             $pm->wait_for_available_procs();
             if ( $pm->start( $id ) == 0 ) {    # Child process
-                Zonemaster::Backend::TestAgent->new->run( $id );
+                Zonemaster::Backend::TestAgent->new({ config => $config })->run( $id );
                 $pm->finish;
             }
         }

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -17,6 +17,13 @@ max_zonemaster_execution_time            = 300
 number_of_processes_for_frontend_testing = 20
 number_of_processes_for_batch_testing    = 20
 
+[PUBLIC PROFILES]
+#example_profile_1=/example/directory/test1_profile.json
+#default=/example/directory/default_profile.json
+
+[PRIVATE PROFILES]
+#example_profile_2=/example/directory/test2_profile.json
+
 [GEOLOCATION]
 # Requires the Geo::IP Perl module to be installed
 #maxmind_isp_db_file  =


### PR DESCRIPTION
Fixes issue #405
Adds the profiles feature to the backend.
Changes the way the config file is read to allow passing it as a parameter to the test agent.