### PR TITLE
Add forgotten dependency

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -62,7 +62,7 @@ for Zonemaster::Backend, see the [declaration of prerequisites].
 Install dependencies available from binary packages:
 
 ```sh
-sudo yum install perl-Module-Install perl-IO-CaptureOutput perl-String-ShellQuote
+sudo yum install perl-Module-Install perl-IO-CaptureOutput perl-String-ShellQuote redhat-lsb-core
 ```
 
 Install dependencies not available from binary packages:


### PR DESCRIPTION
Fixes #589. 
This makes sure /lib/lsb/init-functions is installed on CentOS. We depend on those for zm-rpcapi.lsb and we're using that on CentOS.