### PR TITLE
Stricter handling of the language tag (updated version)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -334,6 +334,7 @@ Example response:
 }
 ```
 
+
 #### `"result"`
 
 An object with the following properties:
@@ -374,12 +375,13 @@ Example response:
 }
 ```
 
+
 #### `"result"`
 
 An array of *Profile names* in lower case. `"default"` is always included.
 
 
-## API method: `translation_language_strings`
+## API method: `get_language_strings`
 
 Returns valid strings for [translation language] based on the setting in the
 configuration file.
@@ -389,7 +391,7 @@ Example request:
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "method": "translation_language_strings"
+  "method": "get_language_strings"
 }
 ```
 
@@ -409,9 +411,11 @@ Example response:
 }
 ```
 
+
 #### `"result"`
 
 An array of strings for *translation language*. It is never empty.
+
 
 #### `"error"`
 
@@ -473,6 +477,7 @@ value `0.0.0.0` if the lookup returned no A or AAAA records.
 >
 > TODO: If the name resolves to two or more IPv4 address, how is that represented?
 >
+
 
 #### `"error"`
 
@@ -629,13 +634,15 @@ An object with the following properties:
 > TODO: Clarify the purpose of each `"params"` property.
 >
 
+
 #### `"result"`
 
 A *test id*. 
 
 If the test has been run with the same domain name within an interval of 10 mins (hard coded), 
 then the new request does not trigger a new test, but returns with the results of the last test
- 
+
+
 #### `"error"`
 
 * If the given `profile` is not among the [available profiles], a user
@@ -799,7 +806,6 @@ In the case of a test created with `add_batch_job`:
 >
 
 
-
 #### `"error"`
 
 >
@@ -936,9 +942,11 @@ An object with the following properties:
 * `"username"`: An *username*, required. The name of the user to add.
 * `"api_key"`: An *api key*, required. The API key for the user to add.
 
+
 #### `"result"`
 
 An integer. The value is equal to 1 if the registration is a success, or 0 if it failed.
+
 
 #### `"error"`
 >
@@ -1146,6 +1154,7 @@ Example response:
     }
 }
 ```
+
 
 #### `"params"`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -268,13 +268,19 @@ Example: "2017-12-18 07:56:17.156939"
 Basic data type: string
 
 A string of alphanumeric, hyphens, underscores, full stops and at-signs (`@`),
-of at least 1 and at most 30 characters.
-I.e. a string matching `/^[a-zA-Z0-9-_.@]{1,30}$/`.
+of at least 2 and at most 30 characters,
+i.e. a string matching `/^[a-zA-Z0-9-_.@]{1,30}$/`, where only the first 2
+characters are used.
 
-* Any string starting with `"fr"` is interpreted as French.
-* Any string starting with `"sv"` is interpreted as Swedish.
-* Any string starting with `"da"` is interpreted as Danish.
-* Any other string is interpreted as English.
+The 2 first characters must match the list of language
+codes defined in the configuration file. Any other string
+is an error.
+
+A default installation will will accept:
+* Any string starting with `"da"` (Danish).
+* Any string starting with `"en"` (English).
+* Any string starting with `"fr"` (French).
+* Any string starting with `"sv"` (Swedish).
 
 
 ### Unsigned integer
@@ -651,6 +657,10 @@ Example request:
   }
 }
 ```
+
+Both `id` and `language` are mandatory parameters. The `id` parameter must match the `result` in
+the response to a `start_domain_test` call, and that test must have been completed. The `language`
+parameter must match a language string defined above.
 
 Example response:
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -282,7 +282,7 @@ The two first characters of the `language tag` are intended to be an
 [ISO 639-1] two-character language code and the optional two last characters
 are intended to be an [ISO 3166-1 alpha-2] two-character country code.
 
-A default installation will will accept the following `language tags`:
+A default installation will accept the following `language tags`:
 * `da` or `da_DK` for Danish language.
 * `en` or `en_US` for English language.
 * `fr` or `fr_FR` for French language.

--- a/docs/API.md
+++ b/docs/API.md
@@ -267,20 +267,28 @@ Example: "2017-12-18 07:56:17.156939"
 
 Basic data type: string
 
-A string of alphanumeric, hyphens, underscores, full stops and at-signs (`@`),
-of at least 2 and at most 30 characters,
-i.e. a string matching `/^[a-zA-Z0-9-_.@]{1,30}$/`, where only the first 2
-characters are used.
+A string of A-Z, a-z and underscores matching the regular expression
+`/^[a-z]{2}(_[A-Z]{2})?$/`.
 
-The 2 first characters must match the list of language
-codes defined in the configuration file. Any other string
-is an error.
+The two first characters of the translation language string are
+expected to be an [ISO 639-1] two-character language code and the
+optional two last characters are expected to be an [ISO 3166-1 alpha-2]
+two-character country code.
 
-A default installation will will accept:
-* Any string starting with `"da"` (Danish).
-* Any string starting with `"en"` (English).
-* Any string starting with `"fr"` (French).
-* Any string starting with `"sv"` (Swedish).
+The translation language string must match a language tag in the
+configuration file. If the language translation string is a
+two-character string (language code only), it only need to match
+the first two characters of the language tag in the configuration file,
+if that is unique (there is only one language tag starting with the same
+language code), else it is an error.
+
+Any other string is an error.
+
+A default installation will will accept the following strings:
+* `"da"` or `"da_DK"` for Danish language.
+* `"en"` or `"en_US"` for English language.
+* `"fr"` or `"fr_FR"` for French language.
+* `"sv"` or `"sv_SE"` for Swedish language.
 
 
 ### Unsigned integer
@@ -326,7 +334,6 @@ Example response:
 }
 ```
 
-
 #### `"result"`
 
 An object with the following properties:
@@ -367,10 +374,53 @@ Example response:
 }
 ```
 
