### PR TITLE
Provide configure-time-deps for Zonemaster::LDNS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ before_install:
     - local-lib
     - git clone --depth=1 --branch=develop https://github.com/zonemaster/zonemaster-ldns.git
     - git clone --depth=1 --branch=develop https://github.com/zonemaster/zonemaster-engine.git
-    - cpan-install --deps Devel::CheckLib
-    - cpan-install --deps ./zonemaster-ldns
-    - cpan-install --deps ./zonemaster-engine
+    - cpan-install --deps Devel::CheckLib Module::Install Module::Install::XSUtil ./zonemaster-ldns ./zonemaster-engine
 
 before_script:
     - if [[ "$TARGET" == "PostreSQL" ]]; then psql -c "create user travis_zonemaster WITH PASSWORD 'travis_zonemaster';" -U postgres; fi


### PR DESCRIPTION
I expect Travis to start failing for Backend once zonemaster/zonemaster-ldns#72 is merged. This PR should pass both before and after merging zonemaster/zonemaster-ldns#72.