### PR TITLE
Remove direct dependency on Net::IP::XS

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,6 @@ requires
   'Log::Any::Adapter::Dispatch' => 0,
   'Log::Dispatch'               => 0,
   'Moose'                       => 2.04,
-  'Net::IP::XS'                 => 0.14,
   'Parallel::ForkManager'       => 1.12,
   'Plack::Builder'              => 0,
   'Role::Tiny'                  => 1.001003,

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -68,7 +68,7 @@ sudo yum install perl-Class-Method-Modifiers perl-Config-IniFiles perl-JSON-RPC 
 Install dependencies not available from binary packages:
 
 ```sh
-sudo cpanm Daemon::Control Net::IP::XS Starman
+sudo cpanm Daemon::Control Starman
 ```
 
 Install Zonemaster::Backend:
@@ -333,7 +333,7 @@ sudo apt install libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-s
 Install dependencies not available from binary packages:
 
 ```sh
-sudo cpanm Daemon::Control JSON::Validator Net::IP::XS
+sudo cpanm Daemon::Control JSON::Validator
 ```
 
 Install Zonemaster::Backend:
@@ -487,7 +487,7 @@ su -l
 Install dependencies available from binary packages:
 
 ```sh
-pkg install p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-IO-CaptureOutput p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote net-mgmt/p5-Net-IP-XS databases/p5-DBD-SQLite devel/p5-Log-Dispatch devel/p5-Log-Any devel/p5-Log-Any-Adapter-Dispatch
+pkg install p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-IO-CaptureOutput p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote databases/p5-DBD-SQLite devel/p5-Log-Dispatch devel/p5-Log-Any devel/p5-Log-Any-Adapter-Dispatch
 ```
 
 Optionally install Curl (only needed for the post-installation smoke test):

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -10,16 +10,16 @@ use DBI qw(:utils);
 use Digest::MD5 qw(md5_hex);
 use String::ShellQuote;
 use File::Slurp qw(append_file);
-use Zonemaster::LDNS;
-use Net::IP::XS qw(:PROC);
 use HTML::Entities;
 use JSON::Validator::Joi;
 
 # Zonemaster Modules
+use Zonemaster::LDNS;
 use Zonemaster::Engine;
 use Zonemaster::Engine::DNSName;
 use Zonemaster::Engine::Logger::Entry;
 use Zonemaster::Engine::Nameserver;
+use Zonemaster::Engine::Net::IP;
 use Zonemaster::Engine::Recursor;
 use Zonemaster::Backend;
 use Zonemaster::Backend::Config;
@@ -271,7 +271,9 @@ sub validate_syntax {
                 unless( !$ns_ip->{ip} || $ns_ip->{ip} =~ /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/ || $ns_ip->{ip} =~ /^([0-9A-Fa-f]{1,4}:[0-9A-Fa-f:]{1,}(:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?)|([0-9A-Fa-f]{1,4}::[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$/);
 
             return { status => 'nok', message => encode_entities( "Invalid IP address: [$ns_ip->{ip}]" ) }
-              unless ( !$ns_ip->{ip} || ip_is_ipv4( $ns_ip->{ip} ) || ip_is_ipv6( $ns_ip->{ip} ) );
+              unless ( !$ns_ip->{ip}
+                || Zonemaster::Engine::Net::IP::ip_is_ipv4( $ns_ip->{ip} )
+                || Zonemaster::Engine::Net::IP::ip_is_ipv6( $ns_ip->{ip} ) );
         }
 
         foreach my $ds_digest ( @{ $syntax_input->{ds_info} } ) {


### PR DESCRIPTION
Net::IP::XS will still be used (via Zonemaster::Engine::Net::IP) if it's installed.

Works towards solving #449 and completely fixes #193.