### PR TITLE
Properly initialize SQLite handle

### DIFF
--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -36,6 +36,7 @@ sub BUILD {
 
         my $dbh = DBI->connect(
             $connection_string,
+            undef, undef,
             {
                 AutoCommit => 1,
                 RaiseError => 1,


### PR DESCRIPTION
This properly initialized the SQLite handle to throw exceptions on error instead of just setting $DBI::errstr and returning an error value.

Fixes #722.