### PR TITLE
Simplify the installation commands for FreeBSD

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -410,11 +410,10 @@ cpanm Zonemaster::Backend
 > The command above might try to install "DBD::Pg" and "DBD::mysql".
 > You can ignore if it fails. The relevant libraries are installed further down in these instructions.
 
-Add `zonemaster` user and group:
+Add `zonemaster` user and `zonemaster` group (the group is created automatically): 
 
 ```sh
-pw groupadd zonemaster
-pw useradd zonemaster -g zonemaster -s /sbin/nologin -d /nonexistent -c "Zonemaster daemon user"
+pw useradd zonemaster -s /sbin/nologin -d /nonexistent -c "Zonemaster daemon user"
 ```
 
 Install files to their proper locations:


### PR DESCRIPTION
When you create the user, a group with the same name is automatically created and "attached" to the created user, if you do not specify the group. Two commands are collapsed into one.