### PR TITLE
Updated language specification handling

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -263,25 +263,37 @@ Default database timestamp format: "Y-M-D H:M:S.ms".
 Example: "2017-12-18 07:56:17.156939"
 
 
-### Translation language
+### Language tag
 
 Basic data type: string
 
-A string of alphanumeric, hyphens, underscores, full stops and at-signs (`@`),
-of at least 1 and at most 30 characters.
-I.e. a string matching `/^[a-zA-Z0-9-_.@]{1,30}$/`.
+A string of A-Z, a-z and underscores matching the regular expression
+`/^[a-z]{2}(_[A-Z]{2})?$/`.
 
-* Any string starting with `"fr"` is interpreted as French.
-* Any string starting with `"sv"` is interpreted as Swedish.
-* Any string starting with `"da"` is interpreted as Danish.
-* Any other string is interpreted as English.
+The `language tag` must match a `locale tag` in the configuration file.
+If the `language tag` is a two-character string, it only needs to match the
+first two characters of the `locale tag` from the configuration file, if
+that is unique (there is only one `locale tag` starting with the same two
+characters), else it is an error.
+
+Any other string is an error.
+
+The two first characters of the `language tag` are intended to be an
+[ISO 639-1] two-character language code and the optional two last characters
+are intended to be an [ISO 3166-1 alpha-2] two-character country code.
+
+A default installation will accept the following `language tags`:
+* `da` or `da_DK` for Danish language.
+* `en` or `en_US` for English language.
+* `fr` or `fr_FR` for French language.
+* `sv` or `sv_SE` for Swedish language.
 
 
 ### Unsigned integer
 
- Basic data type: number (integer)
+Basic data type: number (integer)
  
- An unsigned integer is either positive or zero.
+An unsigned integer is either positive or zero.
  
 
 ### Username
@@ -367,6 +379,52 @@ Example response:
 An array of *Profile names* in lower case. `"default"` is always included.
 
 
+## API method: `get_language_tags`
+
+Returns all valid [language tags][language tag] generated from the setting in
+the configuration file.
+
+Example request:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "get_language_tags"
+}
+```
+
+Example response:
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": [
+    "en",
+    "en_US",
+    "fr",
+    "fr_FR",
+    "sv",
+    "sv_SE"
+  ]
+}
+```
+
+
+#### `"result"`
+
+An array of *language tags*. It is never empty.
+
+
+#### `"error"`
+
+>
+> TODO: List all possible error codes and describe what they mean enough for
+> clients to know how react to them. Or prevent RPCAPI from starting with
+> errors in the configuration file and make it not to reread the configuration
+> file while running.
+>
+
+
 ## API method: `get_host_by_name`
 
 Looks up the A and AAAA records for a hostname (*domain name*) on the public Internet.
@@ -417,6 +475,7 @@ value `0.0.0.0` if the lookup returned no A or AAAA records.
 >
 > TODO: If the name resolves to two or more IPv4 address, how is that represented?
 >
+
 
 #### `"error"`
 
@@ -573,13 +632,15 @@ An object with the following properties:
 > TODO: Clarify the purpose of each `"params"` property.
 >
 
+
 #### `"result"`
 
 A *test id*. 
 
 If the test has been run with the same domain name within an interval of 10 mins (hard coded), 
 then the new request does not trigger a new test, but returns with the results of the last test
- 
+
+
 #### `"error"`
 
 * If the given `profile` is not among the [available profiles], a user
@@ -637,7 +698,8 @@ A *progress percentage*.
 
 ## API method: `get_test_results`
 
-Return all *test result* objects of a *test*, with *messages* in the requested *translation language*.
+Return all *test result* objects of a *test*, with *messages* in the requested language as selected by the
+*language tag*.
 
 Example request:
 ```json
@@ -651,6 +713,9 @@ Example request:
   }
 }
 ```
