### PR TITLE
 Make age for reused test configurable 

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -167,11 +167,13 @@ to specifying a profile JSON file containing the entire
 ## ZONEMASTER section
 
 The ZONEMASTER section has several keys :
-`max_zonemaster_execution_time`,
-`number_of_processes_for_frontend_testing`,
-`number_of_processes_for_batch_testing`,
-`force_hash_id_use_in_API_starting_from_id`, `lock_on_queue`,
-`maximal_number_of_retries`.
+* max_zonemaster_execution_time
+* number_of_processes_for_frontend_testing
+* number_of_processes_for_batch_testing
+* force_hash_id_use_in_API_starting_from_id
+* lock_on_queue
+* maximal_number_of_retries
+* age_reuse_previous_test
 
 ### max_zonemaster_execution_time
 
@@ -204,6 +206,13 @@ simple id, for everything above hash_id will be forced). Default value:
 ### lock_on_queue
 
 Integer working as a label to associate a test to a specific Test Agent.
+
+### age_reuse_previous_test
+
+Positiv integer (in seconds) for how old a previous test of the same
+zone name and parameters must be before we start a new test. Internally
+the value is converted to whole minutes. If the conversion results in
+zero minutes, then the default value (600 seconds) is used.
 
 --------
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -190,7 +190,8 @@ sub PollingInterval {
 
 =head3 INPUT
 
-'max_zonemaster_execution_time' from [ZONEMASTER] section in ini file.
+'max_zonemaster_execution_time' from [ZONEMASTER] section in ini file. See
+L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#max_zonemaster_execution_time>.
 
 =head3 RETURNS
 
@@ -211,7 +212,8 @@ sub MaxZonemasterExecutionTime {
 
 =head3 INPUT
 
-'number_of_processes_for_frontend_testing' from [ZONEMASTER] section in ini file.
+'number_of_processes_for_frontend_testing' from [ZONEMASTER] section in ini file. See
+L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#number_of_processes_for_frontend_testing>.
 
 =head3 RETURNS
 
@@ -233,7 +235,8 @@ sub NumberOfProcessesForFrontendTesting {
 
 =head3 INPUT
 
-'number_of_processes_for_batch_testing' from [ZONEMASTER] section in ini file.
+'number_of_processes_for_batch_testing' from [ZONEMASTER] section in ini file. See
+L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#number_of_processes_for_batch_testing>.
 
 =head3 RETURNS
 
@@ -255,7 +258,8 @@ sub NumberOfProcessesForBatchTesting {
 
 =head3 INPUT
 
-'force_hash_id_use_in_API_starting_from_id' from [ZONEMASTER] section in ini file.
+'force_hash_id_use_in_API_starting_from_id' from [ZONEMASTER] section in ini file. See
+L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#force_hash_id_use_in_api_starting_from_id>.
 
 =head3 RETURNS
 
@@ -275,7 +279,8 @@ sub force_hash_id_use_in_API_starting_from_id {
 
 =head3 INPUT
 
-'lock_on_queue' from [ZONEMASTER] section in ini file.
+'lock_on_queue' from [ZONEMASTER] section in ini file. See
+L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#lock_on_queue>.
 
 =head3 RETURNS
 
@@ -299,7 +304,8 @@ Do not use it (keep the default value "0"), or use it with care.
 
 =head3 INPUT
 
-'maximal_number_of_retries' from [ZONEMASTER] section in ini file.
+'maximal_number_of_retries' from [ZONEMASTER] section in ini file. See
+L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#maximal_number_of_retries>.
 
 =head3 RETURNS
 
@@ -320,7 +326,8 @@ sub maximal_number_of_retries {
 
 =head3 INPUT
 
-'age_reuse_previous_test' from [ZONEMASTER] section in ini file (in seconds).
+'age_reuse_previous_test' from [ZONEMASTER] section in ini file (in seconds). See
+L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#age_reuse_previous_test>.
 
 =head3 RETURNS
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -195,7 +195,7 @@ L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuratio
 
 =head3 RETURNS
 
-Integer (number of seconds)
+Integer (number of seconds), default 600.
 
 =cut
 
@@ -217,7 +217,7 @@ L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuratio
 
 =head3 RETURNS
 
-Positive integer (default 600).
+Positive integer.
 
 =cut
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -33,7 +33,7 @@ sub load_config {
     my $self = {};
 
     $log->notice( "Loading config: $path" );
-    
+
     $self->{cfg} = Config::IniFiles->new( -file => $path );
     die "UNABLE TO LOAD $path ERRORS:[".join('; ', @Config::IniFiles::errors)."] \n" unless ( $self->{cfg} );
     bless( $self, $class );
@@ -185,31 +185,83 @@ sub PollingInterval {
     return $self->{cfg}->val( 'DB', 'polling_interval' );
 }
 
+
+=head2 MaxZonemasterExecutionTime
+
+=head3 INPUT
+
+'max_zonemaster_execution_time' from [ZONEMASTER] section in ini file.
+
+=head3 RETURNS
+
+Integer (number of seconds)
+
+=cut
+
 sub MaxZonemasterExecutionTime {
     my ($self) = @_;
 
     my $val = $self->{cfg}->val( 'ZONEMASTER', 'max_zonemaster_execution_time' );
-    
+
     return ($val)?($val):(10*60);
 }
+
+
+=head2 NumberOfProcessesForFrontendTesting
+
+=head3 INPUT
+
+'number_of_processes_for_frontend_testing' from [ZONEMASTER] section in ini file.
+
+=head3 RETURNS
+
+Positive integer (default 600).
+
+=cut
 
 sub NumberOfProcessesForFrontendTesting {
     my ($self) = @_;
 
     my $nb = $self->{cfg}->val( 'ZONEMASTER', 'number_of_professes_for_frontend_testing' );
     $nb = $self->{cfg}->val( 'ZONEMASTER', 'number_of_processes_for_frontend_testing' ) unless ($nb);
-    
+
     return $nb;
 }
+
+
+=head2 NumberOfProcessesForBatchTesting
+
+=head3 INPUT
+
+'number_of_processes_for_batch_testing' from [ZONEMASTER] section in ini file.
+
+=head3 RETURNS
+
+Integer.
+
+=cut
 
 sub NumberOfProcessesForBatchTesting {
     my ($self) = @_;
 
     my $nb = $self->{cfg}->val( 'ZONEMASTER', 'number_of_professes_for_batch_testing' );
     $nb = $self->{cfg}->val( 'ZONEMASTER', 'number_of_processes_for_batch_testing' ) unless ($nb);
-    
+
     return $nb;
 }
+
+
+=head2 force_hash_id_use_in_API_starting_from_id
+
+=head3 INPUT
+
+'force_hash_id_use_in_API_starting_from_id' from [ZONEMASTER] section in ini file.
+
+=head3 RETURNS
+
+Integer (default 0).
+
+=cut
 
 sub force_hash_id_use_in_API_starting_from_id {
     my ($self) = @_;
@@ -219,9 +271,54 @@ sub force_hash_id_use_in_API_starting_from_id {
     return ($val)?($val):(0);
 }
 
+=head2 lock_on_queue
+
+=head3 INPUT
+
+'lock_on_queue' from [ZONEMASTER] section in ini file.
+
+=head3 RETURNS
+
+Integer (default 0).
+
+=cut
+
+sub lock_on_queue {
+    my ($self) = @_;
+
+    my $val = $self->{cfg}->val( 'ZONEMASTER', 'lock_on_queue' );
+
+    return $val;
+}
+
+
+=head2 maximal_number_of_retries
+
+This option is experimental and all edge cases are not fully tested.
+Do not use it (keep the default value "0"), or use it with care.
+
+=head3 INPUT
+
+'maximal_number_of_retries' from [ZONEMASTER] section in ini file.
+
+=head3 RETURNS
+
+A scalar value of the number of retries (default 0).
+
+=cut
+
+sub maximal_number_of_retries {
+    my ($self) = @_;
+
+    my $val = $self->{cfg}->val( 'ZONEMASTER', 'maximal_number_of_retries' );
+
+    return ($val)?($val):(0);
+}
+
+
 sub ReadProfilesInfo {
     my ($self) = @_;
-    
+
     my $profiles;
     $profiles->{'default'}->{type} = 'public';
     $profiles->{'default'}->{profile_file_name} = '';
@@ -234,13 +331,13 @@ sub ReadProfilesInfo {
         $profiles->{lc($private_profile)}->{type} = 'private';
         $profiles->{lc($private_profile)}->{profile_file_name} = $self->{cfg}->val('PRIVATE PROFILES', $private_profile);
     }
-    
+
     return $profiles;
 }
 
 sub ListPublicProfiles {
     my ($self) = @_;
-    
+
     my $profiles;
     $profiles->{'default'}->{type} = 'public';
     foreach my $public_profile ($self->{cfg}->Parameters('PUBLIC PROFILES')) {
@@ -251,36 +348,6 @@ sub ListPublicProfiles {
     return keys %$profiles;
 }
 
-sub lock_on_queue {
-    my ($self) = @_;
-
-    my $val = $self->{cfg}->val( 'ZONEMASTER', 'lock_on_queue' );
-
-    return $val;
-}
-
-=head2 maximal_number_of_retries
-
-WARNING: This option is experimental and all edge cases are not fully tested.
-Do not use it (keep the default value "0"), or use it with care.
-
-=head3 INPUT
-
-None
-
-=head3 RETURNS
-
-A scalar value of the number of retries or the default 0 if no value is defined in the backend_config.ini file.
-
-=cut
-
-sub maximal_number_of_retries {
-    my ($self) = @_;
-
-    my $val = $self->{cfg}->val( 'ZONEMASTER', 'maximal_number_of_retries' );
-
-    return ($val)?($val):(0);
-}
 
 =head2 BackendDBType
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -342,7 +342,7 @@ sub age_reuse_previous_test {
     my $val = $self->{cfg}->val( 'ZONEMASTER', 'age_reuse_previous_test' );
     $val = ($val > 0) ? $val : 0;
     $val = int ( ($val / 60) + 0.5); # in minutes
-    return ($val)? $val : 10;
+    return ($val) ? $val : 10;
 }
 
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -316,6 +316,29 @@ sub maximal_number_of_retries {
 }
 
 
+=head2 age_reuse_previous_test
+
+=head3 INPUT
+
+'age_reuse_previous_test' from [ZONEMASTER] section in ini file (in seconds).
+
+=head3 RETURNS
+
+A scalar value of the number of minutes old the previous test with the same
+parameters can be when it is reused instead of starting a new test (default
+10). Note that it returns in minutes, whereas the input is in seconds.
+
+=cut
+
+sub age_reuse_previous_test {
+    my ($self) = @_;
+    my $val = $self->{cfg}->val( 'ZONEMASTER', 'age_reuse_previous_test' );
+    $val = ($val > 0) ? $val : 0;
+    $val = int ( ($val / 60) + 0.5); # in minutes
+    return ($val)? $val : 10;
+}
+
+
 sub ReadProfilesInfo {
     my ($self) = @_;
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -394,7 +394,7 @@ sub start_domain_test {
 
         $params->{priority}  //= 10;
         $params->{queue}     //= 0;
-        my $minutes_between_tests_with_same_params = 10;
+        my $minutes_between_tests_with_same_params = Zonemaster::Backend::Config->load_config()->age_reuse_previous_test();
 
         $result = $self->{db}->create_new_test( $params->{domain}, $params, $minutes_between_tests_with_same_params );
     };

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -19,7 +19,7 @@ interpreter       = perl
 max_zonemaster_execution_time            = 300
 number_of_processes_for_frontend_testing = 20
 number_of_processes_for_batch_testing    = 20
-
+#age_reuse_previous_test=600
 #
 # WARNING: This option is experimental and all edge cases are not fully tested.
 # Do not use it (keep the default value "0"), or use it with care.

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -20,8 +20,8 @@ max_zonemaster_execution_time            = 300
 number_of_processes_for_frontend_testing = 20
 number_of_processes_for_batch_testing    = 20
 #age_reuse_previous_test=600
-#
-# WARNING: This option is experimental and all edge cases are not fully tested.
+
+# WARNING: The following option is experimental and all edge cases are not fully tested.
 # Do not use it (keep the default value "0"), or use it with care.
 #
 #maximal_number_of_retries=3


### PR DESCRIPTION
When creating a new test through RPCAPI it will first check if there is a recent test with the same test parameters. If so, and that test is not too old, a new test will not be created, instead the test result for that recent test will be reused.

As it is now, "not too old" is hard-coded to 10 minutes. That is probably a good choice in most cases, but sometimes that is too short and sometimes too long. This PR makes that configurable.

As a side effect, this PR sorts the methods in the "[ZONEMASTER]" section from the ini file in `lib/Zonemaster/Backend/Config.pm` and also adds POD documentation to those methods.