### PR TITLE
Fix for translation on FreeBSD 12.1.

### DIFF
--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -6,6 +6,7 @@ use 5.14.2;
 
 use Moose;
 use Encode;
+use POSIX qw[setlocale LC_MESSAGES LC_CTYPE];
 
 # Zonemaster Modules
 require Zonemaster::Engine::Translator;
@@ -29,6 +30,20 @@ sub translate_tag {
     else {
         $self->locale( "en_US.UTF-8" );
     }
+
+    # Make locale really be set. Fix that makes translation work on FreeBSD 12.1. Solution copied from
+    # CLI.pm in the Zonemaster-CLI repository.
+    undef $ENV{LANGUAGE};
+    $ENV{LC_ALL} = $self->locale;
+    if ( not defined setlocale( LC_MESSAGES, "" ) ) {
+        warn sprintf "Warning: setting locale category LC_MESSAGES to %s failed (is it installed on this system?).",
+        $ENV{LANGUAGE} || $ENV{LC_ALL} || $ENV{LC_MESSAGES};
+    }
+    if ( not defined setlocale( LC_CTYPE, "" ) ) {
+        warn sprintf "Warning: setting locale category LC_CTYPE to %s failed (is it installed on this system?)." ,
+        $ENV{LC_ALL} || $ENV{LC_CTYPE};
+    }
+
     my $string = $self->data->{ $entry->{module} }{ $entry->{tag} };
 
     if ( not $string ) {


### PR DESCRIPTION
Resolves issue #593. 

This fix has been successfully tested in FreeBSD 12.1. In FreeBSD 11.3 it does not help, so that version remains broken.

CentOS, Debian and Ubuntu must be tested without and with this fix. Does it make any difference for any of those OSs? Does it create any problem?