### PR TITLE
Fix unitialized value

### DIFF
--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -327,10 +327,11 @@ parameters can be when it is reused instead of starting a new test (default
 
 sub age_reuse_previous_test {
     my ($self) = @_;
-    my $val = $self->{cfg}->val( 'ZONEMASTER', 'age_reuse_previous_test' );
+    my $default = 600; # in seconds
+    my $val = $self->{cfg}->val( 'ZONEMASTER', 'age_reuse_previous_test', $default );
     $val = ($val > 0) ? $val : 0;
     $val = int ( ($val / 60) + 0.5); # in minutes
-    return ($val) ? $val : 10;
+    return $val;
 }
 
 


### PR DESCRIPTION
#692 adds a new parameter. However not specifying its value will give the following message in `t/test01.t` (see [Travis output from the PR](https://travis-ci.org/github/zonemaster/zonemaster-backend/jobs/761422347#L2269)) :

```
Use of uninitialized value $val in numeric gt (>) at /home/travis/build/zonemaster/zonemaster-backend/build_dir/lib/Zonemaster/Backend/Config.pm line 331.
```

This PR passes the default value (set to 600 seconds = 10 minutes) to the [`val()`](
https://metacpan.org/pod/Config::IniFiles#val-($section,-$parameter-%5B,-$default%5D-)) call if the the parameter `age_reuse_previous_test` does not exist.