+
+The `id` parameter must match the `result` in the response to a `start_domain_test` call,
+and that test must have been completed.
 
 Example response:
 ```json
@@ -710,7 +775,7 @@ Example response:
 An object with the following properties:
 
 * `"id"`: A *test id*, required.
-* `"language"`: A *translation language*, required.
+* `"language"`: A *language tag*, required.
 
 
 #### `"result"`
@@ -738,7 +803,6 @@ In the case of a test created with `add_batch_job`:
 >
 > TODO: Change name in the API of `"hash_id"` to `"test_id"`
 >
-
 
 
 #### `"error"`
@@ -877,9 +941,11 @@ An object with the following properties:
 * `"username"`: An *username*, required. The name of the user to add.
 * `"api_key"`: An *api key*, required. The API key for the user to add.
 
+
 #### `"result"`
 
 An integer. The value is equal to 1 if the registration is a success, or 0 if it failed.
+
 
 #### `"error"`
 >
@@ -1088,6 +1154,7 @@ Example response:
 }
 ```
 
+
 #### `"params"`
 
 An object with the property:
@@ -1106,5 +1173,8 @@ The `"params"` object sent to `start_domain_test` or `add_batch_job` when the *t
 > TODO: List all possible error codes and describe what they mean enough for clients to know how react to them.
 >
 
-[Available profiles]: Configuration.md#profiles-section
-[Privilege levels]: #privilege-levels
+[Available profiles]:           Configuration.md#profiles-section
+[ISO 3166-1 alpha-2]:           https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+[ISO 639-1]:                    https://en.wikipedia.org/wiki/ISO_639-1
+[Privilege levels]:             #privilege-levels
+[Language tag]:                 #language-tag

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,6 +32,83 @@ SQLite            | `SQLite`
 
 TBD
 
+## LANGUAGE section
+
+The LANGUAGE section has one key, `locale`.
+
+The value of the `locale` key is a space separated list of
+`locale tags` where each tag must match the regular expression
+`/^[a-z]{2}_[A-Z]{2}$/`.
+
+If the `locale` key is empty or absent, the `locale tag` value
+"en_US" is set by default.
+
+The two first characters of a `locale tag` are intended to be an
+[ISO 639-1] two-character language code and the two last characters
+are intended to be an [ISO 3166-1 alpha-2] two-character country code.
+A `locale tag` is a locale setting for the available translation
+of messages without ".UTF-8", which is implied.
+
+If a new `locale tag` is added to the configuration then the equivalent
+MO file should be added to Zonemaster-Engine at the correct place so
+that gettext can retrieve it, or else the added `locale tag` will not
+add any actual language support. See the
+[Zonemaster-Engine share directory] for the existing PO files that are
+converted to MO files. (Here we should have a link
+to documentation instead.)
+
+Removing a language from the configuration file just blocks that
+language from being allowed. If there are more than one `locale tag`
+(with different country codes) for the same language, then
+all those must be removed to block that language.
+
+English is the Zonemaster default language, but it can be blocked
+from being allowed by RPC-API by not including it in the
+configuration.
+
+In the RPCAPI, `language tag` is used ([Language tag]). The
+`language tags` are generated from the `locale tags`. Each
+`locale tag` will generate two `language tags`, a short tag
+equal to the first two letters (usually the same as a language
+code) and a long tag which is equal to the full `locale tag`.
+If "en_US" is the `locale tag` then "en" and "en_US" are the
+`language tags`.
+
+If there are two `locale tags` that would give the same short
+`language tag` then that is excluded. E.g. "en_US en_UK" will
+only give "en_US" and "en_UK" as `language tags`.
+
+The default installation and configuration supports the
+following languages.
+
+Language | Locale tag value   | Locale value used
+---------|--------------------|------------------
+Danish   | da_DK              | da_DK.UTF-8
+English  | en_US              | en_US.UTF-8
+French   | fr_FR              | fr_FR.UTF-8
+Swedish  | sv_SE              | sv_SE.UTF-8
+
+The following `language tags` are generated:
+* da
+* da_DK
+* en
+* en_US
+* fr
+* fr_FR
+* sv
+* sv_SE
+
+It is an error to repeat the same `locale tag`.
+
+Setting in the default configuration file:
+
+```
+locale = da_DK en_US fr_FR sv_SE
+```
+
+Each locale set in the configuration file, including the implied
+".UTF-8", must also be installed or activate on the system
+running the RPCAPI daemon for the translation to work correctly.
 
 ## LOG section
 
