### PR TITLE
Clean up commented out code

### DIFF
--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -39,8 +39,6 @@ sub dbh {
         my $connection_user     = $self->config->DB_user();
         my $connection_password = $self->config->DB_password();
         $dbh = DBI->connect( $connection_string, $connection_user, $connection_password, $connection_args );
-#        $dbh->{InactiveDestroy} = 1;
-# This line vas introduced to fix a non-trivial, hard to reproduce problem, it is causing giant memory leaks. It is kept here commented out for a while in case the initial problem occurs again.
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );
         return $dbh;


### PR DESCRIPTION
In may 2019 @sandoche2k said we should wait until the next release before removing this. I think it's safe to do it now.

Fixes #490.