### PR TITLE
Clean up Zonemaster::Backend::Translator::translate_tag

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -388,8 +388,6 @@ sub get_test_results {
     my $translator;
     $translator = Zonemaster::Backend::Translator->new;
 
-    eval { $translator->data } if $translator;    # Provoke lazy loading of translation data
-
     my $test_info = $self->{db}->test_results( $params->{id} );
     my @zm_results;
     foreach my $test_res ( @{ $test_info->{results} } ) {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -398,6 +398,9 @@ sub get_test_results {
         die "Undefined language string: '$params->{language}'\n";
     }
 
+    my $previous_locale = $translator->locale;
+    $translator->locale( $locale{$params->{language}} );
+
     eval { $translator->data } if $translator;    # Provoke lazy loading of translation data
 
     my $test_info = $self->{db}->test_results( $params->{id} );
@@ -447,6 +450,8 @@ sub get_test_results {
 
         push( @zm_results, $res );
     }
+
+    $translator->locale( $previous_locale );
 
     $result = $test_info;
     $result->{results} = \@zm_results;

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -388,6 +388,18 @@ sub get_test_results {
     my $translator;
     $translator = Zonemaster::Backend::Translator->new;
 
+    my %locale = Zonemaster::Backend::Config->load_config()->Language_Locale_hash();
+    if ( $locale{$params->{language}} ) {
+        if ( $locale{$params->{language}} eq 'NOT-UNIQUE') {
+            die "Language string not unique: '$params->{language}'\n";
+        }
+    }
+    else {
+        die "Undefined language string: '$params->{language}'\n";
+    }
+
+    eval { $translator->data } if $translator;    # Provoke lazy loading of translation data
+
     my $test_info = $self->{db}->test_results( $params->{id} );
     my @zm_results;
     foreach my $test_res ( @{ $test_info->{results} } ) {

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -17,8 +17,6 @@ extends 'Zonemaster::Engine::Translator';
 
 sub translate_tag {
     my ( $self, $hashref, $browser_lang ) = @_;
-    my $previous_locale = $self->locale;
-    $self->locale( $locale{$browser_lang} );
 
     # Make locale really be set. Fix that makes translation work on FreeBSD 12.1. Solution copied from
     # CLI.pm in the Zonemaster-CLI repository.
@@ -35,7 +33,6 @@ sub translate_tag {
 
     my $entry = Zonemaster::Engine::Logger::Entry->new( %{ $hashref } );
     my $octets = Zonemaster::Engine::Translator::translate_tag( $self, $entry );
-    $self->locale( $previous_locale );
 
     return decode_utf8( $octets );
 }

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -17,20 +17,8 @@ extends 'Zonemaster::Engine::Translator';
 
 sub translate_tag {
     my ( $self, $hashref, $browser_lang ) = @_;
-    my %locale = Zonemaster::Backend::Config->load_config()->Language_Locale_hash();
     my $previous_locale = $self->locale;
-
-    if ( $locale{$browser_lang} ) {
-        if ( $locale{$browser_lang} eq 'NOT-UNIQUE') {
-            die "Language string not unique: '$browser_lang'\n";
-        }
-        else {
-            $self->locale( $locale{$browser_lang} );
-        }
-    }
-    else {
-        die "Undefined language string: '$browser_lang'\n";
-    }
+    $self->locale( $locale{$browser_lang} );
 
     # Make locale really be set. Fix that makes translation work on FreeBSD 12.1. Solution copied from
     # CLI.pm in the Zonemaster-CLI repository.

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -18,6 +18,7 @@ extends 'Zonemaster::Engine::Translator';
 sub translate_tag {
     my ( $self, $hashref, $browser_lang ) = @_;
 
+    # Workaround for broken Zonemaster::Engine::translate_tag in Zonemaster-Engine 3.1.2.
     # Make locale really be set. Fix that makes translation work on FreeBSD 12.1. Solution copied from
     # CLI.pm in the Zonemaster-CLI repository.
     undef $ENV{LANGUAGE};


### PR DESCRIPTION
Handle the language parameter once per request in Z::B::RPCAPI::get_test_results instead of once per message. It also removes a call to Z::E::Translator::data that's useless after Z::B::Translator::translate_tag was updated in #649.