### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,13 @@ env:
 language: perl
 
 perl:
+    - "5.28"
+    - "5.26"
     - "5.24"
     - "5.22"
     - "5.20"
     - "5.18"
     - "5.16"
-    - "5.14"
 
 before_script:
     - if [[ "$TARGET" == "PostreSQL" ]]; then psql -c "create user travis_zonemaster WITH PASSWORD 'travis_zonemaster';" -U postgres; fi


### PR DESCRIPTION
Ubuntu 18.04 uses Perl 5.26. Default perl in FreeBSD is 5.28. No support OS uses perl 5.14.