### PR TITLE
Require test ID to be 16 character "hash_id" in all input

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -230,9 +230,7 @@ One of the strings (in order from least to most severe):
 
 Basic data type: string
 
- * A string of exactly 16 lower-case hex-digits.
-
-I.e. a string matching `/^[0-9a-f]{16}$/`.
+A string of exactly 16 lower-case hex-digits matching `/^[0-9a-f]{16}$/`.
 
 Each *test* has a unique *test id*.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -230,11 +230,9 @@ One of the strings (in order from least to most severe):
 
 Basic data type: string
 
-Either:
- * A string of at least 1 and at most 9 digits where the first digit is not a zero, or
- * a string of exactly 16 lower-case hex-digits.
+ * A string of exactly 16 lower-case hex-digits.
 
-I.e. a string matching `/^([0-9]|[1-9][0-9]{1,8}|[0-9a-f]{16})$/`.
+I.e. a string matching `/^[0-9a-f]{16}$/`.
 
 Each *test* has a unique *test id*.
 

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -66,7 +66,7 @@ sub queue {
     return joi->integer;
 }
 sub test_id {
-    return joi->string->regex('^[0-9]$|^[1-9][0-9]{1,8}$|^[0-9a-f]{16}$');
+    return joi->string->regex('^[0-9a-f]{16}$');
 }
 sub language_tag {
     return joi->string->regex('^[a-z]{2}(_[A-Z]{2})?$');


### PR DESCRIPTION
This is a follow-up to #726 and should be merged if and only if #726 is merged and directly after. Also see https://github.com/zonemaster/zonemaster-backend/pull/726#issuecomment-803972024.