### PR TITLE
Install dependencies from EPEL instead of CPAN

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,7 +24,6 @@ requires
   'Net::IP::XS'                 => 0.14,
   'Parallel::ForkManager'       => 1.12,
   'Plack::Builder'              => 0,
-  'Plack::Middleware::Debug'    => 0.14,
   'Role::Tiny'                  => 1.001003,
   'Router::Simple::Declare'     => 0,
   'Starman'                     => 0,

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -62,13 +62,13 @@ for Zonemaster::Backend, see the [declaration of prerequisites].
 Install dependencies available from binary packages:
 
 ```sh
-sudo yum install perl-Module-Install perl-IO-CaptureOutput perl-String-ShellQuote perl-Net-Server redhat-lsb-core
+sudo yum install perl-Config-IniFiles perl-JSON-RPC perl-Module-Install perl-IO-CaptureOutput perl-Parallel-ForkManager perl-Plack perl-Router-Simple perl-String-ShellQuote perl-Net-Server redhat-lsb-core
 ```
 
 Install dependencies not available from binary packages:
 
 ```sh
-sudo cpanm Class::Method::Modifiers Config::IniFiles Daemon::Control JSON::RPC::Dispatch Net::IP::XS Parallel::ForkManager Plack::Builder Plack::Middleware::Debug Role::Tiny Router::Simple::Declare Starman
+sudo cpanm Class::Method::Modifiers Daemon::Control Net::IP::XS Plack::Middleware::Debug Role::Tiny Starman
 ```
 
 Install Zonemaster::Backend:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -62,13 +62,13 @@ for Zonemaster::Backend, see the [declaration of prerequisites].
 Install dependencies available from binary packages:
 
 ```sh
-sudo yum install perl-Config-IniFiles perl-JSON-RPC perl-Module-Install perl-IO-CaptureOutput perl-Parallel-ForkManager perl-Plack perl-Router-Simple perl-String-ShellQuote perl-Net-Server redhat-lsb-core
+sudo yum install perl-Class-Method-Modifiers perl-Config-IniFiles perl-JSON-RPC perl-Module-Install perl-IO-CaptureOutput perl-Parallel-ForkManager perl-Plack perl-Router-Simple perl-String-ShellQuote perl-Net-Server perl-Role-Tiny redhat-lsb-core
 ```
 
 Install dependencies not available from binary packages:
 
 ```sh
-sudo cpanm Class::Method::Modifiers Daemon::Control Net::IP::XS Plack::Middleware::Debug Role::Tiny Starman
+sudo cpanm Daemon::Control Net::IP::XS Plack::Middleware::Debug Starman
 ```
 
 Install Zonemaster::Backend:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -68,7 +68,7 @@ sudo yum install perl-Class-Method-Modifiers perl-Config-IniFiles perl-JSON-RPC 
 Install dependencies not available from binary packages:
 
 ```sh
-sudo cpanm Daemon::Control Net::IP::XS Plack::Middleware::Debug Starman
+sudo cpanm Daemon::Control Net::IP::XS Starman
 ```
 
 Install Zonemaster::Backend:
@@ -487,7 +487,7 @@ su -l
 Install dependencies available from binary packages:
 
 ```sh
-pkg install p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-IO-CaptureOutput p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Plack-Middleware-Debug p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote net-mgmt/p5-Net-IP-XS databases/p5-DBD-SQLite devel/p5-Log-Dispatch devel/p5-Log-Any devel/p5-Log-Any-Adapter-Dispatch
+pkg install p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-IO-CaptureOutput p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote net-mgmt/p5-Net-IP-XS databases/p5-DBD-SQLite devel/p5-Log-Dispatch devel/p5-Log-Any devel/p5-Log-Any-Adapter-Dispatch
 ```
 
 Optionally install Curl (only needed for the post-installation smoke test):


### PR DESCRIPTION
This a step towards resolving #449. It also speeds up installation on CentOS.
The Zonemaster-Engine installation instruction already adds the EPEL repo. This merely takes advantage of that.
Consideration has been taken to the fact that EPEL has somewhat different sets of packages for CentOS 7 and CentOS 8.

Edit: A couple of the packages aren't available through EPEL on CentOS 8, but they are available through the PowerTools repository, which we're also already prescribing in Zonemaster-Engine.