-
 #### `"result"`
 
 An array of *Profile names* in lower case. `"default"` is always included.
+
+
+## API method: `translation_language_strings`
+
+Returns valid [translation language strings] given the setting in the
+configuration file.
+
+Example request:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "translation_language_strings"
+}
+```
+
+Example response:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    "en",
+    "en_US",
+    "fr",
+    "fr_FR",
+    "sv",
+    "sv_SE"
+  ]
+}
+```
+
+#### `"result"`
+
+An array of *translation language strings*. It is never empty.
+
+#### `"error"`
+
+>
+> TODO: List all possible error codes and describe what they mean enough for
+> clients to know how react to them. Or prevent RPCAPI from starting with
+> errors in the configuration file and make it not to reread the configuration
+> file while running.
+>
 
 
 ## API method: `get_host_by_name`
@@ -658,9 +708,8 @@ Example request:
 }
 ```
 
-Both `id` and `language` are mandatory parameters. The `id` parameter must match the `result` in
-the response to a `start_domain_test` call, and that test must have been completed. The `language`
-parameter must match a language string defined above.
+The `id` parameter must match the `result` in the response to a `start_domain_test` call,
+and that test must have been completed.
 
 Example response:
 ```json
@@ -1116,5 +1165,8 @@ The `"params"` object sent to `start_domain_test` or `add_batch_job` when the *t
 > TODO: List all possible error codes and describe what they mean enough for clients to know how react to them.
 >
 
-[Available profiles]: Configuration.md#profiles-section
-[Privilege levels]: #privilege-levels
+[Available profiles]:           Configuration.md#profiles-section
+[ISO 3166-1 alpha-2]:           https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+[ISO 639-1]:                    https://en.wikipedia.org/wiki/ISO_639-1
+[Privilege levels]:             #privilege-levels
+[Translation language strings]: #translation-language

--- a/docs/API.md
+++ b/docs/API.md
@@ -270,19 +270,19 @@ Basic data type: string
 A string of A-Z, a-z and underscores matching the regular expression
 `/^[a-z]{2}(_[A-Z]{2})?$/`.
 
-The two first characters of the translation language string are
-expected to be an [ISO 639-1] two-character language code and the
-optional two last characters are expected to be an [ISO 3166-1 alpha-2]
-two-character country code.
-
 The translation language string must match a language tag in the
 configuration file. If the language translation string is a
-two-character string (language code only), it only need to match
-the first two characters of the language tag in the configuration file,
-if that is unique (there is only one language tag starting with the same
-language code), else it is an error.
+two-character string, it only needs to match the first two characters
+of the language tag in the configuration file, if that is unique (there
+is only one language tag starting with the same two characters), else
+it is an error.
 
 Any other string is an error.
+
+The two first characters of the translation language string are
+intended to be an [ISO 639-1] two-character language code and the
+optional two last characters are intended to be an [ISO 3166-1 alpha-2]
+two-character country code.
 
 A default installation will will accept the following strings:
 * `"da"` or `"da_DK"` for Danish language.
@@ -293,9 +293,9 @@ A default installation will will accept the following strings:
 
 ### Unsigned integer
 
- Basic data type: number (integer)
+Basic data type: number (integer)
  
- An unsigned integer is either positive or zero.
+An unsigned integer is either positive or zero.
  
 
 ### Username
@@ -381,7 +381,7 @@ An array of *Profile names* in lower case. `"default"` is always included.
 
 ## API method: `translation_language_strings`
 
-Returns valid [translation language strings] given the setting in the
+Returns valid strings for [translation language] based on the setting in the
 configuration file.
 
 Example request:
@@ -411,7 +411,7 @@ Example response:
 
 #### `"result"`
 
-An array of *translation language strings*. It is never empty.
+An array of strings for *translation language*. It is never empty.
 
 #### `"error"`
 
@@ -1169,4 +1169,4 @@ The `"params"` object sent to `start_domain_test` or `add_batch_job` when the *t
 [ISO 3166-1 alpha-2]:           https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                    https://en.wikipedia.org/wiki/ISO_639-1
 [Privilege levels]:             #privilege-levels
-[Translation language strings]: #translation-language
+[Translation language]:         #translation-language

--- a/docs/API.md
+++ b/docs/API.md
@@ -263,32 +263,30 @@ Default database timestamp format: "Y-M-D H:M:S.ms".
 Example: "2017-12-18 07:56:17.156939"
 
 
-### Translation language
+### Language tag
 
 Basic data type: string
 
 A string of A-Z, a-z and underscores matching the regular expression
 `/^[a-z]{2}(_[A-Z]{2})?$/`.
 
-The translation language string must match a language tag in the
-configuration file. If the language translation string is a
-two-character string, it only needs to match the first two characters
-of the language tag in the configuration file, if that is unique (there
-is only one language tag starting with the same two characters), else
-it is an error.
+The `language tag` must match a `locale tag` in the configuration file.
+If the `language tag` is a two-character string, it only needs to match the
+first two characters of the `locale tag` from the configuration file, if
+that is unique (there is only one `locale tag` starting with the same two
+characters), else it is an error.
 
 Any other string is an error.
 
-The two first characters of the translation language string are
-intended to be an [ISO 639-1] two-character language code and the
-optional two last characters are intended to be an [ISO 3166-1 alpha-2]
-two-character country code.
+The two first characters of the `language tag` are intended to be an
+[ISO 639-1] two-character language code and the optional two last characters
+are intended to be an [ISO 3166-1 alpha-2] two-character country code.
 
