### PR TITLE
Fix failing test

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -17,8 +17,9 @@ use JSON::Validator "joi";
 
 # Zonemaster Modules
 use Zonemaster::Engine;
-use Zonemaster::Engine::Nameserver;
 use Zonemaster::Engine::DNSName;
+use Zonemaster::Engine::Logger::Entry;
+use Zonemaster::Engine::Nameserver;
 use Zonemaster::Engine::Recursor;
 use Zonemaster::Backend;
 use Zonemaster::Backend::Config;
@@ -189,8 +190,10 @@ sub _check_domain {
             );
     }
 
+    my %levels = Zonemaster::Engine::Logger::Entry::levels();
     my @res;
     @res = Zonemaster::Engine::Test::Basic->basic00($dn);
+    @res = grep { $_->numeric_level >= $levels{ERROR} } @res;
     if (@res != 0) {
         return ( $dn, { status => 'nok', message => encode_entities( "$type name or label outside allowed length" ) } );
     }

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -6,8 +6,8 @@ use Test::More;    # see done_testing()
 use JSON::PP;
 use Test::Exception;
 
-my $db_backend = $ARGV[0];
-ok( $db_backend eq 'PostgreSQL' || $db_backend eq 'MySQL' , "Testing a supported database backend: $db_backend" );
+my $db_backend = $ARGV[0] // BAIL_OUT( "No database backend specified" );
+( $db_backend eq 'PostgreSQL' || $db_backend eq 'MySQL' ) or BAIL_OUT( "Unsupported database backend: $db_backend" );
 
 my $frontend_params_1 = {
 	client_id      => "$db_backend Unit Test",         # free string


### PR DESCRIPTION
Travis was broken by zonemaster/zonemaster-engine#764. This fixes it again.

While this change works AFAICT, it doesn't seem like the best idea to use basic00 to check name and label length.