### PR TITLE
Fix failing unit test on Debian 10

### DIFF
--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -6,7 +6,6 @@ use 5.14.2;
 
 use Moose;
 use Encode;
-use POSIX qw[setlocale LC_MESSAGES LC_CTYPE];
 
 # Zonemaster Modules
 require Zonemaster::Engine::Translator;
@@ -30,20 +29,6 @@ sub translate_tag {
     else {
         $self->locale( "en_US.UTF-8" );
     }
-
-    # Make locale really be set. Fix that makes translation work on FreeBSD 12.1. Solution copied from
-    # CLI.pm in the Zonemaster-CLI repository.
-    undef $ENV{LANGUAGE};
-    $ENV{LC_ALL} = $self->locale;
-    if ( not defined setlocale( LC_MESSAGES, "" ) ) {
-        warn sprintf "Warning: setting locale category LC_MESSAGES to %s failed (is it installed on this system?).",
-        $ENV{LANGUAGE} || $ENV{LC_ALL} || $ENV{LC_MESSAGES};
-    }
-    if ( not defined setlocale( LC_CTYPE, "" ) ) {
-        warn sprintf "Warning: setting locale category LC_CTYPE to %s failed (is it installed on this system?)." ,
-        $ENV{LC_ALL} || $ENV{LC_CTYPE};
-    }
-
     my $string = $self->data->{ $entry->{module} }{ $entry->{tag} };
 
     if ( not $string ) {


### PR DESCRIPTION
On Debian 10 #594 breaks a unit test, and therefore installation. I have not investigated this further. At this point in the release cycle I'm more comfortable just reverting that PR than trying to make a more elaborate fix.

This reverts commit 61dbab1e20bf3d70118bc568763a96c186cc8e2d.