### PR TITLE
Language option for zmtest

### DIFF
--- a/share/zmb
+++ b/share/zmb
@@ -114,12 +114,12 @@ sub cmd_version_info {
  Options:
 
     --domain DOMAIN_NAME
-    --nameserver DOMAIN_NAME:IP_ADDRESS
-    --client-id CLIENT_ID
-    --client-version CLIENT_VERSION
-    --ds-info DS_INFO
     --ipv4 true|false|null
     --ipv6 true|false|null
+    --nameserver DOMAIN_NAME:IP_ADDRESS
+    --ds-info DS_INFO
+    --client-id CLIENT_ID
+    --client-version CLIENT_VERSION
 
  DS_INFO is a comma separated list of key-value pairs. The expected pairs are:
 

--- a/share/zmtest
+++ b/share/zmtest
@@ -16,6 +16,7 @@ usage () {
     echo "  --noipv4              Run the test without ipv4." >&2
     echo "  --noipv6              Run the test without ipv6." >&2
     echo "  --lang LANG           A language tag. Default is en." >&2
+    echo "                        Valid values are determined by backend_config.ini." >&2
     exit "${status}"
 }
 

--- a/share/zmtest
+++ b/share/zmtest
@@ -55,6 +55,10 @@ done
 output="$(zmb "${server_url}" start_domain_test --domain "${domain}" --ipv4 "${ipv4}" --ipv6 "${ipv6}")" || exit $?
 testid="$(echo "${output}" | "${JQ}" -r .result)" || exit $?
 
+if echo "${testid}" | grep -qE '[^0-9a-fA-F]' ; then
+    error 1 "start_domain_test did not return a testid: ${testid}"
+fi
+
 # Wait for test to finish
 while true
 do

--- a/share/zmtest
+++ b/share/zmtest
@@ -15,6 +15,7 @@ usage () {
     echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
     echo "  --noipv4              Run the test without ipv4." >&2
     echo "  --noipv6              Run the test without ipv6." >&2
+    echo "  --lang LANG           A language tag. Default is en." >&2
     exit "${status}"
 }
 
@@ -44,6 +45,7 @@ while [ $# -gt 0 ] ; do
         -s|--server) server_url="$2"; shift 2;;
         --noipv4) ipv4="false"; shift 1;;
         --noipv6) ipv6="false"; shift 1;;
+        --lang) lang="$1"; shift 1;;
         *) domain="$1" ; shift 1;;
     esac
 done
@@ -67,5 +69,5 @@ do
 done
 
 # Get test results
-zmb "${server_url}" get_test_results --testid "${testid}" --lang en
+zmb "${server_url}" get_test_results --testid "${testid}" --lang "${lang}"
 echo "testid: ${testid}" >&2

--- a/share/zmtest
+++ b/share/zmtest
@@ -15,7 +15,7 @@ usage () {
     echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
     echo "  --noipv4              Run the test without ipv4." >&2
     echo "  --noipv6              Run the test without ipv6." >&2
-    echo "  --lang LANG           A language tag. Default is en." >&2
+    echo "  --lang LANG           A language tag. Default is \"en\"." >&2
     echo "                        Valid values are determined by backend_config.ini." >&2
     exit "${status}"
 }

--- a/share/zmtest
+++ b/share/zmtest
@@ -12,7 +12,7 @@ usage () {
     echo "Usage: zmtest [OPTIONS] DOMAIN" >&2
     echo >&2
     echo "Options:" >&2
-    echo "  -s URL --server=URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
+    echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
     echo "  --noipv4              Run the test without ipv4." >&2
     echo "  --noipv6              Run the test without ipv6." >&2
     exit "${status}"


### PR DESCRIPTION
Adds `zmtest --lang LANG` option.

This also includes some small fixes remotely related documentation.

Implements part of #628.