### PR TITLE
Attach adapter to Log::Any in RPCAPI

### DIFF
--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -6,14 +6,17 @@ our $VERSION = '1.1.0';
 
 use 5.14.2;
 
-use JSON::RPC::Dispatch;
-use Router::Simple::Declare;
+use English qw( $PID );
 use JSON::PP;
+use JSON::RPC::Dispatch;
+use Log::Any qw( $log );
+use Log::Any::Adapter;
+use Log::Dispatch;
 use POSIX;
-use Try::Tiny;
-
 use Plack::Builder;
 use Plack::Response;
+use Router::Simple::Declare;
+use Try::Tiny;
 
 BEGIN { $ENV{PERL_JSON_BACKEND} = 'JSON::PP' };
 
@@ -102,6 +105,23 @@ my $router = router {
 		action => "get_batch_job_result"
 	};
 };
+
+Log::Any::Adapter->set(
+    'Dispatch',
+    dispatcher => Log::Dispatch->new(
+        outputs => [
+            [
+                'Screen',
+                min_level => 'warning',
+                stderr    => 1,
+                callbacks => sub {
+                    my %args = @_;
+                    $args{message} = sprintf "%s [%d] %s - %s\n", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
+                },
+            ],
+        ]
+    ),
+);
 
 my $dispatch = JSON::RPC::Dispatch->new(
 	router => $router,


### PR DESCRIPTION
This fixes #640 in a minimalist way. We do get logging but the severity threshold is hard-coded to "warning".

For the moment we want to avoid setting it any lower because the config module keeps repeating that it reloaded the config file. This happens a lot!

Once we have the config reloading under control we also want the ability to configure the logging severity threshold, but that's for another time.

All the new dependencies added here are already being used in the test agent.