### PR TITLE
Deploy without debug middleware

### DIFF
--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -23,7 +23,6 @@ use Zonemaster::Backend::Config;
 local $| = 1;
 
 builder {
-    enable 'Debug';
     enable sub {
         my $app = shift;
 


### PR DESCRIPTION
In #638 I included a commit removing Plack::Middleware::Debug from the installation instruction in the belief that it wasn't used. It turns out that it is in fact being used. At least in a technical sense, though I'm not sure if it actually did anything.

In any case it doesn't seem to me like something we would want to enable in production installations. This PR goes ahead an really removes the use of Plack::Middleware::Debug.

I set the priority to high because at the moment the develop branch installation instruction doesn't install Plack::Middleware::Debug but when you start the RPCAPI the module is loaded. And we don't want to have it like that in the release.