### PR TITLE
Support SQLite in t/test_DB_backend.pl

### DIFF
--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -56,7 +56,7 @@ sub run_zonemaster_test_with_backend_API {
     foreach my $i ( 1 .. 12 ) {
         sleep( 5 );
         my $progress = $engine->test_progress( $api_test_id );
-        diag "pregress: $progress";
+        diag "progress: $progress";
         last if ( $progress == 100 );
     }
     ok( $engine->test_progress( $api_test_id ) == 100 , 'API test_progress -> Test finished' );

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -7,7 +7,7 @@ use JSON::PP;
 use Test::Exception;
 
 my $db_backend = $ARGV[0] // BAIL_OUT( "No database backend specified" );
-( $db_backend eq 'PostgreSQL' || $db_backend eq 'MySQL' ) or BAIL_OUT( "Unsupported database backend: $db_backend" );
+( $db_backend eq 'SQLite' || $db_backend eq 'PostgreSQL' || $db_backend eq 'MySQL' ) or BAIL_OUT( "Unsupported database backend: $db_backend" );
 
 my $frontend_params_1 = {
     client_id      => "$db_backend Unit Test",         # free string
@@ -83,7 +83,7 @@ my $user_check_query;
 if ($db_backend eq 'PostgreSQL') {
     $user_check_query = q/SELECT * FROM users WHERE user_info->>'username' = 'zonemaster_test'/;
 }
-elsif ($db_backend eq 'MySQL') {
+else {
     $user_check_query = q/SELECT * FROM users WHERE username = 'zonemaster_test'/;
 }
 

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -10,17 +10,17 @@ my $db_backend = $ARGV[0] // BAIL_OUT( "No database backend specified" );
 ( $db_backend eq 'PostgreSQL' || $db_backend eq 'MySQL' ) or BAIL_OUT( "Unsupported database backend: $db_backend" );
 
 my $frontend_params_1 = {
-	client_id      => "$db_backend Unit Test",         # free string
-	client_version => '1.0',               # free version like string
-	domain         => 'afnic.fr',          # content of the domain text field
-	ipv4           => JSON::PP::true,                   # 0 or 1, is the ipv4 checkbox checked
-	ipv6           => JSON::PP::true,                   # 0 or 1, is the ipv6 checkbox checked
-	profile        => 'default',    # the id if the Test profile listbox
+    client_id      => "$db_backend Unit Test",         # free string
+    client_version => '1.0',               # free version like string
+    domain         => 'afnic.fr',          # content of the domain text field
+    ipv4           => JSON::PP::true,                   # 0 or 1, is the ipv4 checkbox checked
+    ipv6           => JSON::PP::true,                   # 0 or 1, is the ipv6 checkbox checked
+    profile        => 'default',    # the id if the Test profile listbox
 
-	nameservers => [                       # list of the nameserves up to 32
-		{ ns => 'ns1.nic.fr', ip => '1.1.1.1' },       # key values pairs representing nameserver => namesterver_ip
-		{ ns => 'ns2.nic.fr', ip => '192.134.4.1' },
-	],
+    nameservers => [                       # list of the nameserves up to 32
+        { ns => 'ns1.nic.fr', ip => '1.1.1.1' },       # key values pairs representing nameserver => namesterver_ip
+        { ns => 'ns2.nic.fr', ip => '192.134.4.1' },
+    ],
     ds_info => [                                  # list of DS/Digest pairs up to 32
         { keytag => 11627, algorithm => 8, digtype => 2, digest => 'a6cca9e6027ecc80ba0f6d747923127f1d69005fe4f0ec0461bd633482595448' },
     ],
@@ -32,9 +32,9 @@ my $engine = Zonemaster::Backend::RPCAPI->new( { db => "Zonemaster::Backend::DB:
 isa_ok( $engine, 'Zonemaster::Backend::RPCAPI' );
 
 sub run_zonemaster_test_with_backend_API {
-	my ($test_id) = @_;
+    my ($test_id) = @_;
     # add a new test to the db
-    
+
     my $api_test_id = $engine->start_domain_test( $frontend_params_1 );
     ok( $api_test_id eq $test_id || length($api_test_id) == 16 , 'API start_domain_test -> Call OK' );
     ok( scalar( $engine->{db}->dbh->selectrow_array( qq/SELECT id FROM test_results WHERE id=$test_id/ ) ) eq $test_id , 'API start_domain_test -> Test inserted in the DB' );
@@ -44,11 +44,11 @@ sub run_zonemaster_test_with_backend_API {
     # test test_progress API
     ok( $engine->test_progress( $api_test_id ) == 0 , 'API test_progress -> OK');
 
-	use_ok( 'Zonemaster::Backend::Config' );
-	my $config = Zonemaster::Backend::Config->load_config();
-	
+    use_ok( 'Zonemaster::Backend::Config' );
+    my $config = Zonemaster::Backend::Config->load_config();
+
     use_ok( 'Zonemaster::Backend::TestAgent' );
-	Zonemaster::Backend::TestAgent->new( { db => "Zonemaster::Backend::DB::$db_backend", config => $config } )->run( $api_test_id );
+    Zonemaster::Backend::TestAgent->new( { db => "Zonemaster::Backend::DB::$db_backend", config => $config } )->run( $api_test_id );
 
     sleep( 5 );
     ok( $engine->test_progress( $api_test_id ) > 0 , 'API test_progress -> Test started');
@@ -81,18 +81,19 @@ ok( $engine->add_api_user( { username => "zonemaster_test", api_key => "zonemast
 
 my $user_check_query;
 if ($db_backend eq 'PostgreSQL') {
-	$user_check_query = q/SELECT * FROM users WHERE user_info->>'username' = 'zonemaster_test'/;
+    $user_check_query = q/SELECT * FROM users WHERE user_info->>'username' = 'zonemaster_test'/;
 }
 elsif ($db_backend eq 'MySQL') {
-	$user_check_query = q/SELECT * FROM users WHERE username = 'zonemaster_test'/;
+    $user_check_query = q/SELECT * FROM users WHERE username = 'zonemaster_test'/;
 }
 
 ok(
-	scalar(
-		$engine->{db}
-			->dbh->selectrow_array( $user_check_query )
-	) == 1
+    scalar(
+        $engine->{db}
+            ->dbh->selectrow_array( $user_check_query )
+    ) == 1
 , 'API add_api_user user created' );
+
 
 run_zonemaster_test_with_backend_API(1);
 $frontend_params_1->{ipv6} = 0;
@@ -101,11 +102,10 @@ run_zonemaster_test_with_backend_API(2);
 my $offset = 0;
 my $limit  = 10;
 my $test_history =
-	$engine->get_test_history( { frontend_params => $frontend_params_1, offset => $offset, limit => $limit } );
+    $engine->get_test_history( { frontend_params => $frontend_params_1, offset => $offset, limit => $limit } );
 diag explain( $test_history );
 ok( scalar( @$test_history ) == 2 );
 ok( $test_history->[0]->{id} eq '1' || $test_history->[1]->{id} eq '1' );
 ok( length($test_history->[0]->{id}) == 16 || length($test_history->[1]->{id}) == 16 );
 
 done_testing();
-


### PR DESCRIPTION
Allow SQLite as database in the `test_DB_backend.pl` script. This requires some small fixes in the code.
In order to make all test pass, this PR requires #715 (and the use of parameter `force_hash_id_use_in_API_starting_from_id`).

_Remark:_ this PR contains a commit (51de4b1) that reformats the code (replace tabs with spaces and remove trailing spaces).