### PR TITLE
Fix warning in RPCAPI

### DIFF
--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -49,9 +49,7 @@ sub translate_tag {
     my $octets = Zonemaster::Engine::Translator::translate_tag( $self, $entry );
     $self->locale( $previous_locale );
 
-    return ( defined $octets )
-      ? decode_utf8( $octets )
-      : $entry->string;
+    return decode_utf8( $octets );
 }
 
 1;

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -16,7 +16,7 @@ require Zonemaster::Engine::Logger::Entry;
 extends 'Zonemaster::Engine::Translator';
 
 sub translate_tag {
-    my ( $self, $entry, $browser_lang ) = @_;
+    my ( $self, $hashref, $browser_lang ) = @_;
     my %locale = Zonemaster::Backend::Config->load_config()->Language_Locale_hash();
     my $previous_locale = $self->locale;
 
@@ -45,17 +45,13 @@ sub translate_tag {
         $ENV{LC_ALL} || $ENV{LC_CTYPE};
     }
 
-    my $string = $self->data->{ $entry->{module} }{ $entry->{tag} };
-
-    if ( not $string ) {
-        return $entry->{string};
-    }
-
-    my $blessed_entry = bless($entry, 'Zonemaster::Engine::Logger::Entry');
-    my $octets = Zonemaster::Engine::Translator::translate_tag( $self, $blessed_entry );
+    my $entry = Zonemaster::Engine::Logger::Entry->new( %{ $hashref } );
+    my $octets = Zonemaster::Engine::Translator::translate_tag( $self, $entry );
     $self->locale( $previous_locale );
-    my $str = decode_utf8( $octets );
-    return $str;
+
+    return ( defined $octets )
+      ? decode_utf8( $octets )
+      : $entry->string;
 }
 
 1;


### PR DESCRIPTION
I think I've got this figured out now.

* `$entry->{string}` never seems to exist, but  `Zonemaster::Engine::Logger::Entry::string` does exist, and it actually makes sense to call that on proper `Z::E::L::Entry` objects.
* Calling bless to get an `Z::E::L::Entry` object doesn't work because the object doesn't get properly initialized we end up crashing. Instead we should just be good citizens and call `Z::E::L::Entry::new`.
* The check of `Z::E::Translator::data` is kind of useless. The `Z::E::T::translate_tag` performs essentially the same check and returns $entry->string if the check fails. It's better to just use the `Z::E::T::translate_tag` return value.
* The early return was unfortunate because that code path failed to reset the locale, so I fixed that as well.

Fixes #631.