### PR TITLE
Installation on Debian

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -8,7 +8,24 @@ Each section in `backend_config.ini` is documented below.
 
 ## DB section
 
-TBD
+The DB section has a number of keys.
+At this time the only documented key is `engine`.
+
+### engine
+
+Specifies what database engine to use.
+
+The value must be one of the following, case-insensitively: `MySQL`,
+`PostgreSQL` and `SQLite`.
+
+This table declares what value to use for each supported database engine.
+
+Database Engine   | Value
+------------------|------
+MariaDB           | MySQL
+MySQL             | MySQL
+PostgreSQL        | PostgreSQL
+SQLite            | SQLite
 
 
 ## GEOLOCATION section

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -22,10 +22,10 @@ This table declares what value to use for each supported database engine.
 
 Database Engine   | Value
 ------------------|------
-MariaDB           | MySQL
-MySQL             | MySQL
-PostgreSQL        | PostgreSQL
-SQLite            | SQLite
+MariaDB           | `MySQL`
+MySQL             | `MySQL`
+PostgreSQL        | `PostgreSQL`
+SQLite            | `SQLite`
 
 
 ## GEOLOCATION section

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -106,7 +106,7 @@ of operating system version and database engine version is supported.
 Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
-sudo sed -i '/\bengine\b/ s/=.*/=MySQL/' /etc/zonemaster/backend_config.ini
+sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
 ```
 
 Install, configure and start database engine (and Perl bindings):
@@ -142,7 +142,7 @@ mysql --user=root --password < ./initial-mysql.sql
 Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
-sudo sed -i '/\bengine\b/ s/=.*/=PostgreSQL/' /etc/zonemaster/backend_config.ini
+sudo sed -i '/\bengine\b/ s/=.*/= PostgreSQL/' /etc/zonemaster/backend_config.ini
 ```
 
 Add PostgreSQL package repository needed to get the appropriate PostgreSQL
@@ -282,7 +282,7 @@ of operating system version and database engine version is supported.
 Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
-sudo sed -i '/\bengine\b/ s/=.*/=MySQL/' /etc/zonemaster/backend_config.ini
+sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
 ```
 
 Install the database engine and its dependencies:
@@ -311,7 +311,7 @@ sudo mysql --password < ./initial-mysql.sql
 Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
-sudo sed -i '/\bengine\b/ s/=.*/=PostgreSQL/' /etc/zonemaster/backend_config.ini
+sudo sed -i '/\bengine\b/ s/=.*/= PostgreSQL/' /etc/zonemaster/backend_config.ini
 ```
 
 Install, configure and start database engine (and Perl bindings):
@@ -441,7 +441,7 @@ of operating system version and database engine version is supported.
 Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
-sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/=MySQL/' /usr/local/etc/zonemaster/backend_config.ini
+sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= MySQL/' /usr/local/etc/zonemaster/backend_config.ini
 ```
 
 Install, configure and start database engine (and Perl bindings):
@@ -497,7 +497,7 @@ mysql -u root -p < ./initial-mysql.sql
 Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
-sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/=PostgreSQL/' /usr/local/etc/zonemaster/backend_config.ini
+sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= PostgreSQL/' /usr/local/etc/zonemaster/backend_config.ini
 ```
 
 Install, configure and start database engine (and Perl bindings):

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -277,7 +277,7 @@ sudo install -v -m 755 ./zm-backend.sh /etc/init.d/
 Check the [declaration of prerequisites] to make sure your preferred combination
 of operating system version and database engine version is supported.
 
-#### 4.2.1 Instructions for MySQL (Debian)
+#### 4.2.1 Instructions for MariaDB (Debian)
 
 Configure Zonemaster::Backend to use the correct database engine:
 
@@ -288,7 +288,7 @@ sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
 Install the database engine and its dependencies:
 
 ```sh
-sudo apt install mysql-server libdbd-mysql-perl
+sudo apt install mariadb-server libdbd-mysql-perl
 ```
 
 Initialize the database:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -611,7 +611,7 @@ sudo -u postgres psql -f ./cleanup-postgres.sql # MUST BE VERIFIED!
 
 -------
 
-[Backend configuration]: https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md
+[Backend configuration]: Configuration.md
 [Declaration of prerequisites]: https://github.com/zonemaster/zonemaster#prerequisites
 [JSON-RPC API]: API.md
 [Main Zonemaster repository]: https://github.com/zonemaster/zonemaster/blob/master/README.md

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -320,13 +320,6 @@ Install, configure and start database engine (and Perl bindings):
 sudo apt install libdbd-pg-perl postgresql
 ```
 
-Check that you have a PostgreSQL installation 9.2 or later. The version should also match the supported database
-engine version depending on OS found in [Zonemaster/README](https://github.com/zonemaster/zonemaster/blob/master/README.md).
-
-```sh
-psql --version
-```
-
 Initialize the database:
 
 ```sh

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -109,6 +109,8 @@ Configure Zonemaster::Backend to use the correct database engine:
 sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
 ```
 
+> **Note:** See the [backend configuration] documentation for details.
+
 Install, configure and start database engine (and Perl bindings):
 
 ```sh
@@ -144,6 +146,8 @@ Configure Zonemaster::Backend to use the correct database engine:
 ```sh
 sudo sed -i '/\bengine\b/ s/=.*/= PostgreSQL/' /etc/zonemaster/backend_config.ini
 ```
+
+> **Note:** See the [backend configuration] documentation for details.
 
 Add PostgreSQL package repository needed to get the appropriate PostgreSQL
 binary package
@@ -285,6 +289,8 @@ Configure Zonemaster::Backend to use the correct database engine:
 sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
 ```
 
+> **Note:** See the [backend configuration] documentation for details.
+
 Install the database engine and its dependencies:
 
 ```sh
@@ -313,6 +319,8 @@ Configure Zonemaster::Backend to use the correct database engine:
 ```sh
 sudo sed -i '/\bengine\b/ s/=.*/= PostgreSQL/' /etc/zonemaster/backend_config.ini
 ```
+
+> **Note:** See the [backend configuration] documentation for details.
 
 Install, configure and start database engine (and Perl bindings):
 
@@ -603,6 +611,7 @@ sudo -u postgres psql -f ./cleanup-postgres.sql # MUST BE VERIFIED!
 
 -------
 
+[Backend configuration]: https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md
 [Declaration of prerequisites]: https://github.com/zonemaster/zonemaster#prerequisites
 [JSON-RPC API]: API.md
 [Main Zonemaster repository]: https://github.com/zonemaster/zonemaster/blob/master/README.md


### PR DESCRIPTION
The `mysql-server` package isn't available on Debian 10, but `mariadb-server` is available on all of Debian 9 (stretch), Debian 10 (buster), Ubuntu 16.04 (xenial) and Ubuntu 18.04 (bionic), so this PR switches over to install that package instead.

I removed the step to verify the PostgreSQL version because we don't support anything that gives you PostgreSQL <= 9.2 by default.

I updated the config file editing steps to make the result look more tidy.