### PR TITLE
Remove unused configuration properties

### DIFF
--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -167,18 +167,6 @@ sub DB_connection_string {
     return $result;
 }
 
-sub LogDir {
-    my ($self) = @_;
-
-    return $self->{cfg}->val( 'LOG', 'log_dir' );
-}
-
-sub PerlInterpreter {
-    my ($self) = @_;
-
-    return $self->{cfg}->val( 'PERL', 'interpreter' );
-}
-
 sub PollingInterval {
     my ($self) = @_;
 

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -9,12 +9,6 @@ database_host     = localhost
 database_name     = zonemaster
 polling_interval  = 0.5
 
-[LOG]
-log_dir           = logs/
-
-[PERL]
-interpreter       = perl
-
 [ZONEMASTER]
 max_zonemaster_execution_time            = 300
 number_of_processes_for_frontend_testing = 20

--- a/share/travis_mysql_backend_config.ini
+++ b/share/travis_mysql_backend_config.ini
@@ -9,12 +9,6 @@ database_name=travis_zonemaster
 polling_interval=0.5
 #seconds
 
-[LOG]
-log_dir=logs/
-
-[PERL]
-interpreter=perl
-
 [ZONEMASTER]
 max_zonemaster_execution_time=300
 number_of_processes_for_frontend_testing=20

--- a/share/travis_postgresql_backend_config.ini
+++ b/share/travis_postgresql_backend_config.ini
@@ -9,12 +9,6 @@ database_name=travis_zonemaster
 polling_interval=0.5
 #seconds
 
-[LOG]
-log_dir=logs/
-
-[PERL]
-interpreter=perl
-
 [ZONEMASTER]
 max_zonemaster_execution_time=300
 number_of_professes_for_frontend_testing=20

--- a/share/travis_sqlite_backend_config.ini
+++ b/share/travis_sqlite_backend_config.ini
@@ -9,12 +9,6 @@ database_name=/tmp/zonemaster
 polling_interval=0.5
 #seconds
 
-[LOG]
-log_dir=logs/
-
-[PERL]
-interpreter=perl
-
 [ZONEMASTER]
 max_zonemaster_execution_time=300
 number_of_processes_for_frontend_testing=20


### PR DESCRIPTION
Some properties defined in the .ini files are read by the Config.pm file but not used anywhere in the code.

As stated in https://github.com/zonemaster/zonemaster-backend/issues/273#issuecomment-701499400, they can be removed safely.

Closes #273