### PR TITLE
Document all backend config keys

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,8 +1,9 @@
 # Configuration
 
-Zonemaster *Backend* is configured as a whole from `/etc/zonemaster/backend_config.ini`
-(CentOS, Debian and Ubuntu) or `/usr/local/etc/zonemaster/backend_config.ini`
-(FreeBSD).
+Zonemaster *Backend* is configured in
+`/etc/zonemaster/backend_config.ini` (CentOS, Debian and Ubuntu) or
+`/usr/local/etc/zonemaster/backend_config.ini` (FreeBSD). Following
+[Installation instructions] will create the file with factory settings.
 
 Each section in `backend_config.ini` is documented below.
 
@@ -31,34 +32,29 @@ SQLite            | `SQLite`
 ### user
 
 The name of the user with sufficient permission to access the database.
-Default value: `zonemaster`.
 
 Ignored by the SQLite database engine.
 
 ### password
 
-The password of the configured user. Default value: `zonemaster`.
+The password of the configured user.
 
 Ignored by the SQLite database engine.
 
 ### database_host
 
-The host name of the machine on which the engine is running. Default
-value: `localhost`.
+The host name of the machine on which the engine is running.
 
 Ignored by the SQLite database engine.
 
 ### database_name
 
 The name of the database to use, except for SQLite database engine where
-it holds the full path to the SQLite database file. Default value:
-`zonemaster` or `/var/lib/zonemaster/db.sqlite`
-(`/var/db/zonemaster/db.sqlite` on FreeBSD).
+it holds the full path to the SQLite database file.
 
 ### polling_interval
 
-Time in seconds between database lookups by Test Agent. Default value:
-`0.5`.
+Time in seconds between database lookups by Test Agent.
 
 
 ## LANGUAGE section
@@ -223,6 +219,7 @@ Integer working as a label to associate a test to a specific Test Agent.
 
 --------
 
+[Installation instructions]:          Installation.md
 [Default JSON profile file]:          https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
 [ISO 3166-1 alpha-2]:                 https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                          https://en.wikipedia.org/wiki/ISO_639-1

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -31,22 +31,34 @@ SQLite            | `SQLite`
 ### user
 
 The name of the user with sufficient permission to access the database.
+Default value: `zonemaster`.
+
+Ignored by the SQLite database engine.
 
 ### password
 
-The password of the configured user.
+The password of the configured user. Default value: `zonemaster`.
+
+Ignored by the SQLite database engine.
 
 ### database_host
 
-The host name of the machine on which the engine is running.
+The host name of the machine on which the engine is running. Default
+value: `localhost`.
+
+Ignored by the SQLite database engine.
 
 ### database_name
 
-The name of the database to use.
+The name of the database to use, except for SQLite database engine where
+it holds the full path to the SQLite database file. Default value:
+`zonemaster` or `/var/lib/zonemaster/db.sqlite`
+(`/var/db/zonemaster/db.sqlite` on FreeBSD).
 
 ### polling_interval
 
-not used anywhere besides in script/zonemaster_backend_testagent
+Time in seconds between database lookups by Test Agent. Default value:
+`0.5`.
 
 
 ## LANGUAGE section
@@ -185,16 +197,13 @@ The ZONEMASTER section has several keys :
 
 ### max_zonemaster_execution_time
 
-This key allows to define the interval in seconds to reload unfinished
-queries.
-This assume that after `max_zonemaster_execution_time`, if the test is
-not finished, it has fail. And it will be run again up to
-`maximal_number_of_retries`.
+Time in seconds before reporting an unfinished test as failed. Default
+value: `600`.
 
 ### maximal_number_of_retries
 
-Specifies the number of time a test is allowed to be run again if
-unfinished after `max_zonemaster_execution_time`.
+Number of time a test is allowed to be run again if unfinished after
+`max_zonemaster_execution_time`. Default value: `0`.
 
 ### number_of_professes_for_frontend_testing
 
@@ -210,7 +219,7 @@ used -> todo
 
 ### lock_on_queue
 
-used -> todo
+Integer working as a label to associate a test to a specific Test Agent.
 
 --------
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -193,7 +193,13 @@ used -> todo
 
 ### force_hash_id_use_in_API_starting_from_id
 
-used -> todo
+This parameter determines if it is possible to get the test results
+using an incremental numeric id (allowing easy enumeration of the whole
+database of results) or if a half-md5 hash id should be used instead. If
+set to a non zero value the API will use the simple id up to that value
+(the id value given here will be the highest posible value allowed as
+simple id, for everything above hash_id will be forced). Default value:
+`0`.
 
 ### lock_on_queue
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -139,24 +139,6 @@ Each locale set in the configuration file, including the implied
 running the RPCAPI daemon for the translation to work correctly.
 
 
