### PR TITLE
Removed unused GEOLOCATION

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -28,10 +28,6 @@ PostgreSQL        | `PostgreSQL`
 SQLite            | `SQLite`
 
 
-## GEOLOCATION section
-
-TBD
-
 ## LANGUAGE section
 
 The LANGUAGE section has one key, `locale`.

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -36,9 +36,3 @@ locale = da_DK en_US fr_FR sv_SE
 [PRIVATE PROFILES]
 #example_profile_2=/example/directory/test2_profile.json
 
-[GEOLOCATION]
-# Requires the Geo::IP Perl module to be installed
-#maxmind_isp_db_file  =
-
-# Requires the GeoIP2::Database::Reader Perl module to be installed
-#maxmind_city_db_file =


### PR DESCRIPTION
There are still traces of previous feature GEOLOCATION in default .ini file and documentation. Since the feature is long gone, these traces will be removed with this update. This resolves issue #607.