-A default installation will will accept the following strings:
-* `"da"` or `"da_DK"` for Danish language.
-* `"en"` or `"en_US"` for English language.
-* `"fr"` or `"fr_FR"` for French language.
-* `"sv"` or `"sv_SE"` for Swedish language.
+A default installation will will accept the following `language tags`:
+* `da` or `da_DK` for Danish language.
+* `en` or `en_US` for English language.
+* `fr` or `fr_FR` for French language.
+* `sv` or `sv_SE` for Swedish language.
 
 
 ### Unsigned integer
@@ -381,9 +379,9 @@ Example response:
 An array of *Profile names* in lower case. `"default"` is always included.
 
 
-## API method: `get_language_strings`
+## API method: `get_language_tags`
 
-Returns valid strings for [translation language] based on the setting in the
+Returns valid [language tags][language tag] generated from the setting in the
 configuration file.
 
 Example request:
@@ -391,7 +389,7 @@ Example request:
 {
   "jsonrpc": "2.0",
   "id": 1,
-  "method": "get_language_strings"
+  "method": "get_language_tags"
 }
 ```
 
@@ -414,7 +412,7 @@ Example response:
 
 #### `"result"`
 
-An array of strings for *translation language*. It is never empty.
+An array of *language tags*. It is never empty.
 
 
 #### `"error"`
@@ -700,7 +698,8 @@ A *progress percentage*.
 
 ## API method: `get_test_results`
 
-Return all *test result* objects of a *test*, with *messages* in the requested *translation language*.
+Return all *test result* objects of a *test*, with *messages* in the requested language as selected by the
+*language tag*.
 
 Example request:
 ```json
@@ -776,7 +775,7 @@ Example response:
 An object with the following properties:
 
 * `"id"`: A *test id*, required.
-* `"language"`: A *translation language*, required.
+* `"language"`: A *language tag*, required.
 
 
 #### `"result"`
@@ -1178,4 +1177,4 @@ The `"params"` object sent to `start_domain_test` or `add_batch_job` when the *t
 [ISO 3166-1 alpha-2]:           https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                    https://en.wikipedia.org/wiki/ISO_639-1
 [Privilege levels]:             #privilege-levels
-[Translation language]:         #translation-language
+[Language tag]:                 #language-tag

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,6 +32,45 @@ SQLite            | `SQLite`
 
 TBD
 
+## LANGUAGES
+
+The LANGUAGE section has one key, `lang`.
+
+The value must be a space separated list of locale setting
+for the available translation of messages without ".UTF-8"
+which is assumed.
+
+Adding a new language to the configuration requires that the
+equivalent MO file is added to Zonemaster-Engine at the correct
+place so that getext get retreive it. Removing a lanugage from
+the configuration file just blocks that language to be displayed.
+
+English is the Zonemaster default language, but can be blocked
+from being displayed by RPC-API by not including it in the
+configuration.
+
+The default installation and configuration supports the
+following languages.
+
+Language | Code in RPC-API* | Value in .ini file | Locale value
+---------|------------------|--------------------|-------------
+Danish   | da               | da_DK              | da_DK.UTF-8
+English  | en               | en_US              | en_US.UTF-8
+French   | fr               | fr_FR              | fr_FR.UTF-8
+Swedish  | sv               | sv_SE              | sv_SE.UTF-8
+
+*) RPC-API just considers the two first characters of the language
+string and disregards the remaining.
+
+The same language code may not be used more than once.
+
+Default setting in the configuration file:
+
+```
+lang = da_DK en_US fr_FR sv_SE
+```
+
+If the section is empty, "en_US" is set by default.
 
 ## LOG section
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,45 +32,54 @@ SQLite            | `SQLite`
 
 TBD
 
-## LANGUAGES
+## LANGUAGE section
 
 The LANGUAGE section has one key, `lang`.
 
-The value must be a space separated list of locale setting
-for the available translation of messages without ".UTF-8"
-which is assumed.
+The value of the `lang` key is a space separated list of
+language tags where each tag must match the regular expression
+`/^[a-z]{2}_[A-Z]{2}$/`.
+
+The two first characters of a language tag are expected to be an
+[ISO 639-1] two-character language code and the two last characters
+are expected to be an [ISO 3166-1 alpha-2] two-character country code.
+A language tag is a locale setting for the available translation
+of messages without ".UTF-8", which is assumed.
 
 Adding a new language to the configuration requires that the
 equivalent MO file is added to Zonemaster-Engine at the correct
-place so that getext get retreive it. Removing a lanugage from
-the configuration file just blocks that language to be displayed.
+place so that gettext get retrieve it. Removing a language from
+the configuration file just blocks that language from being
+allowed.
 
 English is the Zonemaster default language, but can be blocked
-from being displayed by RPC-API by not including it in the
+from being allowed by RPC-API by not including it in the
 configuration.
 
 The default installation and configuration supports the
 following languages.
 
-Language | Code in RPC-API* | Value in .ini file | Locale value
----------|------------------|--------------------|-------------
-Danish   | da               | da_DK              | da_DK.UTF-8
-English  | en               | en_US              | en_US.UTF-8
-French   | fr               | fr_FR              | fr_FR.UTF-8
-Swedish  | sv               | sv_SE              | sv_SE.UTF-8
+Language | Language tag value | Locale value used
+---------|--------------------|------------------
+Danish   | da_DK              | da_DK.UTF-8
+English  | en_US              | en_US.UTF-8
+French   | fr_FR              | fr_FR.UTF-8
+Swedish  | sv_SE              | sv_SE.UTF-8
 
-*) RPC-API just considers the two first characters of the language
-string and disregards the remaining.
+Repeated language tag values are just ignored.
 
-The same language code may not be used more than once.
-
-Default setting in the configuration file:
+Setting in the default configuration file:
 
 ```
 lang = da_DK en_US fr_FR sv_SE
 ```
 
-If the section is empty, "en_US" is set by default.
+If the lang key is empty or absent, the language tag value
+"en_US" is set by default.
+
+Each locale, including ".UTF-8", set in the configuration file
+must also be installed or activate on the system running the RPCAPI
+daemon for the translation to work correctly.
 
 ## LOG section
 
