### PR TITLE
SQLite: harmonize get_test_history with MySQL and PostgreSQL

### DIFF
--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -311,7 +311,8 @@ sub get_test_history {
                     id,
                     hash_id,
                     creation_time,
-                    params
+                    params,
+                    results
                  FROM
                     test_results
                  WHERE
@@ -322,7 +323,6 @@ sub get_test_history {
     $sth1->execute;
     while ( my $h = $sth1->fetchrow_hashref ) {
         $h->{results} = decode_json($h->{results}) if $h->{results};
-        $h->{params} = decode_json($h->{params}) if $h->{params};
         my $critical = ( grep { $_->{level} eq 'CRITICAL' } @{ $h->{results} } );
         my $error    = ( grep { $_->{level} eq 'ERROR' } @{ $h->{results} } );
         my $warning  = ( grep { $_->{level} eq 'WARNING' } @{ $h->{results} } );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -296,6 +296,8 @@ sub get_test_history {
 
     my @results;
 
+    my $use_hash_id_from_id = $self->config->force_hash_id_use_in_API_starting_from_id();
+
     my $undelegated = "";
     if ($p->{filter} eq "undelegated") {
         $undelegated = "AND (params->'nameservers') IS NOT NULL";
@@ -307,6 +309,7 @@ sub get_test_history {
     $quoted_domain =~ s/'/"/g;
     my $query = "SELECT
                     id,
+                    hash_id,
                     creation_time,
                     params
                  FROM
@@ -319,7 +322,11 @@ sub get_test_history {
     $sth1->execute;
     while ( my $h = $sth1->fetchrow_hashref ) {
         push( @results,
-            { id => $h->{id}, creation_time => $h->{creation_time} } );
+            {
+                id               => ($h->{id} > $use_hash_id_from_id)?($h->{hash_id}):($h->{id}),
+                creation_time    => $h->{creation_time},
+            }
+        );
     }
     $sth1->finish;
 


### PR DESCRIPTION
Currently SQLite `get_test_history` does not behave exactly as the MySQL and PostgreSQL equivalent functions.

This PR fixes that :

 * the return `id` is now either the `hash_id` or the `id` based on `force_hash_id_use_in_API_starting_from_id` parameter in the config file
 * `overall_result` is now present in the output

There is an issue #691 currently discussing on a possible removal of `force_hash_id_use_in_API_starting_from_id`. This PR adds it in SQLite to offer the same behavior as with other databases (and because of another PR to add SQLite to `t/test_DB_backend.pl` - #716).