### PR TITLE
Update unit tests (resolve #677)

### DIFF
--- a/t/test01.t
+++ b/t/test01.t
@@ -15,10 +15,10 @@ if ( not $ENV{ZONEMASTER_RECORD} ) {
 	Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
-# The configuration file should be based on the default
+# The configuration file should be the default
 # configuration file, unless the ENV variable below is already
 # set (e.g. for Travis). Set the ENV variable, and this must
-# be placed before Zonemaster::Backend::Config is loaded.
+# be done before Zonemaster::Backend::Config is loaded.
 unless ($ENV{ZONEMASTER_BACKEND_CONFIG_FILE}) {
        $ENV{ZONEMASTER_BACKEND_CONFIG_FILE} =
        dist_file('Zonemaster-Backend', "backend_config.ini");

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -5,8 +5,18 @@ use utf8;
 
 use Encode;
 use Test::More;    # see done_testing()
+use File::ShareDir qw[dist_file];
 
 my $can_use_threads = eval 'use threads; 1';
+
+# The configuration file should be the default
+# configuration file, unless the ENV variable below is already
+# set (e.g. for Travis). Set the ENV variable, and this must
+# be done before Zonemaster::Backend::Config is loaded.
+unless ($ENV{ZONEMASTER_BACKEND_CONFIG_FILE}) {
+       $ENV{ZONEMASTER_BACKEND_CONFIG_FILE} =
+       dist_file('Zonemaster-Backend', "backend_config.ini");
+};
 
 # Require Zonemaster::Backend::RPCAPI.pm test
 use_ok( 'Zonemaster::Backend::RPCAPI' );


### PR DESCRIPTION
Updates  `t/test_validate_syntax.t` to ensure that `/etc/zonemaster/backend_config.ini` is not used for the unit test, but rather the default `backend_config.ini` that comes with the installation. (Unless the environment variable is explicitly set.) This resolves issue #677.

This is the same solution as been implemented in `t/test01.t` by #671. 

Also, two smaller editorial updates have been implemented in `t/test01.t`, one of which comes from a [comment] to #671. 

[comment]: https://github.com/zonemaster/zonemaster-backend/pull/671#pullrequestreview-532286870