### PR TITLE
Fix crash in RPCAPI

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,7 +16,7 @@ requires
   'IO::CaptureOutput'           => 0,
   'JSON::PP'                    => 0,
   'JSON::RPC'                   => 1.01,
-  'JSON::Validator'             => 2.07,
+  'JSON::Validator'             => 3.12,
   'Log::Any'                    => 0,
   'Log::Any::Adapter::Dispatch' => 0,
   'Log::Dispatch'               => 0,

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -522,13 +522,7 @@ my $rpc_request = joi->object->props(
 sub jsonrpc_validate {
     my ( $self, $jsonrpc_request) = @_;
 
-    # FIXME: This is an inlined version of JSON::Validator::Joi::validate() that
-    # has been fixed to not emit deprecation warnings.
-    # Once the method itself is fixed on all supported platforms to not emit
-    # deprecation warnings, the call to it can be reinstated.
-    state $jv = JSON::Validator->new->coerce( { booleans => 1, numbers => 1, strings => 1 } );
-    my @error_rpc = $jv->validate( $jsonrpc_request, $jv->compile );
-
+    my @error_rpc = $rpc_request->validate($jsonrpc_request);
     if (!exists $jsonrpc_request->{"id"} || @error_rpc) {
         return {
             jsonrpc => '2.0',


### PR DESCRIPTION
The crash occurs in a workaround for a bug in JSON::Validator. The bug was fixed in JSON::Validator 3.12 and we don't need the workaround anymore. This PR reverts the workaround and bumps the requirement for JSON::Validator.
Fixes #559.