### PR TITLE
Fixes correct start order at start-up

### DIFF
--- a/share/zm_testagent-bsd
+++ b/share/zm_testagent-bsd
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # PROVIDE: zm_testagent
-# REQUIRE: mysql postgresql
+# REQUIRE: NETWORKING mysql postgresql
 # KEYWORD: shutdown
 
 . /etc/rc.subr


### PR DESCRIPTION
When backend uses SQLite the rc system places zm_testagent to be started before the network, which does not work well, and testagent does not get started. This PR requires the network to be up before zm_testagent is run.