@@ -74,11 +151,14 @@ TBD
 
 --------
 
-[Zonemaster::Engine::Profile]: https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES
-[Default JSON profile file]: https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
-[Profile JSON files]: https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
-[Profile names]: API.md#profile-name
-[Profiles]: Architecture.md#profile
-
+[Default JSON profile file]:          https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
+[ISO 3166-1 alpha-2]:                 https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
+[ISO 639-1]:                          https://en.wikipedia.org/wiki/ISO_639-1
+[Profile JSON files]:                 https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
+[Profile names]:                      API.md#profile-name
+[Profiles]:                           Architecture.md#profile
+[Zonemaster-Engine share directory]:  https://github.com/zonemaster/zonemaster-engine/tree/master/share
+[Zonemaster::Engine::Profile]:        https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES
+[Language tag]:                       API.md#language-tag
 
 

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -7,6 +7,7 @@ use 5.14.2;
 use Moose;
 use Encode;
 use POSIX qw[setlocale LC_MESSAGES LC_CTYPE];
+use Zonemaster::Backend::Config;
 
 # Zonemaster Modules
 require Zonemaster::Engine::Translator;
@@ -16,19 +17,19 @@ extends 'Zonemaster::Engine::Translator';
 
 sub translate_tag {
     my ( $self, $entry, $browser_lang ) = @_;
-
+    my %locale = Zonemaster::Backend::Config->load_config()->Language_Locale_hash();
     my $previous_locale = $self->locale;
-    if ( $browser_lang eq 'fr' ) {
-        $self->locale( "fr_FR.UTF-8" );
-    }
-    elsif ( $browser_lang eq 'sv' ) {
-        $self->locale( "sv_SE.UTF-8" );
-    }
-    elsif ( $browser_lang eq 'da' ) {
-        $self->locale( "da_DK.UTF-8" );
+
+    if ( $locale{$browser_lang} ) {
+        if ( $locale{$browser_lang} eq 'NOT-UNIQUE') {
+            die "Language string not unique: '$browser_lang'\n";
+        }
+        else {
+            $self->locale( $locale{$browser_lang} );
+        }
     }
     else {
-        $self->locale( "en_US.UTF-8" );
+        die "Undefined language string: '$browser_lang'\n";
     }
 
     # Make locale really be set. Fix that makes translation work on FreeBSD 12.1. Solution copied from

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -64,8 +64,8 @@ sub queue {
 sub test_id {
     return joi->string->regex('^[0-9]$|^[1-9][0-9]{1,8}$|^[0-9a-f]{16}$');
 }
-sub translation_language {
-    return joi->string->regex('^[a-zA-Z0-9-_.@]{1,30}$');
+sub language_tag {
+    return joi->string->regex('^[a-z]{2}(_[A-Z]{2})?$');
 }
 sub username {
     return joi->string->regex('^[a-zA-Z0-9-.@]{1,50}$');

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -42,11 +42,16 @@ my $router = router {
 	};
 
 	connect "profile_names" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
-        action => "profile_names"
-  };
-  
-  connect "get_host_by_name" => {
+                handler => "+Zonemaster::Backend::RPCAPI",
+                action => "profile_names"
+        };
+
+	connect "get_language_tags" => {
+                handler => "+Zonemaster::Backend::RPCAPI",
+                action => "get_language_tags"
+        };
+
+        connect "get_host_by_name" => {
 		handler => "+Zonemaster::Backend::RPCAPI",
 		action => "get_host_by_name"
 	};

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -1,3 +1,6 @@
+# For documentation of the backend_config.ini file see
+# https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md
+
 [DB]
 engine            = MySQL
 user              = zonemaster
@@ -22,6 +25,9 @@ number_of_processes_for_batch_testing    = 20
 # Do not use it (keep the default value "0"), or use it with care.
 #
 #maximal_number_of_retries=3
+
+[LANGUAGE]
+locale = da_DK en_US fr_FR sv_SE
 
 [PUBLIC PROFILES]
 #example_profile_1=/example/directory/test1_profile.json

--- a/share/travis_mysql_backend_config.ini
+++ b/share/travis_mysql_backend_config.ini
@@ -27,3 +27,7 @@ number_of_processes_for_batch_testing=20
 # upt to that value (the id value given here will be the highest posible value allowed as 
 # simple id, for everything above hash_id will be forced).
 force_hash_id_use_in_API_starting_from_id=1
+
+[LANGUAGE]
+locale = da_DK en_US fr_FR sv_SE
+

--- a/share/travis_postgresql_backend_config.ini
+++ b/share/travis_postgresql_backend_config.ini
@@ -27,3 +27,7 @@ number_of_professes_for_batch_testing=20
 # upt to that value (the id value given here will be the highest posible value allowed as 
 # simple id, for everything above hash_id will be forced).
 force_hash_id_use_in_API_starting_from_id=1
+
+[LANGUAGE]
+locale = da_DK en_US fr_FR sv_SE
+

--- a/share/travis_sqlite_backend_config.ini
+++ b/share/travis_sqlite_backend_config.ini
@@ -21,3 +21,6 @@ number_of_processes_for_frontend_testing=20
 number_of_processes_for_batch_testing=20
 #seconds
 
+[LANGUAGE]
+locale = da_DK en_US fr_FR sv_SE
+

--- a/t/test01.t
+++ b/t/test01.t
@@ -3,6 +3,7 @@ use warnings;
 use 5.14.2;
 
 use Test::More;    # see done_testing()
+use Test::Exception;
 use Zonemaster::Engine;
 use JSON::PP;
 
@@ -82,13 +83,19 @@ sub run_zonemaster_test_with_backend_API {
 		last if ( $progress == 100 );
 	}
 	ok( $engine->test_progress( $test_id ) == 100 );
-	my $test_results = $engine->get_test_results( { id => $test_id, language => 'fr-FR' } );
+
+        my $test_results = $engine->get_test_results( { id => $test_id, language => 'fr_FR' } );
 	ok( defined $test_results->{id},                 'TEST1 $test_results->{id} defined' );
 	ok( defined $test_results->{params},             'TEST1 $test_results->{params} defined' );
 	ok( defined $test_results->{creation_time},      'TEST1 $test_results->{creation_time} defined' );
 	ok( defined $test_results->{results},            'TEST1 $test_results->{results} defined' );
 	ok( scalar( @{ $test_results->{results} } ) > 1, 'TEST1 got some results' );
 
+        dies_ok { $engine->get_test_results( { id => $test_id, language => 'fr-FR' } ); }
+        'API get_test_results -> [results] parameter not present (wrong language tag)'; # Should be underscore, not hyphen.
+
+        dies_ok { $engine->get_test_results( { id => $test_id, language => 'zz' } ); }
+        'API get_test_results -> [results] parameter not present (wrong language tag)'; # "zz" is not our configuration file.
 }
 
 run_zonemaster_test_with_backend_API(1);

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -4,6 +4,7 @@ use 5.14.2;
 
 use Test::More;    # see done_testing()
 use JSON::PP;
+use Test::Exception;
 
 my $db_backend = $ARGV[0];
 ok( $db_backend eq 'PostgreSQL' || $db_backend eq 'MySQL' , "Testing a supported database backend: $db_backend" );
@@ -59,12 +60,20 @@ sub run_zonemaster_test_with_backend_API {
         last if ( $progress == 100 );
     }
     ok( $engine->test_progress( $api_test_id ) == 100 , 'API test_progress -> Test finished' );
-    my $test_results = $engine->get_test_results( { id => $api_test_id, language => 'fr-FR' } );
+
+    my $test_results = $engine->get_test_results( { id => $api_test_id, language => 'fr_FR' } );
     ok( defined $test_results->{id} , 'API get_test_results -> [id] paramater present' );
     ok( defined $test_results->{params} , 'API get_test_results -> [params] paramater present' );
     ok( defined $test_results->{creation_time} , 'API get_test_results -> [creation_time] paramater present' );
     ok( defined $test_results->{results} , 'API get_test_results -> [results] paramater present' );
     ok( scalar( @{ $test_results->{results} } ) > 1 , 'API get_test_results -> [results] paramater contains data' );
+
+    dies_ok { $engine->get_test_results( { id => $api_test_id, language => 'fr-FR' } ); }
+    'API get_test_results -> [results] parameter not present (wrong language tag)';
+
+    dies_ok { $engine->get_test_results( { id => $api_test_id, language => 'zz' } ); }
+    'API get_test_results -> [results] parameter not present (wrong language tag)';
+
 }
 
 # add test user
@@ -99,3 +108,4 @@ ok( $test_history->[0]->{id} eq '1' || $test_history->[1]->{id} eq '1' );
 ok( length($test_history->[0]->{id}) == 16 || length($test_history->[1]->{id}) == 16 );
 
 done_testing();
+


### PR DESCRIPTION
This PR tries to handle the following issues in Zonemaster-Backend when it comes to selecting language for translation.

1. The API documentation is unclear if field `language` is mandatory in RPCAPI method `get_test_results` but in the implementation it is mandatory.
2. The string that can be used in the `language` field above can be quite long and can contain a broad range of characters, but in practice only the two first characters are considered. The rest is ignored.
3. If the two first characters do not match a supported language, then the error is just silently ignored, and the messages are shown untranslated (from English).
   * The GUI actually just uses a string of two characters, "da", "en", "fr" or "sv".
4. To add support for a new language or to remove support for a some language the code must be updated.

The goals of this PR are:

1. Update the API documentation so that field `language` is mandatory for method `get_test_results`.
2. Restrict the legal strings for `language` to a meaningful set without breaking the current GUI.
3. Move the configuration of supported languages from code to the configuration file to make it possible to add and remove languages without changing the code. It will be possible to add incoming Norwegian without hardcoding it in the code.

The changes of this PR can be found in the diffs, but here is a summary of the changes:

* API.md (defines the RPCAPI)
  * Clarified that the `language` field is mandatory for method `get_test_results`.
  * Defines the value of that field to be a "language tag".
  * Defines the format of a valid "language tag" (compatible with the GUI today).
  * Defines the relation to "locale tag" in the configuration.
* Configuration.md (defines the format of backend_config.ini)
  * Defines a new section, "LANGUAGE", and a new key "locale".
  * Defines a string, "locale tag", which defines a supported language with country code.
  * Specifies that the new key "locale" should a list of "locale tags".
* Code update
  * Adds methods to read the new section and key (LANGUAGE.locale) from the configuration file.
  * From the "locale tags" generate valid "language tags".
  * Use the list of "language tags" to validate the value in `language` in `get_test_results` API calls.
  * Connect selected "language tag" with correct locale setting for Zonemaster-Engine.
  * Return error for invalid "language tag".
  * Add new RCPAPI method to get the list of valid "language tags". This could both be used by GUI to discover supported languages and for verifying that configuration was as intended.
  * Defined "en_US" to be set as "locale tag" (and "en" and "en_US" as "language tags") if the new section and key is not present or empty in the configuration file.
* Updates of test cases (unit tests)
  * Corrected language tag in current tests.
  * Adds tests of non-legal language tags.
    
This update is a changed API against the GUI, but a default installation will not change anything for the GUI since it already uses strings matching the default configuration.

This PR replaces #621.
