### PR TITLE
Avoid reloading configuration in Test Agent

### DIFF
--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -28,6 +28,8 @@ else {
 sub load_config {
     my ( $class, $params ) = @_;
     my $self = {};
+
+    $log->notice( "Loading config: $path" );
     
     $self->{cfg} = Config::IniFiles->new( -file => $path );
     die "UNABLE TO LOAD $path ERRORS:[".join('; ', @Config::IniFiles::errors)."] \n" unless ( $self->{cfg} );

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -239,7 +239,7 @@ sub new_DB {
     $dbclass->import();
     $log->notice("Constructing database adapter: $dbclass");
 
-    my $db = $dbclass->new;
+    my $db = $dbclass->new({ config => $self });
 
     # Connect or die
     $db->dbh;

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -253,7 +253,7 @@ Create a new processing manager object according to configuration.
 
 =head3 INPUT
 
-The values of the following attributes affect the consturction of the returned object:
+The values of the following attributes affect the construction of the returned object:
 
 =over
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -247,6 +247,30 @@ sub new_DB {
     return $db;
 }
 
+=head2 new_PM
+
+Create a new processing manager object according to configuration.
+
+=head3 INPUT
+
+The values of the following attributes affect the consturction of the returned object:
+
+=over
+
+=item MaxZonemasterExecutionTime
+
+=item NumberOfProcessesForBatchTesting
+
+=item NumberOfProcessesForFrontendTesting
+
+=back
+
+=head3 RETURNS
+
+A configured L<Parallel::ForkManager> object.
+
+=cut
+
 sub new_PM {
     my $self = shift;
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -197,10 +197,10 @@ The adapter connects to the database before it is returned.
 
 =head3 INPUT
 
-The database adapter class is selected based on the return value
-of L<Zonemaster::Backend::Config->load_config()->BackendDBType()>. The database
-adapter class constructor is called without arguments and is expected
-to configure itself according to available global configuration.
+The database adapter class is selected based on the return value of
+BackendDBType().
+The database adapter class constructor is called without arguments and is
+expected to configure itself according to available global configuration.
 
 =back
 
@@ -223,8 +223,10 @@ A configured L<Zonemaster::Backend::DB> object.
 =cut
 
 sub new_DB {
+    my ($self) = @_;
+
     # Get DB type from config
-    my $dbtype = Zonemaster::Backend::Config->load_config()->BackendDBType();
+    my $dbtype = $self->BackendDBType();
     if (!defined $dbtype) {
         die "Unrecognized DB.engine in backend config";
     }

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -42,7 +42,7 @@ sub _get_allowed_id_field_name {
 		$id_field = 'hash_id';
     }
     else {
-		if ($test_id <= Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id()) {
+		if ($test_id <= $self->config->force_hash_id_use_in_API_starting_from_id()) {
 			$id_field = 'id';
 		}
 		else {
@@ -60,7 +60,7 @@ sub get_test_request {
     
     
     my ( $id, $hash_id );
-    my $lock_on_queue = Zonemaster::Backend::Config->load_config()->lock_on_queue();
+    my $lock_on_queue = $self->config->lock_on_queue();
 	if ( defined $lock_on_queue ) {
 		( $id, $hash_id ) = $dbh->selectrow_array( qq[ SELECT id, hash_id FROM test_results WHERE progress=0 AND queue=? ORDER BY priority DESC, id ASC LIMIT 1 ], undef, $lock_on_queue );
 	}
@@ -71,7 +71,7 @@ sub get_test_request {
     if ($id) {
 		$dbh->do( q[UPDATE test_results SET progress=1 WHERE id=?], undef, $id );
 
-		if ( $id > Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id() ) {
+		if ( $id > $self->config->force_hash_id_use_in_API_starting_from_id() ) {
 			$result_id = $hash_id;
 		}
 		else {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -29,7 +29,7 @@ sub add_api_user {
 
     my $result = $self->add_api_user_to_db( $username, $api_key );
 
-    die "add_api_user_to_db not successfull\n" unless ( $result );
+    die "add_api_user_to_db not successful\n" unless ( $result );
 
     return $result;
 }

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -14,15 +14,16 @@ use Zonemaster::Backend::Config;
 
 with 'Zonemaster::Backend::DB';
 
+has 'config' => (
+    is       => 'ro',
+    isa      => 'Zonemaster::Backend::Config',
+    required => 1,
+);
+
 has 'dbhandle' => (
     is  => 'rw',
     isa => 'DBI::db',
 );
-
-my $connection_string   = Zonemaster::Backend::Config->load_config()->DB_connection_string( 'mysql' );
-my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-my $connection_user     = Zonemaster::Backend::Config->load_config()->DB_user();
-my $connection_password = Zonemaster::Backend::Config->load_config()->DB_password();
 
 sub dbh {
     my ( $self ) = @_;
@@ -32,6 +33,10 @@ sub dbh {
         return $dbh;
     }
     else {
+        my $connection_string   = $self->config->DB_connection_string( 'mysql' );
+        my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
+        my $connection_user     = $self->config->DB_user();
+        my $connection_password = $self->config->DB_password();
         $dbh = DBI->connect( $connection_string, $connection_user, $connection_password, $connection_args );
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );
@@ -120,7 +125,7 @@ SELECT id, hash_id FROM test_results WHERE params_deterministic_hash = ? AND (TO
 
         if ( $recent_id ) {
             # A recent entry exists, so return its id
-            if ( $recent_id > Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id() ) {
+            if ( $recent_id > $self->config->force_hash_id_use_in_API_starting_from_id() ) {
                 $result_id = $recent_hash_id;
             }
             else {
@@ -145,7 +150,7 @@ SELECT id, hash_id FROM test_results WHERE params_deterministic_hash = ? AND (TO
             my ( $id, $hash_id ) = $dbh->selectrow_array(
                 "SELECT id, hash_id FROM test_results WHERE params_deterministic_hash='$test_params_deterministic_hash' ORDER BY id DESC LIMIT 1" );
                 
-            if ( $id > Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id() ) {
+            if ( $id > $self->config->force_hash_id_use_in_API_starting_from_id() ) {
                 $result_id = $hash_id;
             }
             else {
@@ -219,7 +224,7 @@ sub get_test_history {
     my @results;
     my $sth = {};
 
-    my $use_hash_id_from_id = Zonemaster::Backend::Config->load_config()->force_hash_id_use_in_API_starting_from_id();
+    my $use_hash_id_from_id = $self->config->force_hash_id_use_in_API_starting_from_id();
 
     my $undelegated = "";
     if ($p->{filter} eq "undelegated") {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -35,20 +35,22 @@ sub new {
     my $self = {};
     bless( $self, $type );
 
+    my $config = Zonemaster::Backend::Config->load_config();
+
     if ( $params && $params->{db} ) {
         eval {
             eval "require $params->{db}";
             die "$@ \n" if $@;
-            $self->{db} = "$params->{db}"->new();
+            $self->{db} = "$params->{db}"->new( { config => $config } );
         };
         die "$@ \n" if $@;
     }
     else {
         eval {
-            my $backend_module = "Zonemaster::Backend::DB::" . Zonemaster::Backend::Config->load_config()->BackendDBType();
+            my $backend_module = "Zonemaster::Backend::DB::" . $config->BackendDBType();
             eval "require $backend_module";
             die "$@ \n" if $@;
-            $self->{db} = $backend_module->new();
+            $self->{db} = $backend_module->new( { config => $config } );
         };
         die "$@ \n" if $@;
     }

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -27,12 +27,12 @@ sub new {
 
     if ( $params && $params->{db} ) {
         eval "require $params->{db}";
-        $self->{db} = "$params->{db}"->new();
+        $self->{db} = "$params->{db}"->new( { config => $self->{config} } );
     }
     else {
         my $backend_module = "Zonemaster::Backend::DB::" . $self->{config}->BackendDBType();
         eval "require $backend_module";
-        $self->{db} = $backend_module->new();
+        $self->{db} = $backend_module->new( { config => $self->{config} } );
     }
         
     $self->{profiles} = $self->{config}->ReadProfilesInfo();

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -28,7 +28,7 @@ builder {
         my $app = shift;
 
         # Make sure we can connect to the database
-        Zonemaster::Backend::Config->new_DB();
+        Zonemaster::Backend::Config->load_config()->new_DB();
 
         return $app;
     };

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -161,7 +161,7 @@ eval {
     Zonemaster::Backend::TestAgent->new( { config => $config } );
 
     # Connect to the database
-    Zonemaster::Backend::Config->new_DB();
+    $config->new_DB();
 };
 if ( $@ ) {
     print STDERR "Aborting startup: $@";

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -79,89 +79,47 @@ print STDERR "Logging to $logfile\n";
     Log::Any::Adapter->set( 'Dispatch', dispatcher => $dispatcher );
 }
 
-# Yes, the method names are spelled like that.
-my $config = Zonemaster::Backend::Config->load_config();
-my $maximum_processes = 
-  $config->NumberOfProcessesForFrontendTesting() +
-  $config->NumberOfProcessesForBatchTesting();
-
-my $delay   = $config->PollingInterval();
-my $timeout = $config->MaxZonemasterExecutionTime();
-
-my $pm = Parallel::ForkManager->new( $maximum_processes );
-$pm->set_waitpid_blocking_sleep( 0 ) if $pm->can('set_waitpid_blocking_sleep');
-
-my %times;
-
 ###
 ### Actual functionality
 ###
 
-$pm->run_on_wait(
-    sub {
-        foreach my $pid ( $pm->running_procs ) {
-            my $diff = time() - $times{$pid};
-
-            if ( $diff > $timeout ) {
-                kill 9, $pid;
-            }
-        }
-    },
-    1
-);
-
-$pm->run_on_start(
-    sub {
-        my ( $pid, $id ) = @_;
-
-        $times{$pid} = time();
-    }
-);
-
-$pm->run_on_finish(
-    sub {
-        my ( $pid, $exitcode, $id ) = @_;
-
-        delete $times{$pid};
-    }
-);
-
 sub main {
     my $self = shift;
 
-    my $db = $self->config->{db};
-
 	my $ta;
     while ( 1 ) {
-        my $id = $db->get_test_request();
+        my $id = $self->db->get_test_request();
 
         if ( $id ) {
             $log->info("Test found: $id");
-            $pm->wait_for_available_procs();
-            if ( $pm->start( $id ) == 0 ) {    # Child process
+            $self->pm->wait_for_available_procs();
+            if ( $self->pm->start( $id ) == 0 ) {    # Child process
                 $log->info("Test starting: $id");
-                $ta = Zonemaster::Backend::TestAgent->new({ config => $config });
+                $ta = Zonemaster::Backend::TestAgent->new({ config => $self->config });
                 $ta->run( $id );
                 $ta->reset();
                 
                 $log->info("Test completed: $id");
-                $pm->finish;
+                $self->pm->finish;
             }
         }
         else {
-            sleep $delay;
+            sleep $self->config->PollingInterval();
         }
     }
 }
 
 
 # Make sure the environment is alright before forking
+my $initial_config;
 eval {
+    $initial_config = Zonemaster::Backend::Config->load_config();
+
     # Validate the Zonemaster-Engine profile
-    Zonemaster::Backend::TestAgent->new( { config => $config } );
+    Zonemaster::Backend::TestAgent->new( { config => $initial_config } );
 
     # Connect to the database
-    $config->new_DB();
+    $initial_config->new_DB();
 };
 if ( $@ ) {
     print STDERR "Aborting startup: $@";
@@ -178,6 +136,10 @@ my $daemon = Daemon::Control->with_plugins( qw( +Zonemaster::Backend::Config::DC
         program => sub {
             my $self = shift;
             $log->notice( "Daemon spawned" );
+
+            $self->init_backend_config( $initial_config );
+            undef $initial_config;
+
             eval { main( $self ) };
             if ( $@ ) {
                 chomp $@;

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -113,6 +113,7 @@ sub main {
 # Make sure the environment is alright before forking
 my $initial_config;
 eval {
+    $log->debug("Starting pre-flight check");
     $initial_config = Zonemaster::Backend::Config->load_config();
 
     # Validate the Zonemaster-Engine profile
@@ -120,6 +121,7 @@ eval {
 
     # Connect to the database
     $initial_config->new_DB();
+    $log->debug("Completed pre-flight check");
 };
 if ( $@ ) {
     print STDERR "Aborting startup: $@";

--- a/t/test01.t
+++ b/t/test01.t
@@ -16,8 +16,15 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
 # Require Zonemaster::Backend::RPCAPI.pm test
 use_ok( 'Zonemaster::Backend::RPCAPI' );
 
+my $config = Zonemaster::Backend::Config->load_config();
+
 # Create Zonemaster::Backend::RPCAPI object
-my $engine = Zonemaster::Backend::RPCAPI->new( { db => 'Zonemaster::Backend::DB::SQLite' } );
+my $engine = Zonemaster::Backend::RPCAPI->new(
+    {
+        db     => 'Zonemaster::Backend::DB::SQLite',
+        config => $config,
+    }
+);
 isa_ok( $engine, 'Zonemaster::Backend::RPCAPI' );
 
 # create a new memory SQLite database
@@ -57,7 +64,6 @@ sub run_zonemaster_test_with_backend_API {
 	ok( $engine->test_progress( $test_id ) == 0 );
 
 	use_ok( 'Zonemaster::Backend::Config' );
-	my $config = Zonemaster::Backend::Config->load_config();
 
 	use_ok( 'Zonemaster::Backend::TestAgent' );
 

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -12,7 +12,12 @@ my $can_use_threads = eval 'use threads; 1';
 use_ok( 'Zonemaster::Backend::RPCAPI' );
 
 # Create Zonemaster::Backend::RPCAPI object
-my $engine = Zonemaster::Backend::RPCAPI->new( { db => 'Zonemaster::Backend::DB::SQLite' } );
+my $engine = Zonemaster::Backend::RPCAPI->new(
+    {
+        db     => 'Zonemaster::Backend::DB::SQLite',
+        config => Zonemaster::Backend::Config->load_config(),
+    }
+);
 isa_ok( $engine, 'Zonemaster::Backend::RPCAPI' );
 
 my $frontend_params = {


### PR DESCRIPTION
Fixes #528. The further improvement with reloading on SIGHUP is not included here. I'll create a separate issue for that.

This PR also takes a step towards #214 by introducing a log entry for loading of the config file (which wasn't feasible before with the relentless config reloading), and also beginning and end entries for the "pre-flight check".