### PR TITLE
Update test_validate_syntax.t

### DIFF
--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -70,7 +70,7 @@ ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok',
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 64 characters long domain label
-$frontend_params->{domain} = '012345678901234567890123456789012345678901234567890123456789-64-.fr';
+$frontend_params->{domain} = '012345678901234567890123456789012345678901234567890123456789--64.fr';
 ok( $engine->validate_syntax( $frontend_params )->{status} eq 'nok',
 	encode_utf8( '64 characters long domain label' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );


### PR DESCRIPTION
The too long label should not end with a hyphen because that could be an issue in itself.