### PR TITLE
Proper installation of zmtest and zmb

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -47,6 +47,8 @@ script/add-test.pl
 script/add-batch-job.pl
 script/create_db_mysql.pl
 script/create_db_postgresql_9.3.pl
+script/zmb
+script/zmtest
 script/zonemaster_backend_rpcapi.psgi
 script/zonemaster_backend_testagent
 share/backend_config.ini
@@ -71,8 +73,6 @@ share/zm-rpcapi.lsb
 share/zm-testagent.lsb
 share/zm_rpcapi-bsd
 share/zm_testagent-bsd
-share/zmb
-share/zmtest
 t/test01.data
 t/test01.t
 t/test_DB_backend.pl

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -6,10 +6,6 @@ maint
 ^.*\.swp$
 ^MANIFEST\.SKIP$
 
-# Avoid experimental tools
-script/zmb
-script/zmtest
-
 #!start included /usr/share/perl/5.20/ExtUtils/MANIFEST.SKIP
 # Avoid version control files.
 \bRCS\b

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,7 @@ requires
   'Log::Any'                    => 0,
   'Log::Any::Adapter::Dispatch' => 0,
   'Log::Dispatch'               => 0,
+  'LWP::UserAgent'              => 0,
   'Moose'                       => 2.04,
   'Parallel::ForkManager'       => 1.12,
   'Plack::Builder'              => 0,
@@ -44,6 +45,8 @@ install_share;
 
 install_script 'zonemaster_backend_rpcapi.psgi';
 install_script 'zonemaster_backend_testagent';
+install_script 'zmtest';
+install_script 'zmb';
 
 no_index directory => 'CodeSnippets';
 no_index directory => 'Doc';

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -676,7 +676,7 @@ If you have followed the installation instructions for Zonemaster::Backend above
 you should be able to use the API on localhost port 5000 as below.
 
 ```sh
-`zmtest zonemaster.net
+zmtest zonemaster.net
 ```
 
 The command is expected to immediately print out a testid,

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -56,16 +56,10 @@ for Zonemaster::Backend, see the [declaration of prerequisites].
 > **Note:** Zonemaster::LDNS and Zonemaster::Engine are not listed here as they
 > are dealt with in the [prerequisites](#prerequisites) section.
 
-Optionally install jq (only needed for the post-installation smoke test):
-
-```sh
-sudo yum install jq
-```
-
 Install dependencies available from binary packages:
 
 ```sh
-sudo yum install perl-Class-Method-Modifiers perl-Config-IniFiles perl-JSON-RPC perl-Module-Install perl-Parallel-ForkManager perl-Plack perl-Router-Simple perl-String-ShellQuote perl-Net-Server perl-Role-Tiny redhat-lsb-core
+sudo yum install jq perl-Class-Method-Modifiers perl-Config-IniFiles perl-JSON-RPC perl-Module-Install perl-Parallel-ForkManager perl-Plack perl-Router-Simple perl-String-ShellQuote perl-Net-Server perl-Role-Tiny redhat-lsb-core
 ```
 *  Only for CentOS 7 *
 
@@ -330,12 +324,6 @@ See the [post-installation] section for post-installation matters.
 > **Note:** Zonemaster::LDNS and Zonemaster::Engine are not listed here as they
 > are dealt with in the [prerequisites](#prerequisites) section.
 
-Optionally install Curl and jq (only needed for the post-installation smoke test):
-
-```sh
-sudo apt install curl jq
-```
-
 Install required locales:
 
 ```sh
@@ -350,7 +338,7 @@ sudo locale-gen
 Install dependencies available from binary packages:
 
 ```sh
-sudo apt install libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libjson-pp-perl libjson-rpc-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtry-tiny-perl starman
+sudo apt install jq libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libjson-pp-perl libjson-rpc-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtry-tiny-perl starman
 ```
 
 Install dependencies not available from binary packages:
@@ -510,16 +498,10 @@ su -l
 Install dependencies available from binary packages:
 
 ```sh
-pkg install p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote p5-DBD-SQLite p5-Log-Dispatch p5-Log-Any p5-Log-Any-Adapter-Dispatch p5-JSON-Validator p5-YAML-LibYAML
+pkg install jq p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote p5-DBD-SQLite p5-Log-Dispatch p5-Log-Any p5-Log-Any-Adapter-Dispatch p5-JSON-Validator p5-YAML-LibYAML
 ```
 <!-- JSON::Validator requires YAML::PP, but p5-JSON-Validator currently lacks a dependency on p5-YAML-LibYAML -->
 
-
-Optionally install Curl and jq (only needed for the post-installation smoke test):
-
-```sh
-pkg install curl jq
-```
 
 Install Zonemaster::Backend:
 
@@ -691,12 +673,10 @@ Use the procedure for installation on [Debian](#4-installation-on-debian).
 ### 7.1 Smoke test
 
 If you have followed the installation instructions for Zonemaster::Backend above,
-you should be able to use the
-API on localhost port 5000 as below. The command requires that `curl` and `jq` are installed.
-
+you should be able to use the API on localhost port 5000 as below.
 
 ```sh
-`perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`/zmtest zonemaster.net
+`zmtest zonemaster.net
 ```
 
 The command is expected to immediately print out a testid,

--- a/script/zmb
+++ b/script/zmb
@@ -20,6 +20,8 @@ Zmb is meant to be pronounced I<Zimba>.
 
 zmb [GLOBAL OPTIONS] COMMAND [OPTIONS]
 
+This interface is unstable and will change in a future release.
+
 =head1 GLOBAL OPTIONS
 
  --help         Show usage

--- a/script/zmtest
+++ b/script/zmtest
@@ -11,6 +11,8 @@ usage () {
     printf "%s" "${message}" >&2
     echo "Usage: zmtest [OPTIONS] DOMAIN" >&2
     echo >&2
+    echo "This interface is unstable and may change in a future release." >&2
+    echo >&2
     echo "Options:" >&2
     echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
     echo "  --noipv4              Run the test without ipv4." >&2


### PR DESCRIPTION
Solves #687.

Since the tools are being properly installed the dependencies that needs to be reflected in the dependencies. AFAICT we don't depend on curl anymore, so I'm removing that from the installation instruction. The GettingStarted document still uses curl but it has a separate note about installing it so we shouldn't need to consider that in the installation instruction.