### PR TITLE
Partial fix for translation on FreeBSD 11

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -17,7 +17,6 @@ requires
   'JSON::PP'                    => 0,
   'JSON::RPC'                   => 1.01,
   'JSON::Validator'             => 2.07,
-  'Locale::TextDomain'          => 0,
   'Log::Any'                    => 0,
   'Log::Any::Adapter::Dispatch' => 0,
   'Log::Dispatch'               => 0,

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -237,7 +237,7 @@ See the [post-installation] section for post-installation matters.
 Install dependencies available from binary packages:
 
 ```sh
-sudo apt-get install libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libintl-perl libio-captureoutput-perl libjson-pp-perl libjson-rpc-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libplack-perl libplack-middleware-debug-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl starman
+sudo apt-get install libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libio-captureoutput-perl libjson-pp-perl libjson-rpc-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libplack-perl libplack-middleware-debug-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl starman
 ```
 
 Install dependencies not available from binary packages:
@@ -388,7 +388,7 @@ su -l
 Install dependencies available from binary packages:
 
 ```sh
-pkg install p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-IO-CaptureOutput p5-JSON-PP p5-JSON-RPC p5-Locale-libintl p5-Moose p5-Parallel-ForkManager p5-Plack p5-Plack-Middleware-Debug p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote
+pkg install p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-IO-CaptureOutput p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Plack-Middleware-Debug p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote
 ```
 
 Optionally install Curl (only needed for the post-installation smoke test)

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -5,9 +5,7 @@ our $VERSION = '1.1.0';
 use 5.14.2;
 
 use Moose;
-use Locale::TextDomain 'Zonemaster-Engine';
 use Encode;
-use POSIX qw[setlocale LC_ALL];
 
 # Zonemaster Modules
 require Zonemaster::Engine::Translator;
@@ -18,18 +16,18 @@ extends 'Zonemaster::Engine::Translator';
 sub translate_tag {
     my ( $self, $entry, $browser_lang ) = @_;
 
-    my $previous_locale = setlocale( LC_ALL );
+    my $previous_locale = $self->locale;
     if ( $browser_lang eq 'fr' ) {
-        setlocale( LC_ALL, "fr_FR.UTF-8" );
+        $self->locale( "fr_FR.UTF-8" );
     }
     elsif ( $browser_lang eq 'sv' ) {
-        setlocale( LC_ALL, "sv_SE.UTF-8" );
+        $self->locale( "sv_SE.UTF-8" );
     }
     elsif ( $browser_lang eq 'da' ) {
-        setlocale( LC_ALL, "da_DK.UTF-8" );
+        $self->locale( "da_DK.UTF-8" );
     }
     else {
-        setlocale( LC_ALL, "en_US.UTF-8" );
+        $self->locale( "en_US.UTF-8" );
     }
     my $string = $self->data->{ $entry->{module} }{ $entry->{tag} };
 
@@ -38,9 +36,9 @@ sub translate_tag {
     }
 
     my $blessed_entry = bless($entry, 'Zonemaster::Engine::Logger::Entry');
-    my $str = decode_utf8( __x( $string, %{ ($blessed_entry->can('printable_args'))?($blessed_entry->printable_args()):($entry->{args}) } ) );
-    setlocale( LC_ALL, $previous_locale );
-
+    my $octets = Zonemaster::Engine::Translator::translate_tag( $self, $blessed_entry );
+    $self->locale( $previous_locale );
+    my $str = decode_utf8( $octets );
     return $str;
 }
 

--- a/share/zm-backend.sh
+++ b/share/zm-backend.sh
@@ -13,13 +13,6 @@
 #                    make up the Zonemaster Backend.
 ### END INIT INFO
 
-# Unset potentially conflicting locale, setting the default
-unset LANGUAGE
-unset LANG
-unset LC_MESSAGES
-unset LC_ALL
-export LC_CTYPE="en_US.UTF-8"
-
 BASEDIR=${ZM_BACKEND_BASEDIR:-/usr/local}
 LOGDIR=${ZM_BACKEND_LOGDIR:-/var/log/zonemaster}
 PIDDIR=${ZM_BACKEND_PIDDIR:-/var/run/zonemaster}


### PR DESCRIPTION
This change places the responsibility for how to switch languages on Engine while keeping the responsibility of when that should be done in the Backend.

In combination with zonemaster/zonemaster-engine#562 it enables choosing translation language in requests to the RPCAPI on FreeBSD 11. However once you've chosen a language it gets stuck on that language no matter what language you ask for in subsequent requests. Compare that with the current behavior where the language is simply stuck on English. In my view this is an improvement.

Curiously, when I tested this on FreeBSD 11 I was consistently able to choose different languages twice, but then it got stuck on the second language. I haven't looked into why this happens.

Other OSes are unaffected - I've only verified this on FreeBSD 12 and Debian 8 and 9.

Partially fixes #353 and #512.