### PR TITLE
System user UID/GID for zonemaster user/group under FreeBSD

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -515,7 +515,8 @@ Unless they already exist, add `zonemaster` user and `zonemaster` group
 (the group is created automatically):
 
 ```sh
-pw useradd zonemaster -s /sbin/nologin -d /nonexistent -c "Zonemaster daemon user"
+cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
+pw useradd zonemaster -C freebsd-pwd.conf -s /sbin/nologin -d /nonexistent -c "Zonemaster daemon user"
 ```
 
 Install files to their proper locations:

--- a/share/freebsd-pwd.conf
+++ b/share/freebsd-pwd.conf
@@ -1,0 +1,7 @@
+# Range of free system UIDs that can be used for Zonemaster user
+minuid = 736
+maxuid = 769
+
+# Range of free system GIDs that can be used for Zonemaster group
+mingid = 736
+maxgid = 769


### PR DESCRIPTION
Current installation instruction gives the zonemaster user a UID and a GID that are meant for normal users, not system users. For system users there are UIDs and GIDs reserved for specific programs (packages) and UIDs/GIDs that are still free. This patch will make the instruction give the zonemaster user a UID/GID that is from the free space. When Zonemaster-Backend is packaged for FreeBSD it could get a fixed UID/GID.

Read [here][porters-handbook-users-and-groups] about UIDs and GIDs for applications ported to FreeBSD.

To see the current status of the list of booked and free UIDs and GIDs go to [FreeBSD ports] and scroll down to `GIDs` and `UIDs` and select the revision number for the files.

[porters-handbook-users-and-groups]: https://www.freebsd.org/doc/en_US.ISO8859-1/books/porters-handbook/users-and-groups.html
[FreeBSD ports]: https://svnweb.freebsd.org/ports/head/