### PR TITLE
Load ini file at RPCAPI and TestAgent startup only

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -7,6 +7,9 @@ Zonemaster *Backend* is configured in
 
 Each section in `backend_config.ini` is documented below.
 
+Restart the `zm-rpcapi` and `zm-testagent` daemons to load the changes
+made to the `backend_config.ini` file.
+
 ## DB section
 
 The DB section has a number of keys.

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -40,22 +40,34 @@ sub load_config {
     return $self;
 }
 
+sub check_db {
+    my ( $self, $db ) = @_;
+
+    if ( lc $db eq 'sqlite' ) {
+        return 'SQLite';
+    }
+    elsif ( lc $db eq 'postgresql' ) {
+        return 'PostgreSQL';
+    }
+    elsif ( lc $db eq 'mysql' ) {
+        return 'MySQL';
+    }
+    else {
+        die "Unknown database '$db', should be one of SQLite, MySQL or PostgreSQL\n";
+    }
+}
+
 sub BackendDBType {
     my ($self) = @_;
 
     my $engine = $self->{cfg}->val( 'DB', 'engine' );
-    if ( lc $engine eq 'sqlite' ) {
-        return 'SQLite';
-    }
-    elsif ( lc $engine eq 'postgresql' ) {
-        return 'PostgreSQL';
-    }
-    elsif ( lc $engine eq 'mysql' ) {
-        return 'MySQL';
-    }
-    else {
+    eval {
+        $engine = $self->check_db($engine);
+    };
+    if ($@) {
         die "Unknown config value DB.engine: $engine\n";
     }
+    return $engine;
 }
 
 sub DB_user {
@@ -346,6 +358,13 @@ sub ListPublicProfiles {
     return keys %$profiles;
 }
 
+=head2 check_db
+
+Returns a normalized string based on the supported databases.
+
+=head3 EXCEPTION
+
+Dies if the value is not one of SQLite, PostgreSQL or MySQL.
 
 =head2 BackendDBType
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -57,18 +57,24 @@ sub new {
         }
     }
     else {
-        eval {
-            my $backend_module = "Zonemaster::Backend::DB::" . $self->{config}->BackendDBType();
-            eval "require $backend_module";
-            die "$@ \n" if $@;
-            $self->{db} = $backend_module->new( { config => $self->{config} } );
-        };
-        if ($@) {
-            handle_exception('new', "Failed to initialize the [$params->{db}] database backend module: [$@]", '002');
-        }
+        $self->_init_db($self->{config}->BackendDBType());
     }
 
     return ( $self );
+}
+
+sub _init_db {
+    my ( $self, $dbtype ) = @_;
+
+    eval {
+        my $backend_module = "Zonemaster::Backend::DB::" . $dbtype;
+        eval "require $backend_module";
+        die "$@ \n" if $@;
+        $self->{db} = $backend_module->new( { config => $self->{config} } );
+    };
+    if ($@) {
+        handle_exception('_init_db', "Failed to initialize the [$dbtype] database backend module: [$@]", '002');
+    }
 }
 
 sub handle_exception {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -46,7 +46,7 @@ sub new {
 
     $self->{config} = $params->{config};
 
-    if ( $params && $params->{db} ) {
+    if ( $params->{db} ) {
         eval {
             eval "require $params->{db}";
             die "$@ \n" if $@;

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -40,13 +40,13 @@ sub new {
     my $self = {};
     bless( $self, $type );
 
-    my $config = Zonemaster::Backend::Config->load_config();
+    $self->{config} = Zonemaster::Backend::Config->load_config();
 
     if ( $params && $params->{db} ) {
         eval {
             eval "require $params->{db}";
             die "$@ \n" if $@;
-            $self->{db} = "$params->{db}"->new( { config => $config } );
+            $self->{db} = "$params->{db}"->new( { config => $self->{config} } );
         };
         if ($@) {
             handle_exception('new', "Failed to initialize the [$params->{db}] database backend module: [$@]", '001');
@@ -54,10 +54,10 @@ sub new {
     }
     else {
         eval {
-            my $backend_module = "Zonemaster::Backend::DB::" . $config->BackendDBType();
+            my $backend_module = "Zonemaster::Backend::DB::" . $self->{config}->BackendDBType();
             eval "require $backend_module";
             die "$@ \n" if $@;
-            $self->{db} = $backend_module->new( { config => $config } );
+            $self->{db} = $backend_module->new( { config => $self->{config} } );
         };
         if ($@) {
             handle_exception('new', "Failed to initialize the [$params->{db}] database backend module: [$@]", '002');

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -46,14 +46,15 @@ sub new {
 
     $self->{config} = $params->{config};
 
-    if ( $params->{db} ) {
+    if ( $params->{dbtype} ) {
         eval {
-            eval "require $params->{db}";
+            my $backend_module = "Zonemaster::Backend::DB::" . $params->{dbtype};
+            eval "require $backend_module";
             die "$@ \n" if $@;
-            $self->{db} = "$params->{db}"->new( { config => $self->{config} } );
+            $self->{db} = $backend_module->new( { config => $self->{config} } );
         };
         if ($@) {
-            handle_exception('new', "Failed to initialize the [$params->{db}] database backend module: [$@]", '001');
+            handle_exception('new', "Failed to initialize the [$params->{dbtype}] database backend module: [$@]", '001');
         }
     }
     else {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -89,7 +89,7 @@ sub version_info {
     if ($@) {
         handle_exception('version_info', $@, '003');
     }
-    
+
     return \%ver;
 }
 
@@ -105,7 +105,7 @@ sub profile_names {
     if ($@) {
         handle_exception('profile_names', $@, '004');
     }
-    
+
     return \@profiles;
 }
 
@@ -136,7 +136,7 @@ sub get_host_by_name {
     if ($@) {
         handle_exception('get_host_by_name', $@, '005');
     }
-    
+
     return \@adresses;
 }
 
@@ -148,7 +148,7 @@ sub get_data_from_parent_zone {
     my $domain = "";
 
     my $result = eval {
-		my %result;
+        my %result;
         if (ref \$params eq "SCALAR") {
             $domain = $params;
         } else {
@@ -179,13 +179,13 @@ sub get_data_from_parent_zone {
 
         $result{ns_list} = \@ns_list;
         $result{ds_list} = \@ds_list;
-		return \%result;
+        return \%result;
     };
     if ($@) {
         handle_exception('get_data_from_parent_zone', $@, '006');
     }
     elsif ($result) {
-		return $result;
+        return $result;
     }
 }
 
@@ -238,9 +238,9 @@ sub _check_domain {
         handle_exception('_check_domain', $@, '007');
     }
     elsif ($result) {
-		return $result;
+        return $result;
     }
-    
+
     my %levels = Zonemaster::Engine::Logger::Entry::levels();
     my @res;
     @res = Zonemaster::Engine::Test::Basic->basic00($dn);
@@ -409,7 +409,7 @@ $json_schemas{test_progress} = joi->object->strict->props(
 );
 sub test_progress {
     my ( $self, $params ) = @_;
-    
+
     my $result = 0;
     eval {
         my $test_id = "";
@@ -642,7 +642,7 @@ sub get_batch_job_result {
     my ( $self, $params ) = @_;
 
     my $result;
-    
+
     eval {
         my $batch_id = $params->{"batch_id"};
 
@@ -651,7 +651,7 @@ sub get_batch_job_result {
     if ($@) {
         handle_exception('get_batch_job_result', $@, '016');
     }
-    
+
     return $result;
 }
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -104,7 +104,7 @@ sub profile_names {
 
     my @profiles;
     eval {
-        @profiles = Zonemaster::Backend::Config->load_config()->ListPublicProfiles();
+        @profiles = $self->{config}->ListPublicProfiles();
 
     };
     if ($@) {
@@ -120,7 +120,7 @@ $json_schemas{get_language_tags} = joi->object->strict;
 sub get_language_tags {
     my ( $self ) = @_;
 
-    my @lang = Zonemaster::Backend::Config->load_config()->ListLanguageTags();
+    my @lang = $self->{config}->ListLanguageTags();
 
     return \@lang;
 }
@@ -304,7 +304,7 @@ sub validate_syntax {
         }
 
         if ( defined $syntax_input->{profile} ) {
-            my @profiles = map lc, Zonemaster::Backend::Config->load_config()->ListPublicProfiles();
+            my @profiles = map lc, $self->{config}->ListPublicProfiles();
             return { status => 'nok', message => encode_entities( "Invalid profile option format" ) }
             unless ( grep { $_ eq lc $syntax_input->{profile} } @profiles );
         }
@@ -393,12 +393,12 @@ sub start_domain_test {
 
         if ($params->{config}) {
             $params->{config} =~ s/[^\w_]//isg;
-            die "Unknown test configuration: [$params->{config}]\n" unless ( Zonemaster::Backend::Config->load_config()->GetCustomConfigParameter('ZONEMASTER', $params->{config}) );
+            die "Unknown test configuration: [$params->{config}]\n" unless ( $self->{config}->GetCustomConfigParameter('ZONEMASTER', $params->{config}) );
         }
 
         $params->{priority}  //= 10;
         $params->{queue}     //= 0;
-        my $minutes_between_tests_with_same_params = Zonemaster::Backend::Config->load_config()->age_reuse_previous_test();
+        my $minutes_between_tests_with_same_params = $self->{config}->age_reuse_previous_test();
 
         $result = $self->{db}->create_new_test( $params->{domain}, $params, $minutes_between_tests_with_same_params );
     };
@@ -464,7 +464,7 @@ sub get_test_results {
     my $translator;
     $translator = Zonemaster::Backend::Translator->new;
 
-    my %locale = Zonemaster::Backend::Config->load_config()->Language_Locale_hash();
+    my %locale = $self->{config}->Language_Locale_hash();
     if ( $locale{$params->{language}} ) {
         if ( $locale{$params->{language}} eq 'NOT-UNIQUE') {
             die "Language string not unique: '$params->{language}'\n";

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -47,14 +47,16 @@ sub new {
     $self->{config} = $params->{config};
 
     if ( $params->{dbtype} ) {
+        my $dbtype = $self->{config}->check_db($params->{dbtype});
+
         eval {
-            my $backend_module = "Zonemaster::Backend::DB::" . $params->{dbtype};
+            my $backend_module = "Zonemaster::Backend::DB::" . $dbtype;
             eval "require $backend_module";
             die "$@ \n" if $@;
             $self->{db} = $backend_module->new( { config => $self->{config} } );
         };
         if ($@) {
-            handle_exception('new', "Failed to initialize the [$params->{dbtype}] database backend module: [$@]", '001');
+            handle_exception('new', "Failed to initialize the [$dbtype] database backend module: [$@]", '001');
         }
     }
     else {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -46,22 +46,14 @@ sub new {
 
     $self->{config} = $params->{config};
 
+    my $dbtype;
     if ( $params->{dbtype} ) {
-        my $dbtype = $self->{config}->check_db($params->{dbtype});
+        $dbtype = $self->{config}->check_db($params->{dbtype});
+    } else {
+        $dbtype = $self->{config}->BackendDBType();
+    }
 
-        eval {
-            my $backend_module = "Zonemaster::Backend::DB::" . $dbtype;
-            eval "require $backend_module";
-            die "$@ \n" if $@;
-            $self->{db} = $backend_module->new( { config => $self->{config} } );
-        };
-        if ($@) {
-            handle_exception('new', "Failed to initialize the [$dbtype] database backend module: [$@]", '001');
-        }
-    }
-    else {
-        $self->_init_db($self->{config}->BackendDBType());
-    }
+    $self->_init_db($dbtype);
 
     return ( $self );
 }

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -41,7 +41,7 @@ sub new {
     bless( $self, $type );
 
     if ( ! $params || ! $params->{config} ) {
-        handle_exception('new', "Missing 'config' parameter", '000');
+        handle_exception('new', "Missing 'config' parameter", '001');
     }
 
     $self->{config} = $params->{config};

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -40,7 +40,11 @@ sub new {
     my $self = {};
     bless( $self, $type );
 
-    $self->{config} = Zonemaster::Backend::Config->load_config();
+    if ( ! $params || ! $params->{config} ) {
+        handle_exception('new', "Missing 'config' parameter", '000');
+    }
+
+    $self->{config} = $params->{config};
 
     if ( $params && $params->{db} ) {
         eval {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -95,7 +95,7 @@ sub version_info {
 
 $json_schemas{profile_names} = joi->object->strict;
 sub profile_names {
-    my ($self) = @_;
+    my ( $self ) = @_;
 
     my @profiles;
     eval {
@@ -113,7 +113,7 @@ sub profile_names {
 # derived from the locale tags set in the configuration file.
 $json_schemas{get_language_tags} = joi->object->strict;
 sub get_language_tags {
-    my ($self) = @_;
+    my ( $self ) = @_;
 
     my @lang = Zonemaster::Backend::Config->load_config()->ListLanguageTags();
 
@@ -419,7 +419,6 @@ sub test_progress {
             $test_id = $params->{"test_id"};
         }
 
-
         $result = $self->{db}->test_progress( $test_id );
     };
     if ($@) {
@@ -434,6 +433,7 @@ $json_schemas{get_test_params} = joi->object->strict->props(
 );
 sub get_test_params {
     my ( $self, $params ) = @_;
+
     my $test_id = $params->{"test_id"};
 
     my $result = 0;
@@ -548,16 +548,16 @@ $json_schemas{get_test_history} = joi->object->strict->props(
     )->required
 );
 sub get_test_history {
-    my ( $self, $p ) = @_;
+    my ( $self, $params ) = @_;
 
     my $results;
 
     eval {
-        $p->{offset} //= 0;
-        $p->{limit} //= 200;
-        $p->{filter} //= "all";
+        $params->{offset} //= 0;
+        $params->{limit} //= 200;
+        $params->{filter} //= "all";
 
-        $results = $self->{db}->get_test_history( $p );
+        $results = $self->{db}->get_test_history( $params );
     };
     if ($@) {
         handle_exception('get_test_history', $@, '013');
@@ -571,7 +571,7 @@ $json_schemas{add_api_user} = joi->object->strict->props(
     api_key => $zm_validator->api_key->required,
 );
 sub add_api_user {
-    my ( $self, $p, undef, $remote_ip ) = @_;
+    my ( $self, $params, undef, $remote_ip ) = @_;
 
     my $result = 0;
 
@@ -585,7 +585,7 @@ sub add_api_user {
         }
 
         if ( $allow ) {
-            $result = 1 if ( $self->{db}->add_api_user( $p->{username}, $p->{api_key} ) eq '1' );
+            $result = 1 if ( $self->{db}->add_api_user( $params->{username}, $params->{api_key} ) eq '1' );
         }
     };
     if ($@) {

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -34,7 +34,7 @@ sub new {
         eval "require $backend_module";
         $self->{db} = $backend_module->new( { config => $self->{config} } );
     }
-        
+
     $self->{profiles} = $self->{config}->ReadProfilesInfo();
     foreach my $profile (keys %{$self->{profiles}}) {
         die "default profile cannot be private" if ($profile eq 'default' && $self->{profiles}->{$profile}->{type} eq 'private');
@@ -129,7 +129,7 @@ sub run {
     if ( $params->{ds_info} && @{ $params->{ds_info} } > 0 ) {
         $self->add_fake_ds( $domain, $params->{ds_info} );
     }
-    
+
 
     # If the profile parameter has been set in the API, then load a profile
     if ( $params->{profile} ) {
@@ -200,7 +200,7 @@ sub add_fake_delegation {
             $data{ $self->to_idn( $ns ) } = undef;
         }
     }
-    
+
     Zonemaster::Engine->add_fake_delegation( $domain => \%data );
 
     return;

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -21,13 +21,11 @@ sub new {
     my ( $class, $params ) = @_;
     my $self = {};
 
-    if ( $params && $params->{config} ) {
-        $self->{config} = $params->{config};
+    if ( ! $params || ! $params->{config} ) {
+        die "missing 'config' parameter";
     }
 
-    if ( $params && $params->{db} ) {
-        eval "require $params->{db}";
-        $self->{db} = "$params->{db}"->new( { config => $self->{config} } );
+    $self->{config} = $params->{config};
     }
     else {
         my $backend_module = "Zonemaster::Backend::DB::" . $self->{config}->BackendDBType();

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -29,11 +29,12 @@ sub new {
 
     my $dbtype;
     if ( $params->{dbtype} ) {
-        $dbtype = $params->{dbtype};
+        $dbtype = $self->{config}->check_db($params->{dbtype});
     }
     else {
         $dbtype = $self->{config}->BackendDBType();
     }
+
     my $backend_module = "Zonemaster::Backend::DB::" . $dbtype;
     eval "require $backend_module";
     $self->{db} = $backend_module->new( { config => $self->{config} } );

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -26,12 +26,16 @@ sub new {
     }
 
     $self->{config} = $params->{config};
+
+    my $backend_module;
+    if ( $params->{db} ) {
+        $backend_module = "$params->{db}";
     }
     else {
-        my $backend_module = "Zonemaster::Backend::DB::" . $self->{config}->BackendDBType();
-        eval "require $backend_module";
-        $self->{db} = $backend_module->new( { config => $self->{config} } );
+        $backend_module = "Zonemaster::Backend::DB::" . $self->{config}->BackendDBType();
     }
+    eval "require $backend_module";
+    $self->{db} = $backend_module->new( { config => $self->{config} } );
 
     $self->{profiles} = $self->{config}->ReadProfilesInfo();
     foreach my $profile (keys %{$self->{profiles}}) {

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -27,13 +27,14 @@ sub new {
 
     $self->{config} = $params->{config};
 
-    my $backend_module;
-    if ( $params->{db} ) {
-        $backend_module = "$params->{db}";
+    my $dbtype;
+    if ( $params->{dbtype} ) {
+        $dbtype = $params->{dbtype};
     }
     else {
-        $backend_module = "Zonemaster::Backend::DB::" . $self->{config}->BackendDBType();
+        $dbtype = $self->{config}->BackendDBType();
     }
+    my $backend_module = "Zonemaster::Backend::DB::" . $dbtype;
     eval "require $backend_module";
     $self->{db} = $backend_module->new( { config => $self->{config} } );
 

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -37,72 +37,75 @@ builder {
     };
 };
 
+my $config = Zonemaster::Backend::Config->load_config;
+my $handler = Zonemaster::Backend::RPCAPI->new( { config => $config } );
+
 my $router = router {
 ############## FRONTEND ####################
     connect "version_info" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "version_info"
     };
 
     connect "profile_names" => {
-                handler => "+Zonemaster::Backend::RPCAPI",
+                handler => $handler,
                 action => "profile_names"
         };
 
     connect "get_language_tags" => {
-                handler => "+Zonemaster::Backend::RPCAPI",
+                handler => $handler,
                 action => "get_language_tags"
         };
 
         connect "get_host_by_name" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "get_host_by_name"
     };
 
     connect "get_data_from_parent_zone" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "get_data_from_parent_zone"
     };
 
     connect "start_domain_test" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "start_domain_test"
     };
 
     connect "test_progress" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "test_progress"
     };
 
     connect "get_test_params" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "get_test_params"
     };
 
     connect "get_test_results" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "get_test_results"
     };
 
     connect "get_test_history" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "get_test_history"
     };
 
 ############ BATCH MODE ####################
 
     connect "add_api_user" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "add_api_user"
     };
 
     connect "add_batch_job" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "add_batch_job"
     };
 
     connect "get_batch_job_result" => {
-        handler => "+Zonemaster::Backend::RPCAPI",
+        handler => $handler,
         action => "get_batch_job_result"
     };
 };
@@ -160,7 +163,7 @@ sub {
           $res->body( encode_json($errors) );
           $res->finalize;
         } else {
-            $dispatch->handle_psgi($env, $env->{REMOTE_HOST} );
+            $dispatch->handle_psgi($env, $env->{REMOTE_HOST});
         }
     } else {
         $res = Plack::Response->new(200);

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -39,72 +39,72 @@ builder {
 
 my $router = router {
 ############## FRONTEND ####################
-	connect "version_info" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "version_info"
-	};
+    connect "version_info" => {
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "version_info"
+    };
 
-	connect "profile_names" => {
+    connect "profile_names" => {
                 handler => "+Zonemaster::Backend::RPCAPI",
                 action => "profile_names"
         };
 
-	connect "get_language_tags" => {
+    connect "get_language_tags" => {
                 handler => "+Zonemaster::Backend::RPCAPI",
                 action => "get_language_tags"
         };
 
         connect "get_host_by_name" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "get_host_by_name"
-	};
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "get_host_by_name"
+    };
 
-	connect "get_data_from_parent_zone" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "get_data_from_parent_zone"
-	};
+    connect "get_data_from_parent_zone" => {
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "get_data_from_parent_zone"
+    };
 
-	connect "start_domain_test" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "start_domain_test"
-	};
-	
-	connect "test_progress" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "test_progress"
-	};
-	
-	connect "get_test_params" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "get_test_params"
-	};
+    connect "start_domain_test" => {
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "start_domain_test"
+    };
 
-	connect "get_test_results" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "get_test_results"
-	};
+    connect "test_progress" => {
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "test_progress"
+    };
 
-	connect "get_test_history" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "get_test_history"
-	};
+    connect "get_test_params" => {
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "get_test_params"
+    };
+
+    connect "get_test_results" => {
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "get_test_results"
+    };
+
+    connect "get_test_history" => {
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "get_test_history"
+    };
 
 ############ BATCH MODE ####################
 
-	connect "add_api_user" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "add_api_user"
-	};
+    connect "add_api_user" => {
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "add_api_user"
+    };
 
-	connect "add_batch_job" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "add_batch_job"
-	};
+    connect "add_batch_job" => {
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "add_batch_job"
+    };
 
-	connect "get_batch_job_result" => {
-		handler => "+Zonemaster::Backend::RPCAPI",
-		action => "get_batch_job_result"
-	};
+    connect "get_batch_job_result" => {
+        handler => "+Zonemaster::Backend::RPCAPI",
+        action => "get_batch_job_result"
+    };
 };
 
 # Returns a Log::Any-compatible log level string, or throws an exception.
@@ -136,7 +136,7 @@ Log::Any::Adapter->set(
 );
 
 my $dispatch = JSON::RPC::Dispatch->new(
-	router => $router,
+    router => $router,
 );
 
 sub {

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -125,6 +125,8 @@ sub main {
     };
     local $SIG{TERM} = $catch_sigterm;
 
+    my $agent = Zonemaster::Backend::TestAgent->new( { config => $self->config } );
+
     while ( !$caught_sigterm ) {
         $self->pm->reap_finished_children();    # Reaps terminated child processes
         $self->pm->on_wait();                   # Sends SIGKILL to overdue child processes
@@ -136,8 +138,7 @@ sub main {
             $log->info( "Test found: $id" );
             if ( $self->pm->start( $id ) == 0 ) {    # Forks off child process
                 $log->info( "Test starting: $id" );
-                my $ta = Zonemaster::Backend::TestAgent->new( { config => $self->config } );
-                eval { $ta->run( $id ) };
+                eval { $agent->run( $id ) };
                 if ( $@ ) {
                     chomp $@;
                     $log->error( "Test died: $id: $@" );
@@ -145,7 +146,7 @@ sub main {
                 else {
                     $log->info( "Test completed: $id" );
                 }
-                $ta->reset();
+                $agent->reset();
                 $self->pm->finish;                   # Terminates child process
             }
         }

--- a/t/test01.t
+++ b/t/test01.t
@@ -32,7 +32,7 @@ my $config = Zonemaster::Backend::Config->load_config();
 # Create Zonemaster::Backend::RPCAPI object
 my $engine = Zonemaster::Backend::RPCAPI->new(
     {
-        db     => 'Zonemaster::Backend::DB::SQLite',
+        dbtype => 'SQLite',
         config => $config,
     }
 );
@@ -83,7 +83,7 @@ sub run_zonemaster_test_with_backend_API {
         Zonemaster::Engine->preload_cache( $datafile );
         Zonemaster::Engine->profile->set( q{no_network}, 1 );
     }
-    Zonemaster::Backend::TestAgent->new( { db => "Zonemaster::Backend::DB::SQLite", config => $config } )->run( $hash_id );
+    Zonemaster::Backend::TestAgent->new( { dbtype => "SQLite", config => $config } )->run( $hash_id );
 
     Zonemaster::Backend::TestAgent->reset() unless ( $ENV{ZONEMASTER_RECORD} );
 

--- a/t/test01.t
+++ b/t/test01.t
@@ -12,7 +12,7 @@ my $datafile = q{t/test01.data};
 if ( not $ENV{ZONEMASTER_RECORD} ) {
     die q{Stored data file missing} if not -r $datafile;
     Zonemaster::Engine->preload_cache( $datafile );
-	Zonemaster::Engine->profile->set( q{no_network}, 1 );
+    Zonemaster::Engine->profile->set( q{no_network}, 1 );
 }
 
 # The configuration file should be the default
@@ -66,41 +66,41 @@ my $frontend_params_1 = {
 };
 
 sub run_zonemaster_test_with_backend_API {
-	my ($test_id) = @_;
-	
-	my $hash_id;
-	ok( ($hash_id = $engine->start_domain_test( $frontend_params_1)) && $hash_id , "API start_domain_test OK/test_id=$test_id" );
-	ok( scalar( $engine->{db}->dbh->selectrow_array( qq/SELECT id FROM test_results WHERE id=$test_id/ ) ) == $test_id );
+    my ($test_id) = @_;
 
-	# test test_progress API
-	ok( $engine->test_progress( $hash_id ) == 0 );
+    my $hash_id;
+    ok( ($hash_id = $engine->start_domain_test( $frontend_params_1)) && $hash_id , "API start_domain_test OK/test_id=$test_id" );
+    ok( scalar( $engine->{db}->dbh->selectrow_array( qq/SELECT id FROM test_results WHERE id=$test_id/ ) ) == $test_id );
 
-	use_ok( 'Zonemaster::Backend::Config' );
+    # test test_progress API
+    ok( $engine->test_progress( $hash_id ) == 0 );
 
-	use_ok( 'Zonemaster::Backend::TestAgent' );
+    use_ok( 'Zonemaster::Backend::Config' );
 
-	if ( not $ENV{ZONEMASTER_RECORD} ) {
-		Zonemaster::Engine->preload_cache( $datafile );
-		Zonemaster::Engine->profile->set( q{no_network}, 1 );
-	}
-	Zonemaster::Backend::TestAgent->new( { db => "Zonemaster::Backend::DB::SQLite", config => $config } )->run( $hash_id );
+    use_ok( 'Zonemaster::Backend::TestAgent' );
 
-	Zonemaster::Backend::TestAgent->reset() unless ( $ENV{ZONEMASTER_RECORD} );
+    if ( not $ENV{ZONEMASTER_RECORD} ) {
+        Zonemaster::Engine->preload_cache( $datafile );
+        Zonemaster::Engine->profile->set( q{no_network}, 1 );
+    }
+    Zonemaster::Backend::TestAgent->new( { db => "Zonemaster::Backend::DB::SQLite", config => $config } )->run( $hash_id );
 
-	ok( $engine->test_progress( $hash_id ) > 0 );
+    Zonemaster::Backend::TestAgent->reset() unless ( $ENV{ZONEMASTER_RECORD} );
 
-	foreach my $i ( 1 .. 12 ) {
-		my $progress = $engine->test_progress( $hash_id );
-		last if ( $progress == 100 );
-	}
-	ok( $engine->test_progress( $hash_id ) == 100 );
+    ok( $engine->test_progress( $hash_id ) > 0 );
+
+    foreach my $i ( 1 .. 12 ) {
+        my $progress = $engine->test_progress( $hash_id );
+        last if ( $progress == 100 );
+    }
+    ok( $engine->test_progress( $hash_id ) == 100 );
 
         my $test_results = $engine->get_test_results( { id => $hash_id, language => 'fr_FR' } );
-	ok( defined $test_results->{id},                 'TEST1 $test_results->{id} defined' );
-	ok( defined $test_results->{params},             'TEST1 $test_results->{params} defined' );
-	ok( defined $test_results->{creation_time},      'TEST1 $test_results->{creation_time} defined' );
-	ok( defined $test_results->{results},            'TEST1 $test_results->{results} defined' );
-	ok( scalar( @{ $test_results->{results} } ) > 1, 'TEST1 got some results' );
+    ok( defined $test_results->{id},                 'TEST1 $test_results->{id} defined' );
+    ok( defined $test_results->{params},             'TEST1 $test_results->{params} defined' );
+    ok( defined $test_results->{creation_time},      'TEST1 $test_results->{creation_time} defined' );
+    ok( defined $test_results->{results},            'TEST1 $test_results->{results} defined' );
+    ok( scalar( @{ $test_results->{results} } ) > 1, 'TEST1 got some results' );
 
         dies_ok { $engine->get_test_results( { id => $hash_id, language => 'fr-FR' } ); }
         'API get_test_results -> [results] parameter not present (wrong language tag)'; # Should be underscore, not hyphen.
@@ -114,11 +114,11 @@ $frontend_params_1->{ipv6} = 0;
 run_zonemaster_test_with_backend_API(2);
 
 if ( $ENV{ZONEMASTER_RECORD} ) {
-	Zonemaster::Engine->save_cache( $datafile );
+    Zonemaster::Engine->save_cache( $datafile );
 }
 done_testing();
 
 my $dbfile = 'zonemaster';
 if ( -e $dbfile and -M $dbfile < 0 and -o $dbfile ) {
-	unlink $dbfile;
+    unlink $dbfile;
 }

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -10,17 +10,17 @@ my $db_backend = $ARGV[0] // BAIL_OUT( "No database backend specified" );
 ( $db_backend eq 'PostgreSQL' || $db_backend eq 'MySQL' ) or BAIL_OUT( "Unsupported database backend: $db_backend" );
 
 my $frontend_params_1 = {
-	client_id      => "$db_backend Unit Test",         # free string
-	client_version => '1.0',               # free version like string
-	domain         => 'afnic.fr',          # content of the domain text field
-	ipv4           => JSON::PP::true,                   # 0 or 1, is the ipv4 checkbox checked
-	ipv6           => JSON::PP::true,                   # 0 or 1, is the ipv6 checkbox checked
-	profile        => 'default',    # the id if the Test profile listbox
+    client_id      => "$db_backend Unit Test",         # free string
+    client_version => '1.0',               # free version like string
+    domain         => 'afnic.fr',          # content of the domain text field
+    ipv4           => JSON::PP::true,                   # 0 or 1, is the ipv4 checkbox checked
+    ipv6           => JSON::PP::true,                   # 0 or 1, is the ipv6 checkbox checked
+    profile        => 'default',    # the id if the Test profile listbox
 
-	nameservers => [                       # list of the nameserves up to 32
-		{ ns => 'ns1.nic.fr', ip => '1.1.1.1' },       # key values pairs representing nameserver => namesterver_ip
-		{ ns => 'ns2.nic.fr', ip => '192.134.4.1' },
-	],
+    nameservers => [                       # list of the nameserves up to 32
+        { ns => 'ns1.nic.fr', ip => '1.1.1.1' },       # key values pairs representing nameserver => namesterver_ip
+        { ns => 'ns2.nic.fr', ip => '192.134.4.1' },
+    ],
     ds_info => [                                  # list of DS/Digest pairs up to 32
         { keytag => 11627, algorithm => 8, digtype => 2, digest => 'a6cca9e6027ecc80ba0f6d747923127f1d69005fe4f0ec0461bd633482595448' },
     ],
@@ -34,7 +34,7 @@ isa_ok( $engine, 'Zonemaster::Backend::RPCAPI' );
 sub run_zonemaster_test_with_backend_API {
     my ($test_id) = @_;
     # add a new test to the db
-    
+
     my $api_test_id = $engine->start_domain_test( $frontend_params_1 );
     ok( length($api_test_id) == 16 , 'API start_domain_test -> Call OK' );
 
@@ -45,7 +45,7 @@ sub run_zonemaster_test_with_backend_API {
 
     use_ok( 'Zonemaster::Backend::Config' );
     my $config = Zonemaster::Backend::Config->load_config();
-	
+
     use_ok( 'Zonemaster::Backend::TestAgent' );
     Zonemaster::Backend::TestAgent->new( { db => "Zonemaster::Backend::DB::$db_backend", config => $config } )->run( $api_test_id );
 
@@ -89,8 +89,8 @@ elsif ($db_backend eq 'MySQL') {
 ok(
     scalar(
         $engine->{db}
-			->dbh->selectrow_array( $user_check_query )
-	) == 1
+            ->dbh->selectrow_array( $user_check_query )
+    ) == 1
 , 'API add_api_user user created' );
 
 run_zonemaster_test_with_backend_API(1);
@@ -100,7 +100,7 @@ run_zonemaster_test_with_backend_API(2);
 my $offset = 0;
 my $limit  = 10;
 my $test_history =
-	$engine->get_test_history( { frontend_params => $frontend_params_1, offset => $offset, limit => $limit } );
+    $engine->get_test_history( { frontend_params => $frontend_params_1, offset => $offset, limit => $limit } );
 diag explain( $test_history );
 ok( scalar( @$test_history ) == 2, 'Two tests created' );
 

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -33,7 +33,7 @@ my $config = Zonemaster::Backend::Config->load_config();
 # Create Zonemaster::Backend::RPCAPI object
 my $engine = Zonemaster::Backend::RPCAPI->new(
     {
-        db     => 'Zonemaster::Backend::DB::' . "$db_backend",
+        dbtype => "$db_backend",
         config => $config,
     }
 );
@@ -55,7 +55,7 @@ sub run_zonemaster_test_with_backend_API {
     my $config = Zonemaster::Backend::Config->load_config();
 
     use_ok( 'Zonemaster::Backend::TestAgent' );
-    Zonemaster::Backend::TestAgent->new( { db => "Zonemaster::Backend::DB::$db_backend", config => $config } )->run( $api_test_id );
+    Zonemaster::Backend::TestAgent->new( { dbtype => "$db_backend", config => $config } )->run( $api_test_id );
 
     sleep( 5 );
     ok( $engine->test_progress( $api_test_id ) > 0 , 'API test_progress -> Test started');

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -27,8 +27,16 @@ my $frontend_params_1 = {
 };
 
 use_ok( 'Zonemaster::Backend::RPCAPI' );
+
+my $config = Zonemaster::Backend::Config->load_config();
+
 # Create Zonemaster::Backend::RPCAPI object
-my $engine = Zonemaster::Backend::RPCAPI->new( { db => "Zonemaster::Backend::DB::$db_backend" } );
+my $engine = Zonemaster::Backend::RPCAPI->new(
+    {
+        db     => 'Zonemaster::Backend::DB::' . "$db_backend",
+        config => $config,
+    }
+);
 isa_ok( $engine, 'Zonemaster::Backend::RPCAPI' );
 
 sub run_zonemaster_test_with_backend_API {

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -24,7 +24,7 @@ use_ok( 'Zonemaster::Backend::RPCAPI' );
 # Create Zonemaster::Backend::RPCAPI object
 my $engine = Zonemaster::Backend::RPCAPI->new(
     {
-        db     => 'Zonemaster::Backend::DB::SQLite',
+        dbtype => 'SQLite',
         config => Zonemaster::Backend::Config->load_config(),
     }
 );


### PR DESCRIPTION
This PR is about loading the `backend_config.ini` file only once, at daemon startup for RPCAPI and TestAgent.

* it makes mandatory to pass a `config ref` as parameter to each  RPCAPI and TestAgent constructor (die otherwise)
* use this `config ref` everywhere instead of loading a new config
* remove the possibility to pass and load a module from constructor parameter, add a layer to check the validity of the input and then import the module (or die)
* do some refactoring and code formatting

Addresses #651, #674

_Remark:_ one commit (fd7a7f3 ) is only about reformatting (replacing tabs by 4 spaces and removing trailing spaces) 


## How to test the PR

Before, the RPCAPI was loading the ini file on every API calls. This can be highlighted by running the following steps :

1. create a valid `backend_config.ini` file
2. start the daemons `rpcapi` and `testagent`
3. use `zmb` to load the available profiles
   ```
   $ zmb profile_names
   {"result":["default"],"jsonrpc":"2.0","id":1}
   ```
4. add a new profile to the `backend_config.ini` file :
   ```
   ...
   [PUBLIC PROFILES]
   dummy=/tmp/dummy-profile.json
   ...
   ```
5. run `zmb` again, and see this profile being listed
   ```
   $ zmb profile_names
   {"result":["default","dummy"],"jsonrpc":"2.0","id":1}
   ```

Now with this PR, steps 1 to 4 are the same, however the output from step 5 should be the same as the output in 3.
1. create a valid `backend_config.ini` file
2. **restart** the daemons `rpcapi` and `testagent`
3. use `zmb` to load the available profiles
4. add a new profile to the `backend_config.ini` file
5. run `zmb` again, and see the same output as in 3.
   ```
   $ zmb profile_names
   {"result":["default"],"jsonrpc":"2.0","id":1}
   ```
This can be tested with other parameters than a new profile entry (for instance removing a `locale`). Any modification of the `backend_config.ini` file should remain invisible to the TestAgent and the RPCAPI. Only restarting the daemons will apply the changes.


---
Edit :

* it is possible to pass the config reference to the constructor, see https://github.com/zonemaster/zonemaster-backend/pull/717#discussion_r594380960 and 06ef769 
* rebased and force pushed with [commit 6a12dea](#commits-pushed-6a12dea)
* removed the _work in progress_ statement
* updated PR description
* update commit ref after rebase
* added examples on how to test this PR