### PR TITLE
Extended zm tools

### DIFF
--- a/share/zmb
+++ b/share/zmb
@@ -148,6 +148,7 @@ sub cmd_get_language_tags {
     --ds-info DS_INFO
     --client-id CLIENT_ID
     --client-version CLIENT_VERSION
+    --profile PROFILE_NAME
 
  DS_INFO is a comma separated list of key-value pairs. The expected pairs are:
 
@@ -168,6 +169,7 @@ sub cmd_start_domain_test {
     my @opt_ds_info;
     my $opt_ipv4;
     my $opt_ipv6;
+    my $opt_profile;
     GetOptionsFromArray(
         \@opts,
         'domain|d=s'       => \$opt_domain,
@@ -177,16 +179,17 @@ sub cmd_start_domain_test {
         'ds-info=s'        => \@opt_ds_info,
         'ipv4=s'           => \$opt_ipv4,
         'ipv6=s'           => \$opt_ipv6,
+        'profile=s'        => \$opt_profile,
     ) or pod2usage( 2 );
 
     my %params = ( domain => $opt_domain, );
 
     if ( $opt_client_id ) {
-        $params{client_id} = $opt_client_id,
+        $params{client_id} = $opt_client_id;
     }
 
     if ( $opt_client_version ) {
-        $params{client_version} = $opt_client_version,
+        $params{client_version} = $opt_client_version;
     }
 
     if ( @opt_ds_info ) {
@@ -224,6 +227,10 @@ sub cmd_start_domain_test {
 
     if ( $opt_ipv6 ) {
         $params{ipv6} = json_tern( $opt_ipv6 );
+    }
+
+    if ( $opt_profile ) {
+        $params{profile} = $opt_profile;
     }
 
     return to_jsonrpc(

--- a/share/zmb
+++ b/share/zmb
@@ -119,6 +119,22 @@ sub cmd_profile_names {
         method => 'profile_names',
     );
 }
+
+
+=head2 get_language_tags
+
+ zmb [GLOBAL OPTIONS] get_language_tags
+
+=cut
+
+sub cmd_get_language_tags {
+    return to_jsonrpc(
+        id     => 1,
+        method => 'get_language_tags',
+    );
+}
+
+
 =head2 start_domain_test
 
  zmb [GLOBAL OPTIONS] start_domain_test [OPTIONS]

--- a/share/zmb
+++ b/share/zmb
@@ -107,6 +107,18 @@ sub cmd_version_info {
 }
 
 
+=head2 profile_names
+
+ zmb [GLOBAL OPTIONS] profile_names
+
+=cut
+
+sub cmd_profile_names {
+    return to_jsonrpc(
+        id     => 1,
+        method => 'profile_names',
+    );
+}
 =head2 start_domain_test
 
  zmb [GLOBAL OPTIONS] start_domain_test [OPTIONS]

--- a/share/zmtest
+++ b/share/zmtest
@@ -17,6 +17,9 @@ usage () {
     echo "  --noipv6              Run the test without ipv6." >&2
     echo "  --lang LANG           A language tag. Default is \"en\"." >&2
     echo "                        Valid values are determined by backend_config.ini." >&2
+    echo "  --profile PROFILE     The name of a profile. Default is \"default\"." >&2
+    echo "                        Valid values are determined by backend_config.ini except that" >&2
+    echo "                        \"default\" is always a valid value." >&2
     exit "${status}"
 }
 
@@ -42,19 +45,21 @@ server_url="http://localhost:5000/"
 ipv4="true"
 ipv6="true"
 lang="en"
+profile="default"
 while [ $# -gt 0 ] ; do
     case "$1" in
         -s|--server) server_url="$2"; shift 2;;
         --noipv4) ipv4="false"; shift 1;;
         --noipv6) ipv6="false"; shift 1;;
         --lang) lang="$2"; shift 2;;
+        --profile) profile="$2"; shift 2;;
         *) domain="$1" ; shift 1;;
     esac
 done
 [ -n "${domain}" ] || usage 2 "No domain specified"
 
 # Start test
-output="$(zmb "${server_url}" start_domain_test --domain "${domain}" --ipv4 "${ipv4}" --ipv6 "${ipv6}")" || exit $?
+output="$(zmb "${server_url}" start_domain_test --domain "${domain}" --ipv4 "${ipv4}" --ipv6 "${ipv6}" --profile "${profile}")" || exit $?
 testid="$(printf "%s" "${output}" | "${JQ}" -r .result)" || exit $?
 printf "testid: %s\n" "${testid}" >&2
 


### PR DESCRIPTION
The zm tools (zmb and zmtest) are good tools for querying the backend directly from the command line. Here those tools are extended with more functions.

* Add support for method `profile_names` in `zmb`
* Add support for method `get_language_tags` in `zmb`
* Add support for "profile" in method `start_domain_test` in `zmb`
* Add support for "profile" in `zmtest` 