### PR TITLE
Debian installation

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -395,8 +395,8 @@ check that the service has started with the following command (if you get output
 with the `start` command, you probably do not get it with the `status` command).
 
 ```sh
-sudo service zm-rpcapi status
-sudo service zm-testagent status
+sudo service zm-rpcapi status | cat
+sudo service zm-testagent status | cat
 ```
 
 ### 4.4 Post-installation (Debian)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -248,6 +248,16 @@ See the [post-installation] section for post-installation matters.
 > **Note:** Zonemaster::LDNS and Zonemaster::Engine are not listed here as they
 > are dealt with in the [prerequisites](#prerequisites) section.
 
+Install required locales:
+
+```sh
+locale -a | grep en_US.utf8 || echo en_US.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
+locale -a | grep sv_SE.utf8 || echo sv_SE.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
+locale -a | grep fr_FR.utf8 || echo fr_FR.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
+locale -a | grep da_DK.utf8 || echo da_DK.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
+sudo locale-gen
+```
+
 Install dependencies available from binary packages:
 
 ```sh

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -248,6 +248,12 @@ See the [post-installation] section for post-installation matters.
 > **Note:** Zonemaster::LDNS and Zonemaster::Engine are not listed here as they
 > are dealt with in the [prerequisites](#prerequisites) section.
 
+Optionally install Curl (only needed for the post-installation smoke test):
+
+```sh
+sudo apt install curl
+```
+
 Install required locales:
 
 ```sh

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -369,12 +369,6 @@ sudo -u postgres psql -f ./initial-postgres.sql
 
 ### 4.3 Service configuration and startup (Debian)
 
-Make sure our tmpfiles configuration takes effect:
-
-```sh
-sudo systemd-tmpfiles --create /usr/lib/tmpfiles.d/zonemaster.conf
-```
-
 Add services to the default runlevel:
 
 ```sh
@@ -385,6 +379,7 @@ sudo update-rc.d zm-testagent defaults
 Start the services:
 
 ```sh
+sudo systemd-tmpfiles --create /usr/lib/tmpfiles.d/zonemaster.conf
 sudo service zm-rpcapi start
 sudo service zm-testagent start
 ```


### PR DESCRIPTION
Installation failed because Backend depends on a certain set of locales - namely en_US.UTF-8, sv_SE.UTF-8, fr_FR.UTF-8 and da_DK.UTF-8. If they're not present Backend crashes. In particular this happens when tests are run at installation time, causing the installation to abort. This PR fixes that problem by making sure the locales are installed.

This PR also includes a couple of other small improvements.