-## LOG section
-
-The LOG section has a unique key, `log_dir`.
-
-### log_dir
-
-not used in the code
-
-
-## PERL section
-
-The PERL section has a unique key, `interpreter`.
-
-### interpreter
-
-not used in the code
-
-
 ## PUBLIC PROFILES and PRIVATE PROFILES sections
 
 The PUBLIC PROFILES and PRIVATE PROFILES sections together define the available [profiles].
@@ -203,11 +185,11 @@ Number of time a test is allowed to be run again if unfinished after
 
 ### number_of_professes_for_frontend_testing
 
-not used in the code
+used -> todo
 
 ### number_of_professes_for_batch_testing
 
-not used in the code
+used -> todo
 
 ### force_hash_id_use_in_API_starting_from_id
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -168,8 +168,8 @@ to specifying a profile JSON file containing the entire
 
 The ZONEMASTER section has several keys :
 `max_zonemaster_execution_time`,
-`number_of_professes_for_frontend_testing`,
-`number_of_professes_for_batch_testing`,
+`number_of_processes_for_frontend_testing`,
+`number_of_processes_for_batch_testing`,
 `force_hash_id_use_in_API_starting_from_id`, `lock_on_queue`,
 `maximal_number_of_retries`.
 
@@ -183,11 +183,11 @@ value: `600`.
 Number of time a test is allowed to be run again if unfinished after
 `max_zonemaster_execution_time`. Default value: `0`.
 
-### number_of_professes_for_frontend_testing
+### number_of_processes_for_frontend_testing
 
 used -> todo
 
-### number_of_professes_for_batch_testing
+### number_of_processes_for_batch_testing
 
 used -> todo
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -9,7 +9,8 @@ Each section in `backend_config.ini` is documented below.
 ## DB section
 
 The DB section has a number of keys.
-At this time the only documented key is `engine`.
+Available keys : `engine`, `user`, `password`, `database_name`,
+`database_host`, `polling_interval`.
 
 ### engine
 
@@ -26,6 +27,26 @@ MariaDB           | `MySQL`
 MySQL             | `MySQL`
 PostgreSQL        | `PostgreSQL`
 SQLite            | `SQLite`
+
+### user
+
+The name of the user with sufficient permission to access the database.
+
+### password
+
+The password of the configured user.
+
+### database_host
+
+The host name of the machine on which the engine is running.
+
+### database_name
+
+The name of the database to use.
+
+### polling_interval
+
+not used anywhere besides in script/zonemaster_backend_testagent
 
 
 ## LANGUAGE section
@@ -109,14 +130,23 @@ Each locale set in the configuration file, including the implied
 ".UTF-8", must also be installed or activate on the system
 running the RPCAPI daemon for the translation to work correctly.
 
+
 ## LOG section
 
-TBD
+The LOG section has a unique key, `log_dir`.
+
+### log_dir
+
+not used in the code
 
 
 ## PERL section
 
-TBD
+The PERL section has a unique key, `interpreter`.
+
+### interpreter
+
+not used in the code
 
 
 ## PUBLIC PROFILES and PRIVATE PROFILES sections
@@ -146,7 +176,41 @@ to specifying a profile JSON file containing the entire
 
 ## ZONEMASTER section
 
-TBD
+The ZONEMASTER section has several keys :
+`max_zonemaster_execution_time`,
+`number_of_professes_for_frontend_testing`,
+`number_of_professes_for_batch_testing`,
+`force_hash_id_use_in_API_starting_from_id`, `lock_on_queue`,
+`maximal_number_of_retries`.
+
+### max_zonemaster_execution_time
+
+This key allows to define the interval in seconds to reload unfinished
+queries.
+This assume that after `max_zonemaster_execution_time`, if the test is
+not finished, it has fail. And it will be run again up to
+`maximal_number_of_retries`.
+
+### maximal_number_of_retries
+
+Specifies the number of time a test is allowed to be run again if
+unfinished after `max_zonemaster_execution_time`.
+
+### number_of_professes_for_frontend_testing
+
+not used in the code
+
+### number_of_professes_for_batch_testing
+
+not used in the code
+
+### force_hash_id_use_in_API_starting_from_id
+
+used -> todo
+
+### lock_on_queue
+
+used -> todo
 
 --------
 


### PR DESCRIPTION
Add documentation to all backend keys as found in the `/lib/Zonemaster/Backend/Config.pm` file.

It appears that some keys are not used anywhere in the code.

This addresses #520 

This is a work in progress, some used keys are not documented yet.