### PR TITLE
Deprecate force_hash_id_use_in_API_starting_from_id

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -193,6 +193,8 @@ used -> todo
 
 ### force_hash_id_use_in_API_starting_from_id
 
+> **Deprecated**
+
 This parameter determines if it is possible to get the test results
 using an incremental numeric id (allowing easy enumeration of the whole
 database of results) or if a half-md5 hash id should be used instead. If


### PR DESCRIPTION
Deprecate `force_hash_id_use_in_API_starting_from_id` in preparation for #691.