### PR TITLE
Compatibility with systemd-tmpfiles

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -56,6 +56,7 @@ share/cleanup-postgres.sql
 share/initial-mysql.sql
 share/initial-postgres.sql
 share/starman-zm-backend-RPC-API.conf
+share/tmpfiles.conf
 share/travis_mysql_backend_config.ini
 share/travis_postgresql_backend_config.ini
 share/travis_sqlite_backend_config.ini

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -267,9 +267,9 @@ Install files to their proper locations:
 cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
 sudo install -v -m 755 -d /etc/zonemaster
 sudo install -v -m 775 -g zonemaster -d /var/log/zonemaster
-sudo install -v -m 775 -g zonemaster -d /var/run/zonemaster
 sudo install -v -m 640 -g zonemaster ./backend_config.ini /etc/zonemaster/
 sudo install -v -m 755 ./zm-backend.sh /etc/init.d/
+sudo install -v -m 755 ./tmpfiles.conf /usr/lib/tmpfiles.d/zonemaster.conf
 ```
 
 ### 4.2 Database engine installation and configuration (Debian)
@@ -346,6 +346,12 @@ sudo -u postgres psql -f ./initial-postgres.sql
 
 
 ### 4.3 Service configuration and startup (Debian)
+
+Make sure our tmpfiles configuration takes effect:
+
+```sh
+sudo systemd-tmpfiles --create
+```
 
 Add `zm-backend.sh` to start up script:
 

--- a/share/tmpfiles.conf
+++ b/share/tmpfiles.conf
@@ -1,0 +1,2 @@
+#Type Path              Mode UID        GID          Age Argument
+d     /run/zonemaster   0755 zonemaster zonemaster   -   -


### PR DESCRIPTION
I had strange behaviors with the RPCAPI sometimes not starting and when I dug into it I stumbled upon a solution to the reboot problem. The trick is to tell systemd-tmpfiles to (re)create `/var/run/zonemaster` at start up. The directory goes away because it resides on a tmpfs partition.

Fixes #513.