### PR TITLE
Activate Norwegian in Backend

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -286,6 +286,7 @@ A default installation will accept the following `language tags`:
 * `da` or `da_DK` for Danish language.
 * `en` or `en_US` for English language.
 * `fr` or `fr_FR` for French language.
+* `nb` or `nb_NO` for Norwegian language.
 * `sv` or `sv_SE` for Swedish language.
 
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -82,6 +82,7 @@ Language | Locale tag value   | Locale value used
 Danish   | da_DK              | da_DK.UTF-8
 English  | en_US              | en_US.UTF-8
 French   | fr_FR              | fr_FR.UTF-8
+Norwegian| nb_NO              | nb_NO.UTF-8
 Swedish  | sv_SE              | sv_SE.UTF-8
 
 The following `language tags` are generated:
@@ -91,6 +92,8 @@ The following `language tags` are generated:
 * en_US
 * fr
 * fr_FR
+* nb
+* nb_NO
 * sv
 * sv_SE
 
@@ -99,7 +102,7 @@ It is an error to repeat the same `locale tag`.
 Setting in the default configuration file:
 
 ```
-locale = da_DK en_US fr_FR sv_SE
+locale = da_DK en_US fr_FR nb_NO sv_SE
 ```
 
 Each locale set in the configuration file, including the implied

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -317,10 +317,11 @@ sudo apt install curl
 Install required locales:
 
 ```sh
-locale -a | grep en_US.utf8 || echo en_US.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
-locale -a | grep sv_SE.utf8 || echo sv_SE.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
-locale -a | grep fr_FR.utf8 || echo fr_FR.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
 locale -a | grep da_DK.utf8 || echo da_DK.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
+locale -a | grep en_US.utf8 || echo en_US.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
+locale -a | grep fr_FR.utf8 || echo fr_FR.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
+locale -a | grep nb_NO.utf8 || echo nb_NO.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
+locale -a | grep sv_SE.utf8 || echo sv_SE.UTF-8 UTF-8 | sudo tee -a /etc/locale.gen
 sudo locale-gen
 ```
 

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -27,7 +27,7 @@ number_of_processes_for_batch_testing    = 20
 #maximal_number_of_retries=3
 
 [LANGUAGE]
-locale = da_DK en_US fr_FR sv_SE
+locale = da_DK en_US fr_FR nb_NO sv_SE
 
 [PUBLIC PROFILES]
 #example_profile_1=/example/directory/test1_profile.json

--- a/share/travis_mysql_backend_config.ini
+++ b/share/travis_mysql_backend_config.ini
@@ -29,5 +29,5 @@ number_of_processes_for_batch_testing=20
 force_hash_id_use_in_API_starting_from_id=1
 
 [LANGUAGE]
-locale = da_DK en_US fr_FR sv_SE
+locale = da_DK en_US fr_FR nb_NO sv_SE
 

--- a/share/travis_postgresql_backend_config.ini
+++ b/share/travis_postgresql_backend_config.ini
@@ -29,5 +29,5 @@ number_of_professes_for_batch_testing=20
 force_hash_id_use_in_API_starting_from_id=1
 
 [LANGUAGE]
-locale = da_DK en_US fr_FR sv_SE
+locale = da_DK en_US fr_FR nb_NO sv_SE
 

--- a/share/travis_sqlite_backend_config.ini
+++ b/share/travis_sqlite_backend_config.ini
@@ -22,5 +22,5 @@ number_of_processes_for_batch_testing=20
 #seconds
 
 [LANGUAGE]
-locale = da_DK en_US fr_FR sv_SE
+locale = da_DK en_US fr_FR nb_NO sv_SE
 


### PR DESCRIPTION
The language strings for Norwegian, nb_NO and nb, are added to documentation and configuration to activate the support of that language as will be added to Engine by next release.