### PR TITLE
update initial sql script for postgres 

### DIFF
--- a/share/initial-postgres.sql
+++ b/share/initial-postgres.sql
@@ -36,5 +36,7 @@ CREATE TABLE users (
     user_info JSON
 );
 
-GRANT SELECT,UPDATE,INSERT ON test_results, batch_jobs, users TO zonemaster;
+ALTER TABLE test_results OWNER TO zonemaster;
+ALTER TABLE batch_jobs OWNER TO zonemaster;
+ALTER TABLE users OWNER TO zonemaster;
 GRANT USAGE ON test_results_id_seq, batch_jobs_id_seq, users_id_seq TO zonemaster;


### PR DESCRIPTION
update initial sql script for postgres. Give ownership of main table to zonemaster instead of postgres.
Fix #503 