### PR TITLE
Remove configuration that allows non-hash test ID

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -170,7 +170,6 @@ The ZONEMASTER section has several keys :
 * max_zonemaster_execution_time
 * number_of_processes_for_frontend_testing
 * number_of_processes_for_batch_testing
-* force_hash_id_use_in_API_starting_from_id
 * lock_on_queue
 * maximal_number_of_retries
 * age_reuse_previous_test
@@ -192,18 +191,6 @@ used -> todo
 ### number_of_processes_for_batch_testing
 
 used -> todo
-
-### force_hash_id_use_in_API_starting_from_id
-
-> **Deprecated**
-
-This parameter determines if it is possible to get the test results
-using an incremental numeric id (allowing easy enumeration of the whole
-database of results) or if a half-md5 hash id should be used instead. If
-set to a non zero value the API will use the simple id up to that value
-(the id value given here will be the highest posible value allowed as
-simple id, for everything above hash_id will be forced). Default value:
-`0`.
 
 ### lock_on_queue
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -242,27 +242,6 @@ sub NumberOfProcessesForBatchTesting {
 }
 
 
-=head2 force_hash_id_use_in_API_starting_from_id
-
-=head3 INPUT
-
-'force_hash_id_use_in_API_starting_from_id' from [ZONEMASTER] section in ini file. See
-L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#force_hash_id_use_in_api_starting_from_id>.
-
-=head3 RETURNS
-
-Integer (default 0).
-
-=cut
-
-sub force_hash_id_use_in_API_starting_from_id {
-    my ($self) = @_;
-
-    my $val = $self->{cfg}->val( 'ZONEMASTER', 'force_hash_id_use_in_API_starting_from_id' );
-
-    return ($val)?($val):(0);
-}
-
 =head2 lock_on_queue
 
 =head3 INPUT

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -35,24 +35,7 @@ sub add_api_user {
     return $result;
 }
 
-sub _get_allowed_id_field_name {
-	my ( $self, $test_id ) = @_;
-	
-    my $id_field;
-    if (length($test_id) == 16) {
-		$id_field = 'hash_id';
-    }
-    else {
-		if ($test_id <= $self->config->force_hash_id_use_in_API_starting_from_id()) {
-			$id_field = 'id';
-		}
-		else {
-			die "Querying test results with the [id] field is dissallowed by the current configuration values\n";
-		}
-    }
-}
-
-# Standatd SQL, can be here
+# Standard SQL, can be here
 sub get_test_request {
     my ( $self ) = @_;
 
@@ -62,25 +45,18 @@ sub get_test_request {
     
     my ( $id, $hash_id );
     my $lock_on_queue = $self->config->lock_on_queue();
-	if ( defined $lock_on_queue ) {
-		( $id, $hash_id ) = $dbh->selectrow_array( qq[ SELECT id, hash_id FROM test_results WHERE progress=0 AND queue=? ORDER BY priority DESC, id ASC LIMIT 1 ], undef, $lock_on_queue );
-	}
-	else {
-		( $id, $hash_id ) = $dbh->selectrow_array( q[ SELECT id, hash_id FROM test_results WHERE progress=0 ORDER BY priority DESC, id ASC LIMIT 1 ] );
-	}
+    if ( defined $lock_on_queue ) {
+        ( $id, $hash_id ) = $dbh->selectrow_array( qq[ SELECT id, hash_id FROM test_results WHERE progress=0 AND queue=? ORDER BY priority DESC, id ASC LIMIT 1 ], undef, $lock_on_queue );
+    }
+    else {
+        ( $id, $hash_id ) = $dbh->selectrow_array( q[ SELECT id, hash_id FROM test_results WHERE progress=0 ORDER BY priority DESC, id ASC LIMIT 1 ] );
+    }
         
     if ($id) {
-		$dbh->do( q[UPDATE test_results SET progress=1 WHERE id=?], undef, $id );
-
-		if ( $id > $self->config->force_hash_id_use_in_API_starting_from_id() ) {
-			$result_id = $hash_id;
-		}
-		else {
-			$result_id = $id;
-		}
-	}
-   
-	return $result_id;
+        $dbh->do( q[UPDATE test_results SET progress=1 WHERE id=?], undef, $id );
+        $result_id = $hash_id;
+    }
+    return $result_id;
 }
 
 # Standatd SQL, can be here

--- a/share/travis_mysql_backend_config.ini
+++ b/share/travis_mysql_backend_config.ini
@@ -15,13 +15,6 @@ number_of_processes_for_frontend_testing=20
 number_of_processes_for_batch_testing=20
 #seconds
 
-# This parameter determines if it is possible to get the test results using a incremental 
-# numeric id (allowing easy enumeration of the whole database of results) or if a half-md5 
-# hash id should be used instead. If set to a non zero value the API will use the simple id 
-# upt to that value (the id value given here will be the highest posible value allowed as 
-# simple id, for everything above hash_id will be forced).
-force_hash_id_use_in_API_starting_from_id=1
-
 [LANGUAGE]
 locale = da_DK en_US fr_FR nb_NO sv_SE
 

--- a/share/travis_postgresql_backend_config.ini
+++ b/share/travis_postgresql_backend_config.ini
@@ -15,13 +15,6 @@ number_of_professes_for_frontend_testing=20
 number_of_professes_for_batch_testing=20
 #seconds
 
-# This parameter determines if it is possible to get the test results using a incremental 
-# numeric id (allowing easy enumeration of the whole database of results) or if a half-md5 
-# hash id should be used instead. If set to a non zero value the API will use the simple id 
-# upt to that value (the id value given here will be the highest posible value allowed as 
-# simple id, for everything above hash_id will be forced).
-force_hash_id_use_in_API_starting_from_id=1
-
 [LANGUAGE]
 locale = da_DK en_US fr_FR nb_NO sv_SE
 

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -102,10 +102,10 @@ my $limit  = 10;
 my $test_history =
 	$engine->get_test_history( { frontend_params => $frontend_params_1, offset => $offset, limit => $limit } );
 diag explain( $test_history );
