### PR TITLE
Updated smoke test

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -52,18 +52,18 @@ for Zonemaster::Backend, see the [declaration of prerequisites].
 > **Note:** In addition to the normal dependencies, the post-installation
 > smoke test instruction assumes that you have curl installed.
 
-Optionally install jq (only needed for the post-installation smoke test):
-
-```sh
-sudo yum install jq
-```
-
 ## 3. Installation on CentOS
 
 ### 3.1 Install Zonemaster::Backend and related dependencies (CentOS)
 
 > **Note:** Zonemaster::LDNS and Zonemaster::Engine are not listed here as they
 > are dealt with in the [prerequisites](#prerequisites) section.
+
+Optionally install jq (only needed for the post-installation smoke test):
+
+```sh
+sudo yum install jq
+```
 
 Install dependencies available from binary packages:
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -49,9 +49,6 @@ Prerequisite for FreeBSD is that the package system is upadated and activated
 For details on supported versions of Perl, database engine and operating system
 for Zonemaster::Backend, see the [declaration of prerequisites].
 
-> **Note:** In addition to the normal dependencies, the post-installation
-> smoke test instruction assumes that you have curl installed.
-
 ## 3. Installation on CentOS
 
 ### 3.1 Install Zonemaster::Backend and related dependencies (CentOS)

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -684,8 +684,7 @@ API on localhost port 5000 as below. The command requires that `curl` and `jq` a
 
 
 ```sh
-cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
-./zmtest zonemaster.net
+`perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`/zmtest zonemaster.net
 ```
 
 The command is expected to immediately print out a testid,

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -687,11 +687,9 @@ cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backen
 ./zmtest zonemaster.net
 ```
 
-The command is expected to give an immediate JSON response similiar to:
-
-```json
-{"id":"1","jsonrpc":"2.0","result":{"zonemaster_backend":"2.0.2","zonemaster_engine":"v2.0.6"}}
-```
+The command is expected to immediately print out a testid,
+followed by a percentage ticking up from 0% to 100%.
+Once the number reaches 100% a JSON object is printed and zmtest terminates.
 
 
 ### 7.2. What to do next?

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -736,10 +736,3 @@ database to use it with the new version of Zonemaster-Backend. Please see the
 [Zonemaster::Engine installation]: https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md
 [Zonemaster::Engine]: https://github.com/zonemaster/zonemaster-engine/blob/master/README.md
 [Zonemaster::LDNS]: https://github.com/zonemaster/zonemaster-ldns/blob/master/README.md
-
-Copyright (c) 2013 - 2017, IIS (The Internet Foundation in Sweden) \
-Copyright (c) 2013 - 2017, AFNIC \
-Creative Commons Attribution 4.0 International License
-
-You should have received a copy of the license along with this
-work.  If not, see <https://creativecommons.org/licenses/by/4.0/>.

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -680,7 +680,8 @@ Use the procedure for installation on [Debian](#2-installation-on-debian).
 
 If you have followed the installation instructions for Zonemaster::Backend above,
 you should be able to use the
-API on localhost port 5000 as below. The command requires that `curl` is installed.
+API on localhost port 5000 as below. The command requires that `curl` and `jq` are installed.
+
 
 ```sh
 cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -52,6 +52,12 @@ for Zonemaster::Backend, see the [declaration of prerequisites].
 > **Note:** In addition to the normal dependencies, the post-installation
 > smoke test instruction assumes that you have curl installed.
 
+Optionally install jq (only needed for the post-installation smoke test):
+
+```sh
+sudo yum install jq
+```
+
 ## 3. Installation on CentOS
 
 ### 3.1 Install Zonemaster::Backend and related dependencies (CentOS)
@@ -308,10 +314,10 @@ See the [post-installation] section for post-installation matters.
 > **Note:** Zonemaster::LDNS and Zonemaster::Engine are not listed here as they
 > are dealt with in the [prerequisites](#prerequisites) section.
 
-Optionally install Curl (only needed for the post-installation smoke test):
+Optionally install Curl and jq (only needed for the post-installation smoke test):
 
 ```sh
-sudo apt install curl
+sudo apt install curl jq
 ```
 
 Install required locales:
@@ -491,10 +497,10 @@ Install dependencies available from binary packages:
 pkg install p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote databases/p5-DBD-SQLite devel/p5-Log-Dispatch devel/p5-Log-Any devel/p5-Log-Any-Adapter-Dispatch
 ```
 
-Optionally install Curl (only needed for the post-installation smoke test):
+Optionally install Curl and jq (only needed for the post-installation smoke test):
 
 ```sh
-pkg install curl
+pkg install curl jq
 ```
 
 Install dependencies not available from binary packages:
@@ -677,7 +683,8 @@ you should be able to use the
 API on localhost port 5000 as below. The command requires that `curl` is installed.
 
 ```sh
-curl -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"version_info","id":"1"}' http://localhost:5000/ && echo
+cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
+./zmtest zonemaster.net
 ```
 
 The command is expected to give an immediate JSON response similiar to:

--- a/share/zmtest
+++ b/share/zmtest
@@ -4,35 +4,36 @@ bindir="$(dirname "$0")"
 
 ZMB="${bindir}/zmb"
 JQ="$(which jq)"
+ECHO=/bin/echo
 
 usage () {
     status="$1"
     message="$2"
-    echo "${message}" >&2
-    echo "Usage: zmtest [OPTIONS] DOMAIN" >&2
-    echo >&2
-    echo "Options:" >&2
-    echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
-    echo "  --noipv4              Run the test without ipv4." >&2
-    echo "  --noipv6              Run the test without ipv6." >&2
-    echo "  --lang LANG           A language tag. Default is \"en\"." >&2
-    echo "                        Valid values are determined by backend_config.ini." >&2
+    "${ECHO}" "${message}" >&2
+    "${ECHO}" "Usage: zmtest [OPTIONS] DOMAIN" >&2
+    "${ECHO}" >&2
+    "${ECHO}" "Options:" >&2
+    "${ECHO}" "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
+    "${ECHO}" "  --noipv4              Run the test without ipv4." >&2
+    "${ECHO}" "  --noipv6              Run the test without ipv6." >&2
+    "${ECHO}" "  --lang LANG           A language tag. Default is \"en\"." >&2
+    "${ECHO}" "                        Valid values are determined by backend_config.ini." >&2
     exit "${status}"
 }
 
 error () {
     status="$1"
     message="$2"
-    echo "error: ${message}" >&2
+    "${ECHO}" "error: ${message}" >&2
     exit "${status}"
 }
 
 zmb () {
     server_url="$1"; shift
     json="$("${ZMB}" --server="${server_url}" "$@" 2>&1)" || error 1 "method $1: ${json}"
-    json="$(echo "${json}" | "${JQ}" -S . 2>/dev/null)" || error 1 "method $1 did not return valid JSON output"
-    error="$(echo "${json}" | "${JQ}" -e .error 2>/dev/null)" && error 1 "method $1: ${error}"
-    echo "${json}"
+    json="$("${ECHO}" -E "${json}" | "${JQ}" -S . 2>/dev/null)" || error 1 "method $1 did not return valid JSON output"
+    error="$("${ECHO}" -E "${json}" | "${JQ}" -e .error 2>/dev/null)" && error 1 "method $1: ${error}"
+    "${ECHO}" -E "${json}"
 }
 
 [ -n "${JQ}" ] || error 2 "Dependency not found: jq"
@@ -55,10 +56,10 @@ done
 
 # Start test
 output="$(zmb "${server_url}" start_domain_test --domain "${domain}" --ipv4 "${ipv4}" --ipv6 "${ipv6}")" || exit $?
-testid="$(echo "${output}" | "${JQ}" -r .result)" || exit $?
-echo "testid: ${testid}" >&2
+testid="$("${ECHO}" -E "${output}" | "${JQ}" -r .result)" || exit $?
+"${ECHO}" -E "testid: ${testid}" >&2
 
-if echo "${testid}" | grep -qE '[^0-9a-fA-F]' ; then
+if "${ECHO}" -E "${testid}" | grep -qE '[^0-9a-fA-F]' ; then
     error 1 "start_domain_test did not return a testid: ${testid}"
 fi
 
@@ -66,10 +67,10 @@ fi
 while true
 do
     output="$(zmb "${server_url}" test_progress --testid "${testid}")" || exit $?
-    progress="$(echo "${output}" | "${JQ}" -r .result)" || exit $?
+    progress="$("${ECHO}" -E "${output}" | "${JQ}" -r .result)" || exit $?
     printf "\r${progress}%% done" >&2
     if [ "${progress}" -eq 100 ] ; then
-        echo >&2
+        "${ECHO}" >&2
         break
     fi
     sleep 1

--- a/share/zmtest
+++ b/share/zmtest
@@ -56,6 +56,7 @@ done
 # Start test
 output="$(zmb "${server_url}" start_domain_test --domain "${domain}" --ipv4 "${ipv4}" --ipv6 "${ipv6}")" || exit $?
 testid="$(echo "${output}" | "${JQ}" -r .result)" || exit $?
+echo "testid: ${testid}" >&2
 
 if echo "${testid}" | grep -qE '[^0-9a-fA-F]' ; then
     error 1 "start_domain_test did not return a testid: ${testid}"
@@ -76,4 +77,3 @@ done
 
 # Get test results
 zmb "${server_url}" get_test_results --testid "${testid}" --lang "${lang}"
-echo "testid: ${testid}" >&2

--- a/share/zmtest
+++ b/share/zmtest
@@ -4,36 +4,35 @@ bindir="$(dirname "$0")"
 
 ZMB="${bindir}/zmb"
 JQ="$(which jq)"
-ECHO=/bin/echo
 
 usage () {
     status="$1"
     message="$2"
-    "${ECHO}" "${message}" >&2
-    "${ECHO}" "Usage: zmtest [OPTIONS] DOMAIN" >&2
-    "${ECHO}" >&2
-    "${ECHO}" "Options:" >&2
-    "${ECHO}" "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
-    "${ECHO}" "  --noipv4              Run the test without ipv4." >&2
-    "${ECHO}" "  --noipv6              Run the test without ipv6." >&2
-    "${ECHO}" "  --lang LANG           A language tag. Default is \"en\"." >&2
-    "${ECHO}" "                        Valid values are determined by backend_config.ini." >&2
+    printf "%s" "${message}" >&2
+    echo "Usage: zmtest [OPTIONS] DOMAIN" >&2
+    echo >&2
+    echo "Options:" >&2
+    echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
+    echo "  --noipv4              Run the test without ipv4." >&2
+    echo "  --noipv6              Run the test without ipv6." >&2
+    echo "  --lang LANG           A language tag. Default is \"en\"." >&2
+    echo "                        Valid values are determined by backend_config.ini." >&2
     exit "${status}"
 }
 
 error () {
     status="$1"
     message="$2"
-    "${ECHO}" "error: ${message}" >&2
+    printf "error: %s\n" "${message}" >&2
     exit "${status}"
 }
 
 zmb () {
     server_url="$1"; shift
     json="$("${ZMB}" --server="${server_url}" "$@" 2>&1)" || error 1 "method $1: ${json}"
-    json="$("${ECHO}" -E "${json}" | "${JQ}" -S . 2>/dev/null)" || error 1 "method $1 did not return valid JSON output"
-    error="$("${ECHO}" -E "${json}" | "${JQ}" -e .error 2>/dev/null)" && error 1 "method $1: ${error}"
-    "${ECHO}" -E "${json}"
+    json="$(printf "%s" "${json}" | "${JQ}" -S . 2>/dev/null)" || error 1 "method $1 did not return valid JSON output"
+    error="$(printf "%s" "${json}" | "${JQ}" -e .error 2>/dev/null)" && error 1 "method $1: ${error}"
+    printf "%s" "${json}"
 }
 
 [ -n "${JQ}" ] || error 2 "Dependency not found: jq"
@@ -56,10 +55,10 @@ done
 
 # Start test
 output="$(zmb "${server_url}" start_domain_test --domain "${domain}" --ipv4 "${ipv4}" --ipv6 "${ipv6}")" || exit $?
-testid="$("${ECHO}" -E "${output}" | "${JQ}" -r .result)" || exit $?
-"${ECHO}" -E "testid: ${testid}" >&2
+testid="$(printf "%s" "${output}" | "${JQ}" -r .result)" || exit $?
+printf "testid: %s\n" "${testid}" >&2
 
-if "${ECHO}" -E "${testid}" | grep -qE '[^0-9a-fA-F]' ; then
+if echo "${testid}" | grep -qE '[^0-9a-fA-F]' ; then
     error 1 "start_domain_test did not return a testid: ${testid}"
 fi
 
@@ -67,10 +66,10 @@ fi
 while true
 do
     output="$(zmb "${server_url}" test_progress --testid "${testid}")" || exit $?
-    progress="$("${ECHO}" -E "${output}" | "${JQ}" -r .result)" || exit $?
+    progress="$(printf "%s" "${output}" | "${JQ}" -r .result)" || exit $?
     printf "\r${progress}%% done" >&2
     if [ "${progress}" -eq 100 ] ; then
-        "${ECHO}" >&2
+        echo >&2
         break
     fi
     sleep 1


### PR DESCRIPTION
I ran into a bug when trying to use `zmtest` in the smoke test.
For unknown reasons the message strings in the JSON output end with "\n". In `zmtest` we process the output through echo and jq. Echo interprets escape sequences by default. New-line characters aren't allowed in JSON. And jq throws up on invalid JSON. So zmtest crashes.

This PR:
1. Makes zmtest not interpret escape sequences in the JSON output.
2. Makes zmtest print the testid earlier to make sure it gets printed even the program crashes during result processing.
3. Makes the installation instruction smoke test use zmtest.

An old copyright statement is also removed.