@@ -113,11 +122,13 @@ TBD
 
 --------
 
+[Default JSON profile file]:   https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
+[ISO 3166-1 alpha-2]:          https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+[ISO 639-1]:                   https://en.wikipedia.org/wiki/ISO_639-1
+[Profile JSON files]:          https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
+[Profile names]:               API.md#profile-name
+[Profiles]:                    Architecture.md#profile
 [Zonemaster::Engine::Profile]: https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES
-[Default JSON profile file]: https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
-[Profile JSON files]: https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
-[Profile names]: API.md#profile-name
-[Profiles]: Architecture.md#profile
 
 
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -40,19 +40,25 @@ The value of the `lang` key is a space separated list of
 language tags where each tag must match the regular expression
 `/^[a-z]{2}_[A-Z]{2}$/`.
 
-The two first characters of a language tag are expected to be an
+The two first characters of a language tag are intended to be an
 [ISO 639-1] two-character language code and the two last characters
-are expected to be an [ISO 3166-1 alpha-2] two-character country code.
+are intended to be an [ISO 3166-1 alpha-2] two-character country code.
 A language tag is a locale setting for the available translation
-of messages without ".UTF-8", which is assumed.
+of messages without ".UTF-8", which is implied.
 
-Adding a new language to the configuration requires that the
-equivalent MO file is added to Zonemaster-Engine at the correct
-place so that gettext get retrieve it. Removing a language from
-the configuration file just blocks that language from being
-allowed.
+Adding a new language tag to the configuration requires that the
+equivalent .mo file is added to Zonemaster-Engine at the correct
+place so that gettext get retrieve it. See the
+[Zonemaster-Engine share directory] for the existing .po files
+that are converted to .mo files. (Here we should have a link
+to documentation instead.)
 
-English is the Zonemaster default language, but can be blocked
+Removing a language from the configuration file just blocks that
+language from being allowed. If there are more than one language
+tag (with different country codes) for the same language, then
+all those must probably be removed to block the language.
+
+English is the Zonemaster default language, but it can be blocked
 from being allowed by RPC-API by not including it in the
 configuration.
 
@@ -122,13 +128,14 @@ TBD
 
 --------
 
-[Default JSON profile file]:   https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
-[ISO 3166-1 alpha-2]:          https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
-[ISO 639-1]:                   https://en.wikipedia.org/wiki/ISO_639-1
-[Profile JSON files]:          https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
-[Profile names]:               API.md#profile-name
-[Profiles]:                    Architecture.md#profile
-[Zonemaster::Engine::Profile]: https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES
+[Default JSON profile file]:          https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
+[ISO 3166-1 alpha-2]:                 https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+[ISO 639-1]:                          https://en.wikipedia.org/wiki/ISO_639-1
+[Profile JSON files]:                 https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
+[Profile names]:                      API.md#profile-name
+[Profiles]:                           Architecture.md#profile
+[Zonemaster-Engine share directory]:  https://github.com/zonemaster/zonemaster-engine/tree/master/share
+[Zonemaster::Engine::Profile]:        https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES
 
 
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -72,7 +72,7 @@ English  | en_US              | en_US.UTF-8
 French   | fr_FR              | fr_FR.UTF-8
 Swedish  | sv_SE              | sv_SE.UTF-8
 
-Repeated language tag values are just ignored.
+It is an error to repeate the sama language tag.
 
 Setting in the default configuration file:
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -40,17 +40,20 @@ The value of the `locale` key is a space separated list of
 `locale tags` where each tag must match the regular expression
 `/^[a-z]{2}_[A-Z]{2}$/`.
 
+If the `locale` key is empty or absent, the `locale tag` value
+"en_US" is set by default.
+
 The two first characters of a `locale tag` are intended to be an
 [ISO 639-1] two-character language code and the two last characters
 are intended to be an [ISO 3166-1 alpha-2] two-character country code.
 A `locale tag` is a locale setting for the available translation
 of messages without ".UTF-8", which is implied.
 