-ok( scalar( @$test_history ) == 2 ), 'Two tests created';
+ok( scalar( @$test_history ) == 2, 'Two tests created' );
 
-ok( length($test_history->[0]->{id}) == 16 ),'Test 0 has 16 character length hash ID';
-ok( length($test_history->[1]->{id}) == 16 ),'Test 1 has 16 character length hash ID';
+ok( length($test_history->[0]->{id}) == 16,'Test 0 has 16 character length hash ID' );
+ok( length($test_history->[1]->{id}) == 16,'Test 1 has 16 character length hash ID' );
 
 done_testing();
 

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -32,23 +32,22 @@ my $engine = Zonemaster::Backend::RPCAPI->new( { db => "Zonemaster::Backend::DB:
 isa_ok( $engine, 'Zonemaster::Backend::RPCAPI' );
 
 sub run_zonemaster_test_with_backend_API {
-	my ($test_id) = @_;
+    my ($test_id) = @_;
     # add a new test to the db
     
     my $api_test_id = $engine->start_domain_test( $frontend_params_1 );
-    ok( $api_test_id eq $test_id || length($api_test_id) == 16 , 'API start_domain_test -> Call OK' );
+    ok( length($api_test_id) == 16 , 'API start_domain_test -> Call OK' );
+
     ok( scalar( $engine->{db}->dbh->selectrow_array( qq/SELECT id FROM test_results WHERE id=$test_id/ ) ) eq $test_id , 'API start_domain_test -> Test inserted in the DB' );
-    my $hash_id = $engine->{db}->dbh->selectrow_array( qq/SELECT hash_id FROM test_results WHERE id=$test_id/ );
-    ok( ($test_id == 1 && $api_test_id eq $test_id || $test_id == 2 && $api_test_id eq $hash_id), "API start_domain_test -> id returned by the api is OK: [$api_test_id]" );
 
     # test test_progress API
     ok( $engine->test_progress( $api_test_id ) == 0 , 'API test_progress -> OK');
 
-	use_ok( 'Zonemaster::Backend::Config' );
-	my $config = Zonemaster::Backend::Config->load_config();
+    use_ok( 'Zonemaster::Backend::Config' );
+    my $config = Zonemaster::Backend::Config->load_config();
 	
     use_ok( 'Zonemaster::Backend::TestAgent' );
-	Zonemaster::Backend::TestAgent->new( { db => "Zonemaster::Backend::DB::$db_backend", config => $config } )->run( $api_test_id );
+    Zonemaster::Backend::TestAgent->new( { db => "Zonemaster::Backend::DB::$db_backend", config => $config } )->run( $api_test_id );
 
     sleep( 5 );
     ok( $engine->test_progress( $api_test_id ) > 0 , 'API test_progress -> Test started');
@@ -81,15 +80,15 @@ ok( $engine->add_api_user( { username => "zonemaster_test", api_key => "zonemast
 
 my $user_check_query;
 if ($db_backend eq 'PostgreSQL') {
-	$user_check_query = q/SELECT * FROM users WHERE user_info->>'username' = 'zonemaster_test'/;
+    $user_check_query = q/SELECT * FROM users WHERE user_info->>'username' = 'zonemaster_test'/;
 }
 elsif ($db_backend eq 'MySQL') {
-	$user_check_query = q/SELECT * FROM users WHERE username = 'zonemaster_test'/;
+    $user_check_query = q/SELECT * FROM users WHERE username = 'zonemaster_test'/;
 }
 
 ok(
-	scalar(
-		$engine->{db}
+    scalar(
+        $engine->{db}
 			->dbh->selectrow_array( $user_check_query )
 	) == 1
 , 'API add_api_user user created' );
@@ -103,9 +102,10 @@ my $limit  = 10;
 my $test_history =
 	$engine->get_test_history( { frontend_params => $frontend_params_1, offset => $offset, limit => $limit } );
 diag explain( $test_history );
-ok( scalar( @$test_history ) == 2 );
-ok( $test_history->[0]->{id} eq '1' || $test_history->[1]->{id} eq '1' );
-ok( length($test_history->[0]->{id}) == 16 || length($test_history->[1]->{id}) == 16 );
+ok( scalar( @$test_history ) == 2 ), 'Two tests created';
+
+ok( length($test_history->[0]->{id}) == 16 ),'Test 0 has 16 character lenght hash ID';
+ok( length($test_history->[1]->{id}) == 16 ),'Test 1 has 16 character lenght hash ID';
 
 done_testing();
 

--- a/t/test_DB_backend.pl
+++ b/t/test_DB_backend.pl
@@ -104,8 +104,8 @@ my $test_history =
 diag explain( $test_history );
 ok( scalar( @$test_history ) == 2 ), 'Two tests created';
 
-ok( length($test_history->[0]->{id}) == 16 ),'Test 0 has 16 character lenght hash ID';
-ok( length($test_history->[1]->{id}) == 16 ),'Test 1 has 16 character lenght hash ID';
+ok( length($test_history->[0]->{id}) == 16 ),'Test 0 has 16 character length hash ID';
+ok( length($test_history->[1]->{id}) == 16 ),'Test 1 has 16 character length hash ID';
 
 done_testing();
 


### PR DESCRIPTION
This PR resolves issue #691. The use of configuration key "force_hash_id_use_in_API_starting_from_id" has been deprecated by #694.

This PR simplifies the database engine codes considerable and removes a feature that we see no real use of.
