### PR TITLE
Fix logical type errors

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -198,53 +198,42 @@ sub get_data_from_parent_zone {
 sub _check_domain {
     my ( $self, $dn, $type ) = @_;
 
-    ( $dn, my $result ) = eval {
-        if ( !defined( $dn ) ) {
-            return ( $dn, { status => 'nok', message => encode_entities( "$type required" ) } );
-        }
+    if ( !defined( $dn ) ) {
+        return ( $dn, { status => 'nok', message => encode_entities( "$type required" ) } );
+    }
 
-        if ( $dn =~ m/[^[:ascii:]]+/ ) {
-            if ( Zonemaster::LDNS::has_idn() ) {
-                eval { $dn = Zonemaster::LDNS::to_idn( $dn ); };
-                if ( $@ ) {
-                    return (
-                        $dn,
-                        {
-                            status  => 'nok',
-                            message => encode_entities( "The domain name is not a valid IDNA string and cannot be converted to an A-label" )
-                        }
-                    );
-                }
-            }
-            else {
+    if ( $dn =~ m/[^[:ascii:]]+/ ) {
+        if ( Zonemaster::LDNS::has_idn() ) {
+            eval { $dn = Zonemaster::LDNS::to_idn( $dn ); };
+            if ( $@ ) {
                 return (
                     $dn,
                     {
-                        status => 'nok',
-                        message =>
-                        encode_entities( "$type contains non-ascii characters and IDNA is not installed" )
+                        status  => 'nok',
+                        message => encode_entities( "The domain name is not a valid IDNA string and cannot be converted to an A-label" )
                     }
                 );
             }
         }
-
-        if( $dn !~ m/^[\-a-zA-Z0-9\.\_]+$/ ) {
+        else {
             return (
                 $dn,
                 {
-                status  => 'nok',
-                message => encode_entities( "The domain name character(s) not supported")
+                    status  => 'nok',
+                    message => encode_entities( "$type contains non-ascii characters and IDNA is not installed" )
                 }
             );
         }
-
-        return ( $dn, undef );
-    };
-    if ($@) {
-        handle_exception('_check_domain', $@, '007');
     }
-    elsif ($result) {
-		return ( $dn, $result );
+
+    if ( $dn !~ m/^[\-a-zA-Z0-9\.\_]+$/ ) {
+        return (
+            $dn,
+            {
+                status  => 'nok',
+                message => encode_entities( "The domain name character(s) not supported" )
+            }
+        );
     }
 
     my %levels = Zonemaster::Engine::Logger::Entry::levels();

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -238,6 +238,7 @@ sub _check_domain {
             );
         }
 
+        return ( $dn, undef );
     };
     if ($@) {
         handle_exception('_check_domain', $@, '007');

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -198,7 +198,7 @@ sub get_data_from_parent_zone {
 sub _check_domain {
     my ( $self, $dn, $type ) = @_;
 
-    my $result = eval {
+    ( $dn, my $result ) = eval {
         if ( !defined( $dn ) ) {
             return ( $dn, { status => 'nok', message => encode_entities( "$type required" ) } );
         }
@@ -243,7 +243,7 @@ sub _check_domain {
         handle_exception('_check_domain', $@, '007');
     }
     elsif ($result) {
-        return $result;
+		return ( $dn, $result );
     }
 
     my %levels = Zonemaster::Engine::Logger::Entry::levels();

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -196,18 +196,18 @@ sub get_data_from_parent_zone {
 
 
 sub _check_domain {
-    my ( $self, $dn, $type ) = @_;
+    my ( $self, $domain, $type ) = @_;
 
-    if ( !defined( $dn ) ) {
-        return ( $dn, { status => 'nok', message => encode_entities( "$type required" ) } );
+    if ( !defined( $domain ) ) {
+        return ( $domain, { status => 'nok', message => encode_entities( "$type required" ) } );
     }
 
-    if ( $dn =~ m/[^[:ascii:]]+/ ) {
+    if ( $domain =~ m/[^[:ascii:]]+/ ) {
         if ( Zonemaster::LDNS::has_idn() ) {
-            eval { $dn = Zonemaster::LDNS::to_idn( $dn ); };
+            eval { $domain = Zonemaster::LDNS::to_idn( $domain ); };
             if ( $@ ) {
                 return (
-                    $dn,
+                    $domain,
                     {
                         status  => 'nok',
                         message => encode_entities( "The domain name is not a valid IDNA string and cannot be converted to an A-label" )
@@ -217,7 +217,7 @@ sub _check_domain {
         }
         else {
             return (
-                $dn,
+                $domain,
                 {
                     status  => 'nok',
                     message => encode_entities( "$type contains non-ascii characters and IDNA is not installed" )
@@ -226,9 +226,9 @@ sub _check_domain {
         }
     }
 
-    if ( $dn !~ m/^[\-a-zA-Z0-9\.\_]+$/ ) {
+    if ( $domain !~ m/^[\-a-zA-Z0-9\.\_]+$/ ) {
         return (
-            $dn,
+            $domain,
             {
                 status  => 'nok',
                 message => encode_entities( "The domain name character(s) not supported" )
@@ -238,13 +238,13 @@ sub _check_domain {
 
     my %levels = Zonemaster::Engine::Logger::Entry::levels();
     my @res;
-    @res = Zonemaster::Engine::Test::Basic->basic00($dn);
+    @res = Zonemaster::Engine::Test::Basic->basic00( $domain );
     @res = grep { $_->numeric_level >= $levels{ERROR} } @res;
-    if (@res != 0) {
-        return ( $dn, { status => 'nok', message => encode_entities( "$type name or label is too long" ) } );
+    if ( @res != 0 ) {
+        return ( $domain, { status => 'nok', message => encode_entities( "$type name or label is too long" ) } );
     }
 
-    return ( $dn, { status => 'ok', message => 'Syntax ok' } );
+    return ( $domain, { status => 'ok', message => 'Syntax ok' } );
 }
 
 sub validate_syntax {
@@ -299,7 +299,7 @@ sub validate_syntax {
             unless ( grep { $_ eq lc $syntax_input->{profile} } @profiles );
         }
 
-        my ( $dn, $dn_syntax ) = $self->_check_domain( $syntax_input->{domain}, 'Domain name' );
+        my ( undef, $dn_syntax ) = $self->_check_domain( $syntax_input->{domain}, 'Domain name' );
 
         return $dn_syntax if ( $dn_syntax->{status} eq 'nok' );
 

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -40,55 +40,58 @@ $frontend_params->{nameservers} = [    # list of the namaserves up to 32
 	{ ns => 'ns2.nic.fr', ip => '192.134.4.1' },
 ];
 
-# domain present?
-$frontend_params->{domain} = 'afnic.fr';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', 'domain present' );
+subtest 'domain present' => sub {
+    $frontend_params->{domain} = 'afnic.fr';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok' );
+};
 
-# idn
-$frontend_params->{domain} = 'é';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[é]' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
+subtest 'idn domain=[é]' => sub {
+    $frontend_params->{domain} = 'é';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok' )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+};
 
-# idn
-$frontend_params->{domain} = 'éé';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[éé]' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
+subtest 'idn domain=[éé]' => sub {
+    $frontend_params->{domain} = 'éé';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok' )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+};
 
-# 253 characters long domain without dot
-$frontend_params->{domain} =
-'123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com';
-is(
-	$engine->validate_syntax( $frontend_params )->{status}, 'ok',
-	encode_utf8( '253 characters long domain without dot' )
-) or diag( $engine->validate_syntax( $frontend_params )->{message} );
+subtest '253 characters long domain without dot' => sub {
+    $frontend_params->{domain} =
+    '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com';
+    is(
+        $engine->validate_syntax( $frontend_params )->{status}, 'ok'
+    ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
+};
 
-# 254 characters long domain with trailing dot
-$frontend_params->{domain} =
-'123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.';
-is(
-	$engine->validate_syntax( $frontend_params )->{status}, 'ok',
-	encode_utf8( '254 characters long domain with trailing dot' )
-) or diag( $engine->validate_syntax( $frontend_params )->{message} );
+subtest '254 characters long domain with trailing dot' => sub {
+    $frontend_params->{domain} =
+    '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.';
+    is(
+        $engine->validate_syntax( $frontend_params )->{status}, 'ok'
+    ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
+};
 
-# 254 characters long domain without trailing
-$frontend_params->{domain} =
-'123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club';
-is(
-	$engine->validate_syntax( $frontend_params )->{status}, 'nok',
-	encode_utf8( '254 characters long domain without trailing dot' )
-) or diag( $engine->validate_syntax( $frontend_params )->{message} );
+subtest '254 characters long domain without trailing dot' => sub {
+    $frontend_params->{domain} =
+    '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club';
+    is(
+        $engine->validate_syntax( $frontend_params )->{status}, 'nok'
+    ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
+};
 
-# 63 characters long domain label
-$frontend_params->{domain} = '012345678901234567890123456789012345678901234567890123456789-63.fr';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok',
-	encode_utf8( '63 characters long domain label' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
+subtest '63 characters long domain label' => sub {
+    $frontend_params->{domain} = '012345678901234567890123456789012345678901234567890123456789-63.fr';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok' )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+};
 
-# 64 characters long domain label
-$frontend_params->{domain} = '012345678901234567890123456789012345678901234567890123456789--64.fr';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'nok',
-	encode_utf8( '64 characters long domain label' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
+subtest '64 characters long domain label' => sub {
+    $frontend_params->{domain} = '012345678901234567890123456789012345678901234567890123456789--64.fr';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'nok')
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+};
 
 #TEST NS
 $frontend_params->{domain} = 'afnic.fr';

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -50,7 +50,7 @@ subtest 'domain present' => sub {
     is( $res->{status}, 'ok' );
 };
 
-subtest 'idn domain=[é]' => sub {
+subtest encode_utf8( 'idn domain=[é]' ) => sub {
     my $res = $engine->validate_syntax(
         {
             %$frontend_params, domain => 'é'
@@ -61,7 +61,7 @@ subtest 'idn domain=[é]' => sub {
         or diag( $res->{message} );
 };
 
-subtest 'idn domain=[éé]' => sub {
+subtest encode_utf8( 'idn domain=[éé]' ) => sub {
     my $res = $engine->validate_syntax(
         {
             %$frontend_params, domain => 'éé'

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -41,56 +41,93 @@ $frontend_params->{nameservers} = [    # list of the namaserves up to 32
 ];
 
 subtest 'domain present' => sub {
-    $frontend_params->{domain} = 'afnic.fr';
-    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok' );
+    my $res = $engine->validate_syntax(
+        {
+            %$frontend_params, domain => 'afnic.fr'
+        }
+    );
+
+    is( $res->{status}, 'ok' );
 };
 
 subtest 'idn domain=[é]' => sub {
-    $frontend_params->{domain} = 'é';
-    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok' )
-        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+    my $res = $engine->validate_syntax(
+        {
+            %$frontend_params, domain => 'é'
+        }
+    );
+
+    is( $res->{status}, 'ok' )
+        or diag( $res->{message} );
 };
 
 subtest 'idn domain=[éé]' => sub {
-    $frontend_params->{domain} = 'éé';
-    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok' )
-        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+    my $res = $engine->validate_syntax(
+        {
+            %$frontend_params, domain => 'éé'
+        }
+    );
+
+    is( $res->{status}, 'ok' )
+        or diag( $res->{message} );
 };
 
 subtest '253 characters long domain without dot' => sub {
-    $frontend_params->{domain} =
-    '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com';
+    my $res = $engine->validate_syntax(
+        {
+            %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com'
+        }
+    );
+
     is(
-        $engine->validate_syntax( $frontend_params )->{status}, 'ok'
-    ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
+        $res->{status}, 'ok'
+    ) or diag( $res->{message} );
 };
 
 subtest '254 characters long domain with trailing dot' => sub {
-    $frontend_params->{domain} =
-    '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.';
+    my $res = $engine->validate_syntax(
+        {
+            %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.'
+        }
+    );
+
     is(
-        $engine->validate_syntax( $frontend_params )->{status}, 'ok'
-    ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
+        $res->{status}, 'ok'
+    ) or diag( $res->{message} );
 };
 
 subtest '254 characters long domain without trailing dot' => sub {
-    $frontend_params->{domain} =
-    '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club';
+    my $res = $engine->validate_syntax(
+        {
+            %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club'
+        }
+    );
+
     is(
-        $engine->validate_syntax( $frontend_params )->{status}, 'nok'
-    ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
+        $res->{status}, 'nok'
+    ) or diag( $res->{message} );
 };
 
 subtest '63 characters long domain label' => sub {
-    $frontend_params->{domain} = '012345678901234567890123456789012345678901234567890123456789-63.fr';
-    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok' )
-        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+    my $res = $engine->validate_syntax(
+        {
+            %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789-63.fr'
+        }
+    );
+
+    is( $res->{status}, 'ok' )
+        or diag( $res->{message} );
 };
 
 subtest '64 characters long domain label' => sub {
-    $frontend_params->{domain} = '012345678901234567890123456789012345678901234567890123456789--64.fr';
-    is( $engine->validate_syntax( $frontend_params )->{status}, 'nok')
-        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+    my $res = $engine->validate_syntax(
+        {
+            %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789--64.fr'
+        }
+    );
+
+    is( $res->{status}, 'nok')
+        or diag( $res->{message} );
 };
 
 #TEST NS

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -42,51 +42,51 @@ $frontend_params->{nameservers} = [    # list of the namaserves up to 32
 
 # domain present?
 $frontend_params->{domain} = 'afnic.fr';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok', 'domain present' );
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', 'domain present' );
 
 # idn
 $frontend_params->{domain} = 'é';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok', encode_utf8( 'idn domain=[é]' ) )
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[é]' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # idn
 $frontend_params->{domain} = 'éé';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok', encode_utf8( 'idn domain=[éé]' ) )
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[éé]' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 253 characters long domain without dot
 $frontend_params->{domain} =
 '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com';
-ok(
-	$engine->validate_syntax( $frontend_params )->{status} eq 'ok',
+is(
+	$engine->validate_syntax( $frontend_params )->{status}, 'ok',
 	encode_utf8( '253 characters long domain without dot' )
 ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 254 characters long domain with trailing dot
 $frontend_params->{domain} =
 '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.';
-ok(
-	$engine->validate_syntax( $frontend_params )->{status} eq 'ok',
+is(
+	$engine->validate_syntax( $frontend_params )->{status}, 'ok',
 	encode_utf8( '254 characters long domain with trailing dot' )
 ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 254 characters long domain without trailing
 $frontend_params->{domain} =
 '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club';
-ok(
-	$engine->validate_syntax( $frontend_params )->{status} eq 'nok',
+is(
+	$engine->validate_syntax( $frontend_params )->{status}, 'nok',
 	encode_utf8( '254 characters long domain without trailing dot' )
 ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 63 characters long domain label
 $frontend_params->{domain} = '012345678901234567890123456789012345678901234567890123456789-63.fr';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok',
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok',
 	encode_utf8( '63 characters long domain label' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 64 characters long domain label
 $frontend_params->{domain} = '012345678901234567890123456789012345678901234567890123456789--64.fr';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'nok',
+is( $engine->validate_syntax( $frontend_params )->{status}, 'nok',
 	encode_utf8( '64 characters long domain label' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
@@ -96,51 +96,51 @@ $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
 
 # domain present?
 $frontend_params->{nameservers}->[0]->{ns} = 'afnic.fr';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok', 'domain present' );
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', 'domain present' );
 
 # idn
 $frontend_params->{nameservers}->[0]->{ns} = 'é';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok', encode_utf8( 'idn domain=[é]' ) )
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[é]' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # idn
 $frontend_params->{nameservers}->[0]->{ns} = 'éé';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok', encode_utf8( 'idn domain=[éé]' ) )
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[éé]' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 253 characters long domain without dot
 $frontend_params->{nameservers}->[0]->{ns} =
 '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com';
-ok(
-	$engine->validate_syntax( $frontend_params )->{status} eq 'ok',
+is(
+	$engine->validate_syntax( $frontend_params )->{status}, 'ok',
 	encode_utf8( '253 characters long domain without dot' )
 ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 254 characters long domain with trailing dot
 $frontend_params->{nameservers}->[0]->{ns} =
 '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.';
-ok(
-	$engine->validate_syntax( $frontend_params )->{status} eq 'ok',
+is(
+	$engine->validate_syntax( $frontend_params )->{status}, 'ok',
 	encode_utf8( '254 characters long domain with trailing dot' )
 ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 254 characters long domain without trailing
 $frontend_params->{nameservers}->[0]->{ns} =
 '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club';
-ok(
-	$engine->validate_syntax( $frontend_params )->{status} eq 'nok',
+is(
+	$engine->validate_syntax( $frontend_params )->{status}, 'nok',
 	encode_utf8( '254 characters long domain without trailing dot' )
 ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 63 characters long domain label
 $frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-63.fr';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok',
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok',
 	encode_utf8( '63 characters long domain label' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # 64 characters long domain label
 $frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-64-.fr';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'nok',
+is( $engine->validate_syntax( $frontend_params )->{status}, 'nok',
 	encode_utf8( '64 characters long domain label' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
@@ -148,7 +148,7 @@ ok( $engine->validate_syntax( $frontend_params )->{status} eq 'nok',
 delete( $frontend_params->{nameservers} );
 
 $frontend_params->{domain} = 'afnic.fr';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok', encode_utf8( 'delegated domain exists' ) )
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'delegated domain exists' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # IP ADDRESS FORMAT
@@ -156,20 +156,20 @@ $frontend_params->{domain} = 'afnic.fr';
 $frontend_params->{nameservers}->[0]->{ns} = 'ns1.nic.fr';
 
 $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok', encode_utf8( 'Valid IPV4' ) )
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid IPV4' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4444';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'nok', encode_utf8( 'Invalid IPV4' ) )
+is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid IPV4' ) )
 	or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 $frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bb';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok', encode_utf8( 'Valid IPV6' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid IPV6' ) )
+    or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 $frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bbffffff';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'nok', encode_utf8( 'Invalid IPV6' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
+is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid IPV6' ) )
+    or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 # DS
 $frontend_params->{domain}                 = 'afnic.fr';
@@ -178,22 +178,22 @@ $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
 
 $frontend_params->{ds_info}->[0]->{algorithm} = 1;
 $frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'ok', encode_utf8( 'Valid Algorithm Type [numeric format]' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
+is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid Algorithm Type [numeric format]' ) )
+    or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 $frontend_params->{ds_info}->[0]->{algorithm} = 'a';
 $frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'nok', encode_utf8( 'Invalid Algorithm Type' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
+is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid Algorithm Type' ) )
+    or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 $frontend_params->{ds_info}->[0]->{algorithm} = 1;
 $frontend_params->{ds_info}->[0]->{digest}    = '01234567890123456789012345678901234567890';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'nok', encode_utf8( 'Invalid digest length' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
+is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid digest length' ) )
+    or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 $frontend_params->{ds_info}->[0]->{algorithm} = 1;
 $frontend_params->{ds_info}->[0]->{digest}    = 'Z123456789012345678901234567890123456789';
-ok( $engine->validate_syntax( $frontend_params )->{status} eq 'nok', encode_utf8( 'Invalid digest format' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
+is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid digest format' ) )
+    or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
 done_testing();


### PR DESCRIPTION
This re-enables the domain name validation we had back in 5.0.2.

With these changes the error response for invalid domain names caught by _check_domain is "Internal server error". This is less than great, but at least it's much better than accepting invalid strings.

Fixes #724.