### PR TITLE
Stricter handling of the language tag

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -274,7 +274,8 @@ I.e. a string matching `/^[a-zA-Z0-9-_.@]{1,30}$/`.
 * Any string starting with `"fr"` is interpreted as French.
 * Any string starting with `"sv"` is interpreted as Swedish.
 * Any string starting with `"da"` is interpreted as Danish.
-* Any other string is interpreted as English.
+* Any string starting with `"en"` is interpreted as English.
+* Any other string is an error.
 
 
 ### Unsigned integer
@@ -651,6 +652,10 @@ Example request:
   }
 }
 ```
+
+Both `id` and `language` are mandatory parameters. The `id` parameter must match the `result` in
+the response to a `start_domain_test` call, and that test must have been completed. The `language`
+parameter must match a language string defined above.
 
 Example response:
 ```json

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -16,8 +16,10 @@ extends 'Zonemaster::Engine::Translator';
 
 sub translate_tag {
     my ( $self, $entry, $browser_lang ) = @_;
-
     my $previous_locale = $self->locale;
+
+    # $browser_lang is set to the first two characters of the string in
+    # "language" in "get_test_results" call.
     if ( $browser_lang eq 'fr' ) {
         $self->locale( "fr_FR.UTF-8" );
     }
@@ -27,8 +29,11 @@ sub translate_tag {
     elsif ( $browser_lang eq 'da' ) {
         $self->locale( "da_DK.UTF-8" );
     }
-    else {
+    elsif ( $browser_lang eq 'en' ) {
         $self->locale( "en_US.UTF-8" );
+    }
+    else {
+	die "Invalid language string: '$browser_lang' ";
     }
 
     # Make locale really be set. Fix that makes translation work on FreeBSD 12.1. Solution copied from


### PR DESCRIPTION
The API documentation is unclear if "language" is mandatory in "get_test_results" but in the implementation it is mandatory. Here we follow the implementation and make it mandatory in the documentation.

In the API documentation and in the implementation defines some strings (or rather start of strings) to be specific languages and the remaining strings are interpreted as English. The drawbacks of this behavior are:

* When new languages are added, a string that earlier was interpreted as English, e.g. "no", will if Norwegian is added be interpreted as Norwegian.
* When testing, if the the language string is misspelled it could be interpreted as translation is not working. It is better to get a clear signal that the string was wrong.

This PR introduces the following updates to the API document, and if accepted, a new PR will be created changing the behavior of the RPCAPI.

* Only accept defined language tags (strings)
* Explicitly state that language parameter must be included with
  "get_test_results"

This PR also implements the check in the code (update from earlier version of the PR). That change was in #596 before, which is now closed.