-Adding a new `locale tag` to the configuration requires that the
-equivalent .mo file is added to Zonemaster-Engine at the correct
-place so that gettext get retrieve it. See the
-[Zonemaster-Engine share directory] for the existing .po files
-that are converted to .mo files. (Here we should have a link
+If a new `locale tag` is added to the configuration then the equivalent
+MO file should be added to Zonemaster-Engine at the correct place so
+that gettext can retrieve it, or else the added `locale tag` will not
+add anything. See the [Zonemaster-Engine share directory] for the existing
+PO files that are converted to .mo files. (Here we should have a link
 to documentation instead.)
 
 Removing a language from the configuration file just blocks that
@@ -72,16 +75,13 @@ English  | en_US              | en_US.UTF-8
 French   | fr_FR              | fr_FR.UTF-8
 Swedish  | sv_SE              | sv_SE.UTF-8
 
-It is an error to repeate the same `locale tag`.
+It is an error to repeat the same `locale tag`.
 
 Setting in the default configuration file:
 
 ```
 locale = da_DK en_US fr_FR sv_SE
 ```
-
-If the `locale` key is empty or absent, the `locale tag` value
-"en_US" is set by default.
 
 Each locale set in the configuration file, including the implied
 ".UTF-8", must also be installed or activate on the system

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -34,19 +34,19 @@ TBD
 
 ## LANGUAGE section
 
-The LANGUAGE section has one key, `lang`.
+The LANGUAGE section has one key, `locale`.
 
-The value of the `lang` key is a space separated list of
-language tags where each tag must match the regular expression
+The value of the `locale` key is a space separated list of
+`locale tags` where each tag must match the regular expression
 `/^[a-z]{2}_[A-Z]{2}$/`.
 
-The two first characters of a language tag are intended to be an
+The two first characters of a `locale tag` are intended to be an
 [ISO 639-1] two-character language code and the two last characters
 are intended to be an [ISO 3166-1 alpha-2] two-character country code.
-A language tag is a locale setting for the available translation
+A `locale tag` is a locale setting for the available translation
 of messages without ".UTF-8", which is implied.
 
-Adding a new language tag to the configuration requires that the
+Adding a new `locale tag` to the configuration requires that the
 equivalent .mo file is added to Zonemaster-Engine at the correct
 place so that gettext get retrieve it. See the
 [Zonemaster-Engine share directory] for the existing .po files
@@ -54,9 +54,9 @@ that are converted to .mo files. (Here we should have a link
 to documentation instead.)
 
 Removing a language from the configuration file just blocks that
-language from being allowed. If there are more than one language
-tag (with different country codes) for the same language, then
-all those must probably be removed to block the language.
+language from being allowed. If there are more than one `locale tag`
+(with different country codes) for the same language, then
+all those must be removed to block that language.
 
 English is the Zonemaster default language, but it can be blocked
 from being allowed by RPC-API by not including it in the
@@ -65,27 +65,27 @@ configuration.
 The default installation and configuration supports the
 following languages.
 
-Language | Language tag value | Locale value used
+Language | Locale tag value   | Locale value used
 ---------|--------------------|------------------
 Danish   | da_DK              | da_DK.UTF-8
 English  | en_US              | en_US.UTF-8
 French   | fr_FR              | fr_FR.UTF-8
 Swedish  | sv_SE              | sv_SE.UTF-8
 
-It is an error to repeate the sama language tag.
+It is an error to repeate the same `locale tag`.
 
 Setting in the default configuration file:
 
 ```
-lang = da_DK en_US fr_FR sv_SE
+locale = da_DK en_US fr_FR sv_SE
 ```
 
-If the lang key is empty or absent, the language tag value
+If the `locale` key is empty or absent, the `locale tag` value
 "en_US" is set by default.
 
-Each locale, including ".UTF-8", set in the configuration file
-must also be installed or activate on the system running the RPCAPI
-daemon for the translation to work correctly.
+Each locale set in the configuration file, including the implied
+".UTF-8", must also be installed or activate on the system
+running the RPCAPI daemon for the translation to work correctly.
 
 ## LOG section
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -76,12 +76,26 @@ sub DB_name {
     return $self->{cfg}->val( 'DB', 'database_name' );
 }
 
-# Read LANGUAGE.lang from the configuration (.ini) file and return a
-# hash of translation language strings as keys and locale setting as
-# values. There is one special value to capture ambiguous (and
-# therefore not permitted) translation language strings. The hash
-# is never empty.
+=head2 Translation_Locale_hash
+
+Read LANGUAGE.lang from the configuration (.ini) file and returns
+the valid translation language strings for RPCAPI. The incoming
+language string from RPCAPI is compared to those.
+
+=head3 INPUT
+
+None
+
+=head3 RETURNS
+
+A hash of valid language translation strings as keys with set
+locale value as value. The hash is never empty.
+
+=cut
+
 sub Translation_Locale_hash {
+    # There is one special value to capture ambiguous (and therefore
+    # not permitted) translation language strings.
     my ($self) = @_;
     my $lang = $self->{cfg}->val( 'LANGUAGE', 'lang' );
     $lang = 'en_US' unless $lang;
@@ -104,10 +118,23 @@ sub Translation_Locale_hash {
     return %locale;
 }
 
-# Read LANGUAGE.lang from the configuration (.ini) file and
-# return an array of translation language strings that are valid for the
-# language parameter in a get_test_results() call. The array is never empty.
-# Order of elements has no meaning.
+=head2 ListTranslationLanguageStrings
+
+Read indirectly LANGUAGE.lang from the configuration (.ini) file
+and returns a list of valid translation language strings for RPCAPI.
+The list can be retrieved via an RPCAPI method.
+
+=head3 INPUT
+
+None
+
+=head3 RETURNS
+
+An array of valid language translation strings. The array is never
+empty.
+
+=cut
+
 sub ListTranslationLanguageStrings {
     my ($self) = @_;
     my %locale = &Translation_Locale_hash($self);

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -76,6 +76,21 @@ sub DB_name {
     return $self->{cfg}->val( 'DB', 'database_name' );
 }
 
+sub LANG_hash {
+    my ($self) = @_;
+    my $lang = $self->{cfg}->val( 'LANGUAGES', 'lang' );
+    $lang = 'en_US' unless $lang;
+    my @langs = split (/\s+/,$lang);
+    my %locale;
+    foreach my $l (@langs) {
+        die "Incorrect config value in LANGUAGES.lang: $lang\n" unless $l =~ /^[a-z]{2}_[A-Z]{2}$/;
+        (my $a) = split (/_/,$l);
+        die "Language code used twice in LANGUAGES.lang: $lang\n" if $locale{$a};
+        $locale{$a} = "$l.UTF-8";
+    }
+    return %locale;
+}
+
 sub DB_connection_string {
     my ($self) = @_;
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -102,7 +102,8 @@ sub Translation_Locale_hash {
     my @langs = split (/\s+/,$lang);
     my %locale;
     foreach my $la (@langs) {
-        die "Incorrect language tag in LANGUAGE.lang: $lang\n" unless $la =~ /^[a-z]{2}_[A-Z]{2}$/;
+        die "Incorrect language tag in LANGUAGE.lang: $la\n" unless $la =~ /^[a-z]{2}_[A-Z]{2}$/;
+        die "Repeated language tag in LANGUAGE.lang: $la\n" if $locale{$la};
         (my $a) = split (/_/,$la); # $a is the language code only
         my $lo = "$la.UTF-8";
         # Set special value if the same language code is used more than once

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -76,11 +76,12 @@ sub DB_name {
     return $self->{cfg}->val( 'DB', 'database_name' );
 }
 
-=head2 Translation_Locale_hash
+=head2 Language_Locale_hash
 
-Read LANGUAGE.lang from the configuration (.ini) file and returns
-the valid translation language strings for RPCAPI. The incoming
-language string from RPCAPI is compared to those.
+Read LANGUAGE.locale from the configuration (.ini) file and returns
+the valid language tags for RPCAPI. The incoming language tag
+from RPCAPI is compared to those. The language tags are mapped to
+locale setting value.
 
 =head3 INPUT
 
@@ -88,22 +89,22 @@ None
 
 =head3 RETURNS
 
-A hash of valid language translation strings as keys with set
-locale value as value. The hash is never empty.
+A hash of valid language tags as keys with set locale value as value.
+The hash is never empty.
 
 =cut
 
-sub Translation_Locale_hash {
+sub Language_Locale_hash {
     # There is one special value to capture ambiguous (and therefore
-    # not permitted) translation language strings.
+    # not permitted) translation language tags.
     my ($self) = @_;
-    my $lang = $self->{cfg}->val( 'LANGUAGE', 'lang' );
-    $lang = 'en_US' unless $lang;
-    my @langs = split (/\s+/,$lang);
+    my $data = $self->{cfg}->val( 'LANGUAGE', 'locale' );
+    $data = 'en_US' unless $data;
+    my @localetags = split (/\s+/,$data);
     my %locale;
-    foreach my $la (@langs) {
-        die "Incorrect language tag in LANGUAGE.lang: $la\n" unless $la =~ /^[a-z]{2}_[A-Z]{2}$/;
-        die "Repeated language tag in LANGUAGE.lang: $la\n" if $locale{$la};
+    foreach my $la (@localetags) {
+        die "Incorrect locale tag in LANGUAGE.locale: $la\n" unless $la =~ /^[a-z]{2}_[A-Z]{2}$/;
+        die "Repeated locale tag in LANGUAGE.locale: $la\n" if $locale{$la};
         (my $a) = split (/_/,$la); # $a is the language code only
         my $lo = "$la.UTF-8";
         # Set special value if the same language code is used more than once
@@ -119,11 +120,11 @@ sub Translation_Locale_hash {
     return %locale;
 }
 
-=head2 ListTranslationLanguageStrings
+=head2 ListLanguageTags
 
-Read indirectly LANGUAGE.lang from the configuration (.ini) file
-and returns a list of valid translation language strings for RPCAPI.
-The list can be retrieved via an RPCAPI method.
+Read indirectly LANGUAGE.locale from the configuration (.ini) file
+and returns a list of valid language tags for RPCAPI. The list can
+be retrieved via an RPCAPI method.
 
 =head3 INPUT
 
@@ -131,19 +132,18 @@ None
 
 =head3 RETURNS
 
-An array of valid language translation strings. The array is never
-empty.
+An array of valid language tags. The array is never empty.
 
 =cut
 
-sub ListTranslationLanguageStrings {
+sub ListLanguageTags {
     my ($self) = @_;
-    my %locale = &Translation_Locale_hash($self);
-    my @lang;
+    my %locale = &Language_Locale_hash($self);
+    my @langtags;
     foreach my $key (keys %locale) {
-        push @lang, $key unless $locale{$key} eq 'NOT-UNIQUE';
+        push @langtags, $key unless $locale{$key} eq 'NOT-UNIQUE';
     }
-    return @lang;
+    return @langtags;
 }
 
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -78,6 +78,17 @@ sub profile_names {
     return \@profiles;
 }
 
+# Return the list of language tags supported by get_test_results(). The tags are
+# set in the configuration file.
+$json_schemas{translation_language_strings} = joi->object->strict;
+sub translation_language_strings {
+    my ($self) = @_;
+
+    my @lang = Zonemaster::Backend::Config->load_config()->ListTranslationLanguageStrings();
+
+    return \@lang;
+}
+
 $json_schemas{get_host_by_name} = joi->object->strict->props(
     hostname   => $zm_validator->domain_name->required
 );
@@ -367,7 +378,6 @@ sub get_test_results {
 
     my $translator;
     $translator = Zonemaster::Backend::Translator->new;
-    my ( $browser_lang ) = ( $params->{language} =~ /^(\w{2})/ );
 
     eval { $translator->data } if $translator;    # Provoke lazy loading of translation data
 
@@ -386,7 +396,7 @@ sub get_test_results {
         }
 
         $res->{module} = $test_res->{module};
-        $res->{message} = $translator->translate_tag( $test_res, $browser_lang ) . "\n";
+        $res->{message} = $translator->translate_tag( $test_res, $params->{language} ) . "\n";
         $res->{message} =~ s/,/, /isg;
         $res->{message} =~ s/;/; /isg;
         $res->{level} = $test_res->{level};

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -80,8 +80,8 @@ sub profile_names {
 
 # Return the list of language tags supported by get_test_results(). The tags are
 # set in the configuration file.
-$json_schemas{translation_language_strings} = joi->object->strict;
-sub translation_language_strings {
+$json_schemas{get_language_strings} = joi->object->strict;
+sub get_language_strings {
     my ($self) = @_;
 
     my @lang = Zonemaster::Backend::Config->load_config()->ListTranslationLanguageStrings();

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -79,12 +79,12 @@ sub profile_names {
 }
 
 # Return the list of language tags supported by get_test_results(). The tags are
-# set in the configuration file.
-$json_schemas{get_language_strings} = joi->object->strict;
-sub get_language_strings {
+# derived from the locale tags set in the configuration file.
+$json_schemas{get_language_tags} = joi->object->strict;
+sub get_language_tags {
     my ($self) = @_;
 
-    my @lang = Zonemaster::Backend::Config->load_config()->ListTranslationLanguageStrings();
+    my @lang = Zonemaster::Backend::Config->load_config()->ListLanguageTags();
 
     return \@lang;
 }
@@ -369,7 +369,7 @@ sub get_test_params {
 
 $json_schemas{get_test_results} = joi->object->strict->props(
     id => $zm_validator->test_id->required,
-    language => $zm_validator->translation_language->required
+    language => $zm_validator->language_tag->required
 );
 sub get_test_results {
     my ( $self, $params ) = @_;

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -17,7 +17,7 @@ extends 'Zonemaster::Engine::Translator';
 
 sub translate_tag {
     my ( $self, $entry, $browser_lang ) = @_;
-    my %locale = Zonemaster::Backend::Config->load_config()->Translation_Locale_hash();
+    my %locale = Zonemaster::Backend::Config->load_config()->Language_Locale_hash();
     my $previous_locale = $self->locale;
 
     if ( $locale{$browser_lang} ) {

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -17,11 +17,16 @@ extends 'Zonemaster::Engine::Translator';
 
 sub translate_tag {
     my ( $self, $entry, $browser_lang ) = @_;
-    my %locale = Zonemaster::Backend::Config->load_config()->LANG_hash();
+    my %locale = Zonemaster::Backend::Config->load_config()->Translation_Locale_hash();
     my $previous_locale = $self->locale;
 
     if ( $locale{$browser_lang} ) {
-        $self->locale( $locale{$browser_lang} );
+        if ( $locale{$browser_lang} eq 'NOT-UNIQUE') {
+            die "Language string not unique: '$browser_lang'\n";
+        }
+        else {
+            $self->locale( $locale{$browser_lang} );
+        }
     }
     else {
         die "Undefined language string: '$browser_lang'\n";

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -7,6 +7,7 @@ use 5.14.2;
 use Moose;
 use Encode;
 use POSIX qw[setlocale LC_MESSAGES LC_CTYPE];
+use Zonemaster::Backend::Config;
 
 # Zonemaster Modules
 require Zonemaster::Engine::Translator;
@@ -16,19 +17,14 @@ extends 'Zonemaster::Engine::Translator';
 
 sub translate_tag {
     my ( $self, $entry, $browser_lang ) = @_;
-
+    my %locale = Zonemaster::Backend::Config->load_config()->LANG_hash();
     my $previous_locale = $self->locale;
-    if ( $browser_lang eq 'fr' ) {
-        $self->locale( "fr_FR.UTF-8" );
-    }
-    elsif ( $browser_lang eq 'sv' ) {
-        $self->locale( "sv_SE.UTF-8" );
-    }
-    elsif ( $browser_lang eq 'da' ) {
-        $self->locale( "da_DK.UTF-8" );
+
+    if ( $locale{$browser_lang} ) {
+        $self->locale( $locale{$browser_lang} );
     }
     else {
-        $self->locale( "en_US.UTF-8" );
+        die "Undefined language string: '$browser_lang'\n";
     }
 
     # Make locale really be set. Fix that makes translation work on FreeBSD 12.1. Solution copied from

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -64,7 +64,7 @@ sub queue {
 sub test_id {
     return joi->string->regex('^[0-9]$|^[1-9][0-9]{1,8}$|^[0-9a-f]{16}$');
 }
-sub translation_language {
+sub language_tag {
     return joi->string->regex('^[a-z]{2}(_[A-Z]{2})?$');
 }
 sub username {

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -65,7 +65,7 @@ sub test_id {
     return joi->string->regex('^[0-9]$|^[1-9][0-9]{1,8}$|^[0-9a-f]{16}$');
 }
 sub translation_language {
-    return joi->string->regex('^[a-zA-Z0-9-_.@]{1,30}$');
+    return joi->string->regex('^[a-z]{2}(_[A-Z]{2})?$');
 }
 sub username {
     return joi->string->regex('^[a-zA-Z0-9-.@]{1,50}$');

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -42,11 +42,16 @@ my $router = router {
 	};
 
 	connect "profile_names" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
-        action => "profile_names"
-  };
-  
-  connect "get_host_by_name" => {
+                handler => "+Zonemaster::Backend::RPCAPI",
+                action => "profile_names"
+        };
+
+	connect "translation_language_strings" => {
+                handler => "+Zonemaster::Backend::RPCAPI",
+                action => "translation_language_strings"
+        };
+
+        connect "get_host_by_name" => {
 		handler => "+Zonemaster::Backend::RPCAPI",
 		action => "get_host_by_name"
 	};

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -46,9 +46,9 @@ my $router = router {
                 action => "profile_names"
         };
 
-	connect "get_language_strings" => {
+	connect "get_language_tags" => {
                 handler => "+Zonemaster::Backend::RPCAPI",
-                action => "get_language_strings"
+                action => "get_language_tags"
         };
 
         connect "get_host_by_name" => {

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -46,9 +46,9 @@ my $router = router {
                 action => "profile_names"
         };
 
-	connect "translation_language_strings" => {
+	connect "get_language_strings" => {
                 handler => "+Zonemaster::Backend::RPCAPI",
-                action => "translation_language_strings"
+                action => "get_language_strings"
         };
 
         connect "get_host_by_name" => {

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -1,3 +1,6 @@
+# For documentation of the backend_config.ini file see
+# https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md
+
 [DB]
 engine            = MySQL
 user              = zonemaster
@@ -23,7 +26,7 @@ number_of_processes_for_batch_testing    = 20
 #
 #maximal_number_of_retries=3
 
-[LANGUAGES]
+[LANGUAGE]
 lang = da_DK en_US fr_FR sv_SE
 
 [PUBLIC PROFILES]

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -23,6 +23,9 @@ number_of_processes_for_batch_testing    = 20
 #
 #maximal_number_of_retries=3
 
+[LANGUAGES]
+lang = da_DK en_US fr_FR sv_SE
+
 [PUBLIC PROFILES]
 #example_profile_1=/example/directory/test1_profile.json
 #default=/example/directory/default_profile.json

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -27,7 +27,7 @@ number_of_processes_for_batch_testing    = 20
 #maximal_number_of_retries=3
 
 [LANGUAGE]
-lang = da_DK en_US fr_FR sv_SE
+locale = da_DK en_US fr_FR sv_SE
 
 [PUBLIC PROFILES]
 #example_profile_1=/example/directory/test1_profile.json

--- a/share/travis_mysql_backend_config.ini
+++ b/share/travis_mysql_backend_config.ini
@@ -27,3 +27,7 @@ number_of_processes_for_batch_testing=20
 # upt to that value (the id value given here will be the highest posible value allowed as 
 # simple id, for everything above hash_id will be forced).
 force_hash_id_use_in_API_starting_from_id=1
+
+[LANGUAGE]
+lang = da_DK en_US fr_FR sv_SE
+

--- a/share/travis_mysql_backend_config.ini
+++ b/share/travis_mysql_backend_config.ini
@@ -29,5 +29,5 @@ number_of_processes_for_batch_testing=20
 force_hash_id_use_in_API_starting_from_id=1
 
 [LANGUAGE]
-lang = da_DK en_US fr_FR sv_SE
+locale = da_DK en_US fr_FR sv_SE
 

--- a/share/travis_postgresql_backend_config.ini
+++ b/share/travis_postgresql_backend_config.ini
@@ -29,5 +29,5 @@ number_of_professes_for_batch_testing=20
 force_hash_id_use_in_API_starting_from_id=1
 
 [LANGUAGE]
-lang = da_DK en_US fr_FR sv_SE
+locale = da_DK en_US fr_FR sv_SE
 

--- a/share/travis_postgresql_backend_config.ini
+++ b/share/travis_postgresql_backend_config.ini
@@ -27,3 +27,7 @@ number_of_professes_for_batch_testing=20
 # upt to that value (the id value given here will be the highest posible value allowed as 
 # simple id, for everything above hash_id will be forced).
 force_hash_id_use_in_API_starting_from_id=1
+
+[LANGUAGE]
+lang = da_DK en_US fr_FR sv_SE
+

--- a/share/travis_sqlite_backend_config.ini
+++ b/share/travis_sqlite_backend_config.ini
@@ -22,5 +22,5 @@ number_of_processes_for_batch_testing=20
 #seconds
 
 [LANGUAGE]
-lang = da_DK en_US fr_FR sv_SE
+locale = da_DK en_US fr_FR sv_SE
 

--- a/share/travis_sqlite_backend_config.ini
+++ b/share/travis_sqlite_backend_config.ini
@@ -21,3 +21,6 @@ number_of_processes_for_frontend_testing=20
 number_of_processes_for_batch_testing=20
 #seconds
 
+[LANGUAGE]
+lang = da_DK en_US fr_FR sv_SE
+

--- a/t/test01.t
+++ b/t/test01.t
@@ -82,7 +82,7 @@ sub run_zonemaster_test_with_backend_API {
 		last if ( $progress == 100 );
 	}
 	ok( $engine->test_progress( $test_id ) == 100 );
-	my $test_results = $engine->get_test_results( { id => $test_id, language => 'fr-FR' } );
+	my $test_results = $engine->get_test_results( { id => $test_id, language => 'fr_FR' } );
 	ok( defined $test_results->{id},                 'TEST1 $test_results->{id} defined' );
 	ok( defined $test_results->{params},             'TEST1 $test_results->{params} defined' );
 	ok( defined $test_results->{creation_time},      'TEST1 $test_results->{creation_time} defined' );

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -59,7 +59,7 @@ sub run_zonemaster_test_with_backend_API {
         last if ( $progress == 100 );
     }
     ok( $engine->test_progress( $api_test_id ) == 100 , 'API test_progress -> Test finished' );
-    my $test_results = $engine->get_test_results( { id => $api_test_id, language => 'fr-FR' } );
+    my $test_results = $engine->get_test_results( { id => $api_test_id, language => 'fr_FR' } );
     ok( defined $test_results->{id} , 'API get_test_results -> [id] paramater present' );
     ok( defined $test_results->{params} , 'API get_test_results -> [params] paramater present' );
     ok( defined $test_results->{creation_time} , 'API get_test_results -> [creation_time] paramater present' );


### PR DESCRIPTION
_This description has been updated 2020-06-29 as the PR has been updated._

The API documentation is unclear if "language" is mandatory in "get_test_results" but in the implementation it is mandatory. Here we follow the implementation and make it mandatory in the documentation.

In the API documentation and in the implementation defines some strings (or rather start of strings) to be specific languages and the remaining strings are interpreted as English. The drawbacks of this behavior are:

* When new languages are added, a string that earlier was interpreted as English, e.g. "no", will if Norwegian is added be interpreted as Norwegian.
* When testing, if the the language string is misspelled it could be interpreted as translation is not working. It is better to get a clear signal that the string was wrong.

The acceptable language codes and the mapping between language code and is done in the code. To add a new language you have to update the code. Also, it is not possible to exclude some of the available languages.

This PR moves the configuration of languages to the configuration file. Languages and the main part of the locale string are set there. New languages can be added without updating the code.

Summary of changes:
* Languages are configured, not hard-coded.
  * If configuration is missing, en_US will be configured by default.
* The API now only accepts specific strings, not just strings.
* Using undefined language code will result in error, not in no translation.
* A new API method reports supported language strings.

This update is a changed API against the GUI, but a default installation will not change anything for the GUI since it already uses strings matching the default configuration.

This PR replaces #595.
