### PR TITLE
Separate config section for each db engine

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -35,19 +35,11 @@ SQLite            | `SQLite`
 
 **Deprecated.** Use MYSQL.user or POSTGRESQL.user instead.
 
-The name of the user with sufficient permission to access the database.
-
-Ignored by the SQLite database engine.
-
 The MYSQL.user and POSTGRESQL.user properties take precedense over this.
 
 ### password
 
 **Deprecated.** Use MYSQL.password or POSTGRESQL.password instead.
-
-The password of the configured user.
-
-Ignored by the SQLite database engine.
 
 The MYSQL.password and POSTGRESQL.password properties take precedense over this.
 
@@ -55,18 +47,11 @@ The MYSQL.password and POSTGRESQL.password properties take precedense over this.
 
 **Deprecated.** Use MYSQL.host or POSTGRESQL.host instead.
 
-The host name of the machine on which the engine is running.
-
-Ignored by the SQLite database engine.
-
 The MYSQL.host and POSTGRESQL.host properties take precedense over this.
 
 ### database_name
 
 **Deprecated.** Use MYSQL.database, POSTGRESQL.database or SQLite.file instead.
-
-The name of the database to use, except for SQLite database engine where
-it holds the full path to the SQLite database file.
 
 The MYSQL.database, POSTGRESQL.database, SQLite.file properties take precedense
 over this.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -51,9 +51,9 @@ The [MYSQL.host] and [POSTGRESQL.host] properties take precedence over this.
 
 ### database_name
 
-**Deprecated.** Use [MYSQL.database], [POSTGRESQL.database] or [SQLite.file] instead.
+**Deprecated.** Use [MYSQL.database], [POSTGRESQL.database] or [SQLITE.database_file] instead.
 
-The [MYSQL.database], [POSTGRESQL.database], [SQLite.file] properties take precedence
+The [MYSQL.database], [POSTGRESQL.database], [SQLITE.database_file] properties take precedence
 over this.
 
 ### polling_interval
@@ -298,7 +298,7 @@ zero minutes, then the default value (600 seconds) is used.
 [Profile JSON files]:                 https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
 [Profile names]:                      API.md#profile-name
 [Profiles]:                           Architecture.md#profile
-[SQLite.file]:                        #file
+[SQLITE.database_file]:               #database_file
 [Zonemaster-Engine share directory]:  https://github.com/zonemaster/zonemaster-engine/tree/master/share
 [Zonemaster::Engine::Profile]:        https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -33,34 +33,42 @@ SQLite            | `SQLite`
 
 ### user
 
+**Deprecated.** Use MYSQL.user or POSTGRESQL.user instead.
+
 The name of the user with sufficient permission to access the database.
 
 Ignored by the SQLite database engine.
 
-The MySQL.user and PostgreSQL.user properties take precedense over this.
+The MYSQL.user and POSTGRESQL.user properties take precedense over this.
 
 ### password
+
+**Deprecated.** Use MYSQL.password or POSTGRESQL.password instead.
 
 The password of the configured user.
 
 Ignored by the SQLite database engine.
 
-The MySQL.password and PostgreSQL.password properties take precedense over this.
+The MYSQL.password and POSTGRESQL.password properties take precedense over this.
 
 ### database_host
+
+**Deprecated.** Use MYSQL.host or POSTGRESQL.host instead.
 
 The host name of the machine on which the engine is running.
 
 Ignored by the SQLite database engine.
 
-The MySQL.host and PostgreSQL.host properties take precedense over this.
+The MYSQL.host and POSTGRESQL.host properties take precedense over this.
 
 ### database_name
+
+**Deprecated.** Use MYSQL.database, POSTGRESQL.database or SQLite.file instead.
 
 The name of the database to use, except for SQLite database engine where
 it holds the full path to the SQLite database file.
 
-The MySQL.database, PostgreSQL.database, SQLite.file properties take precedense
+The MYSQL.database, POSTGRESQL.database, SQLite.file properties take precedense
 over this.
 
 ### polling_interval

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -121,11 +121,11 @@ If this property is unspecified, the value of [DB.database_name] is used instead
 
 ## SQLITE section
 
-Available keys : `file`.
+Available keys : `database_file`.
 
-### file
+### database_file
 
-The full path to the SQLite database file.
+The full path to the SQLite main database file.
 
 If this property is unspecified, the value of [DB.database_name] is used instead.
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -12,7 +12,6 @@ made to the `backend_config.ini` file.
 
 ## DB section
 
-The DB section has a number of keys.
 Available keys : `engine`, `user`, `password`, `database_name`,
 `database_host`, `polling_interval`.
 
@@ -38,11 +37,15 @@ The name of the user with sufficient permission to access the database.
 
 Ignored by the SQLite database engine.
 
+The MySQL.user and PostgreSQL.user properties take precedense over this.
+
 ### password
 
 The password of the configured user.
 
 Ignored by the SQLite database engine.
+
+The MySQL.password and PostgreSQL.password properties take precedense over this.
 
 ### database_host
 
@@ -50,14 +53,88 @@ The host name of the machine on which the engine is running.
 
 Ignored by the SQLite database engine.
 
+The MySQL.host and PostgreSQL.host properties take precedense over this.
+
 ### database_name
 
 The name of the database to use, except for SQLite database engine where
 it holds the full path to the SQLite database file.
 
+The MySQL.database, PostgreSQL.database, SQLite.file properties take precedense
+over this.
+
 ### polling_interval
 
 Time in seconds between database lookups by Test Agent.
+
+
+## MYSQL section
+
+Available keys : `host`, `user`, `password`, `database`.
+
+### host
+
+The host name of the machine on which the MYSQL server is running.
+
+If this property is unspecified, the value of DB.database_host is used instead.
+
+### user
+
+The name of the user with sufficient permission to access the database.
+
+If this property is unspecified, the value of DB.user is used instead.
+
+### password
+
+The password of the configured user.
+
+If this property is unspecified, the value of DB.password is used instead.
+
+### database
+
+The name of the database to use.
+
+If this property is unspecified, the value of DB.database_name is used instead.
+
+
+## POSTGRESQL section
+
+Available keys : `host`, `user`, `password`, `database`.
+
+### host
+
+The host name of the machine on which the PostgreSQL server is running.
+
+If this property is unspecified, the value of DB.database_host is used instead.
+
+### user
+
+The name of the user with sufficient permission to access the database.
+
+If this property is unspecified, the value of DB.user is used instead.
+
+### password
+
+The password of the configured user.
+
+If this property is unspecified, the value of DB.password is used instead.
+
+### database
+
+The name of the database to use.
+
+If this property is unspecified, the value of DB.database_name is used instead.
+
+
+## SQLITE section
+
+Available keys : `file`.
+
+### file
+
+The full path to the SQLite database file.
+
+If this property is unspecified, the value of DB.database_name is used instead.
 
 
 ## LANGUAGE section

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -278,27 +278,27 @@ zero minutes, then the default value (600 seconds) is used.
 
 --------
 
-[DB.database_host]:                   #db-section
-[DB.database_name]:                   #db-section
-[DB.password]:                        #db-section
-[DB.user]:                            #db-section
+[DB.database_host]:                   #database_host
+[DB.database_name]:                   #database_name
+[DB.password]:                        #password
+[DB.user]:                            #user
 [Default JSON profile file]:          https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
 [ISO 3166-1 alpha-2]:                 https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                          https://en.wikipedia.org/wiki/ISO_639-1
 [Installation instructions]:          Installation.md
 [Language tag]:                       API.md#language-tag
-[MYSQL.database]:                     #mysql-section
-[MYSQL.host]:                         #mysql-section
-[MYSQL.password]:                     #mysql-section
-[MYSQL.user]:                         #mysql-section
-[POSTGRESQL.database]:                #postgresql-section
-[POSTGRESQL.host]:                    #postgresql-section
-[POSTGRESQL.password]:                #postgresql-section
-[POSTGRESQL.user]:                    #postgresql-section
+[MYSQL.database]:                     #database
+[MYSQL.host]:                         #host
+[MYSQL.password]:                     #password-1
+[MYSQL.user]:                         #user-1
+[POSTGRESQL.database]:                #database-1
+[POSTGRESQL.host]:                    #host-1
+[POSTGRESQL.password]:                #password-2
+[POSTGRESQL.user]:                    #user-2
 [Profile JSON files]:                 https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
 [Profile names]:                      API.md#profile-name
 [Profiles]:                           Architecture.md#profile
-[SQLite.file]:                        #sqlite-section
+[SQLite.file]:                        #file
 [Zonemaster-Engine share directory]:  https://github.com/zonemaster/zonemaster-engine/tree/master/share
 [Zonemaster::Engine::Profile]:        https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -33,27 +33,27 @@ SQLite            | `SQLite`
 
 ### user
 
-**Deprecated.** Use MYSQL.user or POSTGRESQL.user instead.
+**Deprecated.** Use [MYSQL.user] or [POSTGRESQL.user] instead.
 
-The MYSQL.user and POSTGRESQL.user properties take precedense over this.
+The [MYSQL.user] and [POSTGRESQL.user] properties take precedense over this.
 
 ### password
 
-**Deprecated.** Use MYSQL.password or POSTGRESQL.password instead.
+**Deprecated.** Use [MYSQL.password] or [POSTGRESQL.password] instead.
 
-The MYSQL.password and POSTGRESQL.password properties take precedense over this.
+The [MYSQL.password] and [POSTGRESQL.password] properties take precedense over this.
 
 ### database_host
 
-**Deprecated.** Use MYSQL.host or POSTGRESQL.host instead.
+**Deprecated.** Use [MYSQL.host] or [POSTGRESQL.host] instead.
 
-The MYSQL.host and POSTGRESQL.host properties take precedense over this.
+The [MYSQL.host] and [POSTGRESQL.host] properties take precedense over this.
 
 ### database_name
 
-**Deprecated.** Use MYSQL.database, POSTGRESQL.database or SQLite.file instead.
+**Deprecated.** Use [MYSQL.database], [POSTGRESQL.database] or [SQLite.file] instead.
 
-The MYSQL.database, POSTGRESQL.database, SQLite.file properties take precedense
+The [MYSQL.database], [POSTGRESQL.database], [SQLite.file] properties take precedense
 over this.
 
 ### polling_interval
@@ -69,25 +69,25 @@ Available keys : `host`, `user`, `password`, `database`.
 
 The host name of the machine on which the MYSQL server is running.
 
-If this property is unspecified, the value of DB.database_host is used instead.
+If this property is unspecified, the value of [DB.database_host] is used instead.
 
 ### user
 
 The name of the user with sufficient permission to access the database.
 
-If this property is unspecified, the value of DB.user is used instead.
+If this property is unspecified, the value of [DB.user] is used instead.
 
 ### password
 
 The password of the configured user.
 
-If this property is unspecified, the value of DB.password is used instead.
+If this property is unspecified, the value of [DB.password] is used instead.
 
 ### database
 
 The name of the database to use.
 
-If this property is unspecified, the value of DB.database_name is used instead.
+If this property is unspecified, the value of [DB.database_name] is used instead.
 
 
 ## POSTGRESQL section
@@ -98,25 +98,25 @@ Available keys : `host`, `user`, `password`, `database`.
 
 The host name of the machine on which the PostgreSQL server is running.
 
-If this property is unspecified, the value of DB.database_host is used instead.
+If this property is unspecified, the value of [DB.database_host] is used instead.
 
 ### user
 
 The name of the user with sufficient permission to access the database.
 
-If this property is unspecified, the value of DB.user is used instead.
+If this property is unspecified, the value of [DB.user] is used instead.
 
 ### password
 
 The password of the configured user.
 
-If this property is unspecified, the value of DB.password is used instead.
+If this property is unspecified, the value of [DB.password] is used instead.
 
 ### database
 
 The name of the database to use.
 
-If this property is unspecified, the value of DB.database_name is used instead.
+If this property is unspecified, the value of [DB.database_name] is used instead.
 
 
 ## SQLITE section
@@ -127,7 +127,7 @@ Available keys : `file`.
 
 The full path to the SQLite database file.
 
-If this property is unspecified, the value of DB.database_name is used instead.
+If this property is unspecified, the value of [DB.database_name] is used instead.
 
 
 ## LANGUAGE section
@@ -278,15 +278,28 @@ zero minutes, then the default value (600 seconds) is used.
 
 --------
 
-[Installation instructions]:          Installation.md
+[DB.database_host]:                   #db-section
+[DB.database_name]:                   #db-section
+[DB.password]:                        #db-section
+[DB.user]:                            #db-section
 [Default JSON profile file]:          https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
 [ISO 3166-1 alpha-2]:                 https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                          https://en.wikipedia.org/wiki/ISO_639-1
+[Installation instructions]:          Installation.md
+[Language tag]:                       API.md#language-tag
+[MYSQL.database]:                     #mysql-section
+[MYSQL.host]:                         #mysql-section
+[MYSQL.password]:                     #mysql-section
+[MYSQL.user]:                         #mysql-section
+[POSTGRESQL.database]:                #postgresql-section
+[POSTGRESQL.host]:                    #postgresql-section
+[POSTGRESQL.password]:                #postgresql-section
+[POSTGRESQL.user]:                    #postgresql-section
 [Profile JSON files]:                 https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
 [Profile names]:                      API.md#profile-name
 [Profiles]:                           Architecture.md#profile
+[SQLite.file]:                        #sqlite-section
 [Zonemaster-Engine share directory]:  https://github.com/zonemaster/zonemaster-engine/tree/master/share
 [Zonemaster::Engine::Profile]:        https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES
-[Language tag]:                       API.md#language-tag
 
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -35,25 +35,25 @@ SQLite            | `SQLite`
 
 **Deprecated.** Use [MYSQL.user] or [POSTGRESQL.user] instead.
 
-The [MYSQL.user] and [POSTGRESQL.user] properties take precedense over this.
+The [MYSQL.user] and [POSTGRESQL.user] properties take precedence over this.
 
 ### password
 
 **Deprecated.** Use [MYSQL.password] or [POSTGRESQL.password] instead.
 
-The [MYSQL.password] and [POSTGRESQL.password] properties take precedense over this.
+The [MYSQL.password] and [POSTGRESQL.password] properties take precedence over this.
 
 ### database_host
 
 **Deprecated.** Use [MYSQL.host] or [POSTGRESQL.host] instead.
 
-The [MYSQL.host] and [POSTGRESQL.host] properties take precedense over this.
+The [MYSQL.host] and [POSTGRESQL.host] properties take precedence over this.
 
 ### database_name
 
 **Deprecated.** Use [MYSQL.database], [POSTGRESQL.database] or [SQLite.file] instead.
 
-The [MYSQL.database], [POSTGRESQL.database], [SQLite.file] properties take precedense
+The [MYSQL.database], [POSTGRESQL.database], [SQLite.file] properties take precedence
 over this.
 
 ### polling_interval
@@ -67,7 +67,7 @@ Available keys : `host`, `user`, `password`, `database`.
 
 ### host
 
-The host name of the machine on which the MYSQL server is running.
+The host name of the machine on which the MySQL server is running.
 
 If this property is unspecified, the value of [DB.database_host] is used instead.
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -126,7 +126,6 @@ Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
 sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
-sudo sed -i '/\bdatabase_name\b/ s/=.*/= zonemaster/' /etc/zonemaster/backend_config.ini
 ```
 
 > **Note:** See the [backend configuration] documentation for details.
@@ -156,7 +155,6 @@ Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
 sudo sed -i '/\bengine\b/ s/=.*/= PostgreSQL/' /etc/zonemaster/backend_config.ini
-sudo sed -i '/\bdatabase_name\b/ s/=.*/= zonemaster/' /etc/zonemaster/backend_config.ini
 ```
 
 > **Note:** See the [backend configuration] documentation for details.
@@ -206,7 +204,6 @@ path:
 
 ```sh
 sudo sed -i '/\bengine\b/ s/=.*/= SQLite/' /etc/zonemaster/backend_config.ini
-sudo sed -i '/\bdatabase_name\b/ s:=.*:= /var/lib/zonemaster/db.sqlite:' /etc/zonemaster/backend_config.ini
 ```
 
 Create database directory, set correct ownership and create database:
@@ -337,7 +334,6 @@ Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
 sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
-sudo sed -i '/\bdatabase_name\b/ s/=.*/= zonemaster/' /etc/zonemaster/backend_config.ini
 ```
 
 > **Note:** See the [backend configuration] documentation for details.
@@ -365,7 +361,6 @@ Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
 sudo sed -i '/\bengine\b/ s/=.*/= PostgreSQL/' /etc/zonemaster/backend_config.ini
-sudo sed -i '/\bdatabase_name\b/ s/=.*/= zonemaster/' /etc/zonemaster/backend_config.ini
 ```
 
 > **Note:** See the [backend configuration] documentation for details.
@@ -393,7 +388,6 @@ path:
 
 ```sh
 sudo sed -i '/\bengine\b/ s/=.*/= SQLite/' /etc/zonemaster/backend_config.ini
-sudo sed -i '/\bdatabase_name\b/ s:=.*:= /var/lib/zonemaster/db.sqlite:' /etc/zonemaster/backend_config.ini
 ```
 
 Create database directory, set correct ownership and create database:
@@ -503,7 +497,6 @@ Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
 sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= MySQL/' /usr/local/etc/zonemaster/backend_config.ini
-sed -i '' '/[[:<:]]database_name[[:>:]]/ s/=.*/= zonemaster/' /usr/local/etc/zonemaster/backend_config.ini
 ```
 > **Note:** See the [backend configuration] documentation for details.
 
@@ -559,7 +552,6 @@ Configure Zonemaster::Backend to use the correct database engine:
 
 ```sh
 sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= PostgreSQL/' /usr/local/etc/zonemaster/backend_config.ini
-sed -i '' '/[[:<:]]database_name[[:>:]]/ s/=.*/= zonemaster/' /usr/local/etc/zonemaster/backend_config.ini
 ```
 > **Note:** See the [backend configuration] documentation for details.
 
@@ -591,7 +583,6 @@ path:
 
 ```sh
 sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= SQLite/' /usr/local/etc/zonemaster/backend_config.ini
-sed -i '' '/[[:<:]]database_name[[:>:]]/ s:=.*:= /var/db/zonemaster/db.sqlite:' /usr/local/etc/zonemaster/backend_config.ini
 ```
 
 Create database directory, set correct ownership and create database:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -583,7 +583,7 @@ path:
 
 ```sh
 sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= SQLite/' /usr/local/etc/zonemaster/backend_config.ini
-sed -i '' '/[[:<:]]file[[:>:]]/ s:=.*:= /var/db/zonemaster/db.sqlite:' /usr/local/etc/zonemaster/backend_config.ini
+sed -i '' '/[[:<:]]database_file[[:>:]]/ s:=.*:= /var/db/zonemaster/db.sqlite:' /usr/local/etc/zonemaster/backend_config.ini
 ```
 
 Create database directory, set correct ownership and create database:

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -583,6 +583,7 @@ path:
 
 ```sh
 sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= SQLite/' /usr/local/etc/zonemaster/backend_config.ini
+sed -i '' '/[[:<:]]file[[:>:]]/ s:=.*:= /var/db/zonemaster/db.sqlite:' /usr/local/etc/zonemaster/backend_config.ini
 ```
 
 Create database directory, set correct ownership and create database:

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -84,7 +84,7 @@ sub BackendDBType {
     return $engine;
 }
 
-=head2 MySQL_database
+=head2 MYSQL_database
 
 Returns the L<MYSQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
 property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
@@ -92,7 +92,7 @@ property if it is unspecified.
 
 =cut
 
-sub MySQL_database {
+sub MYSQL_database {
     my ( $self ) = @_;
 
     return $self->{cfg}->val( 'MYSQL', 'database' ) // $self->{cfg}->val( 'DB', 'database_name' );
@@ -106,13 +106,13 @@ property if it is unspecified.
 
 =cut
 
-sub MySQL_host {
+sub MYSQL_host {
     my ( $self ) = @_;
 
     return $self->{cfg}->val( 'MYSQL', 'host' ) // $self->{cfg}->val( 'DB', 'database_host' );
 }
 
-=head2 MySQL_password
+=head2 MYSQL_password
 
 Returns the L<MYSQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
 property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
@@ -120,13 +120,13 @@ property if it is unspecified.
 
 =cut
 
-sub MySQL_password {
+sub MYSQL_password {
     my ( $self ) = @_;
 
     return $self->{cfg}->val( 'MYSQL', 'password' ) // $self->{cfg}->val( 'DB', 'password' );
 }
 
-=head2 MySQL_user
+=head2 MYSQL_user
 
 Returns the L<MYSQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
 property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
@@ -134,7 +134,7 @@ property if it is unspecified.
 
 =cut
 
-sub MySQL_user {
+sub MYSQL_user {
     my ( $self ) = @_;
 
     return $self->{cfg}->val( 'MYSQL', 'user' ) // $self->{cfg}->val( 'DB', 'user' );

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -37,6 +37,20 @@ sub load_config {
     $self->{cfg} = Config::IniFiles->new( -file => $path );
     die "UNABLE TO LOAD $path ERRORS:[".join('; ', @Config::IniFiles::errors)."] \n" unless ( $self->{cfg} );
     bless( $self, $class );
+
+    if ( defined $self->{cfg}->val( 'DB', 'database_host' ) ) {
+        $log->warning( "Use of deprecated config property DB.database_host. Use MYSQL.host or POSTGRESQL.host instead." );
+    }
+    if ( defined $self->{cfg}->val( 'DB', 'user' ) ) {
+        $log->warning( "Use of deprecated config property DB.user. Use MYSQL.user or POSTGRESQL.user instead." );
+    }
+    if ( defined $self->{cfg}->val( 'DB', 'password' ) ) {
+        $log->warning( "Use of deprecated config property DB.password. Use MYSQL.password or POSTGRESQL.password instead." );
+    }
+    if ( defined $self->{cfg}->val( 'DB', 'database_name' ) ) {
+        $log->warning( "Use of deprecated config property DB.database_name. Use MYSQL.database, POSTGRESQL.database or SQLITE.file instead." );
+    }
+
     return $self;
 }
 
@@ -68,24 +82,6 @@ sub BackendDBType {
         die "Unknown config value DB.engine: $engine\n";
     }
     return $engine;
-}
-
-sub DB_user {
-    my ($self) = @_;
-
-    return $self->{cfg}->val( 'DB', 'user' );
-}
-
-sub DB_password {
-    my ($self) = @_;
-
-    return $self->{cfg}->val( 'DB', 'password' );
-}
-
-sub DB_name {
-    my ($self) = @_;
-
-    return $self->{cfg}->val( 'DB', 'database_name' );
 }
 
 =head2 MySQL_database

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -519,7 +519,6 @@ sub new_DB {
     my $dbclass = 'Zonemaster::Backend::DB::' . $dbtype;
     require( join( "/", split( /::/, $dbclass ) ) . ".pm" );
     $dbclass->import();
-    $log->notice("Constructing database adapter: $dbclass");
 
     my $db = $dbclass->new({ config => $self });
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -280,27 +280,6 @@ sub ListLanguageTags {
     return @langtags;
 }
 
-
-sub DB_connection_string {
-    my ($self) = @_;
-
-    my $db_engine = $_[1] || $self->BackendDBType;
-
-    my $result;
-
-    if ( lc( $db_engine ) eq 'sqlite' ) {
-        $result = sprintf( 'DBI:SQLite:dbname=%s', $self->SQLite_file );
-    }
-    elsif ( lc( $db_engine ) eq 'postgresql' ) {
-        $result = sprintf( 'DBI:Pg:database=%s;host=%s', $self->PostgreSQL_database, $self->PostgreSQL_host );
-    }
-    elsif ( lc( $db_engine ) eq 'mysql' ) {
-        $result = sprintf( 'DBI:mysql:database=%s;host=%s', $self->MySQL_database, $self->MySQL_host );
-    }
-
-    return $result;
-}
-
 sub PollingInterval {
     my ($self) = @_;
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -88,6 +88,132 @@ sub DB_name {
     return $self->{cfg}->val( 'DB', 'database_name' );
 }
 
+=head2 MySQL_database
+
+Returns the L<MYSQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
+property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+property if it is unspecified.
+
+=cut
+
+sub MySQL_database {
+    my ( $self ) = @_;
+
+    return $self->{cfg}->val( 'MYSQL', 'database' ) // $self->{cfg}->val( 'DB', 'database_name' );
+}
+
+=head2 MySQL_host
+
+Returns the L<MYSQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
+property from the loaded config, or the L<DB.database_host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+property if it is unspecified.
+
+=cut
+
+sub MySQL_host {
+    my ( $self ) = @_;
+
+    return $self->{cfg}->val( 'MYSQL', 'host' ) // $self->{cfg}->val( 'DB', 'database_host' );
+}
+
+=head2 MySQL_password
+
+Returns the L<MYSQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
+property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+property if it is unspecified.
+
+=cut
+
+sub MySQL_password {
+    my ( $self ) = @_;
+
+    return $self->{cfg}->val( 'MYSQL', 'password' ) // $self->{cfg}->val( 'DB', 'password' );
+}
+
+=head2 MySQL_user
+
+Returns the L<MYSQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
+property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+property if it is unspecified.
+
+=cut
+
+sub MySQL_user {
+    my ( $self ) = @_;
+
+    return $self->{cfg}->val( 'MYSQL', 'user' ) // $self->{cfg}->val( 'DB', 'user' );
+}
+
+=head2 POSTGRESQL_database
+
+Returns the L<POSTGRESQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#postgresql>
+property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+property if it is unspecified.
+
+=cut
+
+sub POSTGRESQL_database {
+    my ( $self ) = @_;
+
+    return $self->{cfg}->val( 'POSTGRESQL', 'database' ) // $self->{cfg}->val( 'DB', 'database_name' );
+}
+
+=head2 POSTGRESQL_host
+
+Returns the L<POSTGRESQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#postgresql>
+property from the loaded config, or the L<DB.database_host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+property if it is unspecified.
+
+=cut
+
+sub POSTGRESQL_host {
+    my ( $self ) = @_;
+
+    return $self->{cfg}->val( 'POSTGRESQL', 'host' ) // $self->{cfg}->val( 'DB', 'database_host' );
+}
+
+=head2 POSTGRESQL_password
+
+Returns the L<POSTGRESQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#postgresql>
+property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+property if it is unspecified.
+
+=cut
+
+sub POSTGRESQL_password {
+    my ( $self ) = @_;
+
+    return $self->{cfg}->val( 'POSTGRESQL', 'password' ) // $self->{cfg}->val( 'DB', 'password' );
+}
+
+=head2 POSTGRESQL_user
+
+Returns the L<POSTGRESQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#postgresql>
+property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+property if it is unspecified.
+
+=cut
+
+sub POSTGRESQL_user {
+    my ( $self ) = @_;
+
+    return $self->{cfg}->val( 'POSTGRESQL', 'user' ) // $self->{cfg}->val( 'DB', 'user' );
+}
+
+=head2 SQLITE_file
+
+Returns the L<SQLITE.file|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#sqlite>
+property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+property if it is unspecified.
+
+=cut
+
+sub SQLITE_file {
+    my ( $self ) = @_;
+
+    return $self->{cfg}->val( 'SQLITE', 'file' ) // $self->{cfg}->val( 'DB', 'database_name' );
+}
+
 =head2 Language_Locale_hash
 
 Read LANGUAGE.locale from the configuration (.ini) file and returns
@@ -162,18 +288,18 @@ sub ListLanguageTags {
 sub DB_connection_string {
     my ($self) = @_;
 
-    my $db_engine = $_[1] || $self->{cfg}->val( 'DB', 'engine' );
+    my $db_engine = $_[1] || $self->BackendDBType;
 
     my $result;
 
     if ( lc( $db_engine ) eq 'sqlite' ) {
-        $result = sprintf('DBI:SQLite:dbname=%s', $self->{cfg}->val( 'DB', 'database_name' ));
+        $result = sprintf( 'DBI:SQLite:dbname=%s', $self->SQLite_file );
     }
     elsif ( lc( $db_engine ) eq 'postgresql' ) {
-        $result = sprintf('DBI:Pg:database=%s;host=%s', $self->{cfg}->val( 'DB', 'database_name' ), $self->{cfg}->val( 'DB', 'database_host' ));
+        $result = sprintf( 'DBI:Pg:database=%s;host=%s', $self->PostgreSQL_database, $self->PostgreSQL_host );
     }
     elsif ( lc( $db_engine ) eq 'mysql' ) {
-        $result = sprintf('DBI:mysql:database=%s;host=%s', $self->{cfg}->val( 'DB', 'database_name' ), $self->{cfg}->val( 'DB', 'database_host' ));
+        $result = sprintf( 'DBI:mysql:database=%s;host=%s', $self->MySQL_database, $self->MySQL_host );
     }
 
     return $result;

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -48,7 +48,7 @@ sub load_config {
         $log->warning( "Use of deprecated config property DB.password. Use MYSQL.password or POSTGRESQL.password instead." );
     }
     if ( defined $self->{cfg}->val( 'DB', 'database_name' ) ) {
-        $log->warning( "Use of deprecated config property DB.database_name. Use MYSQL.database, POSTGRESQL.database or SQLITE.file instead." );
+        $log->warning( "Use of deprecated config property DB.database_name. Use MYSQL.database, POSTGRESQL.database or SQLITE.database_file instead." );
     }
 
     return $self;
@@ -196,18 +196,18 @@ sub POSTGRESQL_user {
     return $self->{cfg}->val( 'POSTGRESQL', 'user' ) // $self->{cfg}->val( 'DB', 'user' );
 }
 
-=head2 SQLITE_file
+=head2 SQLITE_database_file
 
-Returns the L<SQLITE.file|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#file>
+Returns the L<SQLITE.database_file|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_file>
 property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_name>
 property if it is unspecified.
 
 =cut
 
-sub SQLITE_file {
+sub SQLITE_database_file {
     my ( $self ) = @_;
 
-    return $self->{cfg}->val( 'SQLITE', 'file' ) // $self->{cfg}->val( 'DB', 'database_name' );
+    return $self->{cfg}->val( 'SQLITE', 'database_file' ) // $self->{cfg}->val( 'DB', 'database_name' );
 }
 
 =head2 Language_Locale_hash

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -86,8 +86,8 @@ sub BackendDBType {
 
 =head2 MYSQL_database
 
-Returns the L<MYSQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
-property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+Returns the L<MYSQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database>
+property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_name>
 property if it is unspecified.
 
 =cut
@@ -100,8 +100,8 @@ sub MYSQL_database {
 
 =head2 MySQL_host
 
-Returns the L<MYSQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
-property from the loaded config, or the L<DB.database_host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+Returns the L<MYSQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#host>
+property from the loaded config, or the L<DB.database_host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_host>
 property if it is unspecified.
 
 =cut
@@ -114,8 +114,8 @@ sub MYSQL_host {
 
 =head2 MYSQL_password
 
-Returns the L<MYSQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
-property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+Returns the L<MYSQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password-1>
+property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password>
 property if it is unspecified.
 
 =cut
@@ -128,8 +128,8 @@ sub MYSQL_password {
 
 =head2 MYSQL_user
 
-Returns the L<MYSQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#mysql>
-property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+Returns the L<MYSQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user-1>
+property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user>
 property if it is unspecified.
 
 =cut
@@ -142,8 +142,8 @@ sub MYSQL_user {
 
 =head2 POSTGRESQL_database
 
-Returns the L<POSTGRESQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#postgresql>
-property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+Returns the L<POSTGRESQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database-1>
+property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_name>
 property if it is unspecified.
 
 =cut
@@ -156,8 +156,8 @@ sub POSTGRESQL_database {
 
 =head2 POSTGRESQL_host
 
-Returns the L<POSTGRESQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#postgresql>
-property from the loaded config, or the L<DB.database_host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+Returns the L<POSTGRESQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#host-1>
+property from the loaded config, or the L<DB.database_host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_host>
 property if it is unspecified.
 
 =cut
@@ -170,8 +170,8 @@ sub POSTGRESQL_host {
 
 =head2 POSTGRESQL_password
 
-Returns the L<POSTGRESQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#postgresql>
-property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+Returns the L<POSTGRESQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password-2>
+property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password>
 property if it is unspecified.
 
 =cut
@@ -184,8 +184,8 @@ sub POSTGRESQL_password {
 
 =head2 POSTGRESQL_user
 
-Returns the L<POSTGRESQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#postgresql>
-property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+Returns the L<POSTGRESQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user-2>
+property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user>
 property if it is unspecified.
 
 =cut
@@ -198,8 +198,8 @@ sub POSTGRESQL_user {
 
 =head2 SQLITE_file
 
-Returns the L<SQLITE.file|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#sqlite>
-property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#db>
+Returns the L<SQLITE.file|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#file>
+property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_name>
 property if it is unspecified.
 
 =cut

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -36,8 +36,8 @@ sub dbh {
     else {
         my $connection_string   = $self->config->DB_connection_string( 'mysql' );
         my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-        my $connection_user     = $self->config->DB_user();
-        my $connection_password = $self->config->DB_password();
+        my $connection_user     = $self->config->MySQL_user();
+        my $connection_password = $self->config->MySQL_password();
         $dbh = DBI->connect( $connection_string, $connection_user, $connection_password, $connection_args );
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -10,6 +10,7 @@ use DBI qw(:utils);
 use Digest::MD5 qw(md5_hex);
 use Encode;
 use JSON::PP;
+use Log::Any qw($log);
 
 use Zonemaster::Backend::Config;
 
@@ -38,9 +39,10 @@ sub dbh {
         my $host     = $self->config->MYSQL_host;
         my $user     = $self->config->MYSQL_user();
         my $password = $self->config->MYSQL_password();
-        my $connection_string = "DBI:mysql:database=$database;host=$host";
+
+        $log->notice( "Connecting to MySQL: database=$database host=$host user=$user" ) if $log->is_notice;
         $dbh = DBI->connect(
-            $connection_string,
+            "DBI:mysql:database=$database;host=$host",
             $user,
             $password,
             {
@@ -48,6 +50,7 @@ sub dbh {
                 AutoCommit => 1
             }
         );
+
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );
         return $dbh;

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -5,11 +5,11 @@ our $VERSION = '1.1.0';
 use Moose;
 use 5.14.2;
 
-use Encode;
-use DBI qw(:utils);
-use JSON::PP;
-use Digest::MD5 qw(md5_hex);
 use Data::Dumper;
+use DBI qw(:utils);
+use Digest::MD5 qw(md5_hex);
+use Encode;
+use JSON::PP;
 
 use Zonemaster::Backend::Config;
 
@@ -34,11 +34,20 @@ sub dbh {
         return $dbh;
     }
     else {
-        my $connection_string   = sprintf( 'DBI:mysql:database=%s;host=%s', $self->config->MYSQL_database, $self->config->MYSQL_host );
-        my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-        my $connection_user     = $self->config->MYSQL_user();
-        my $connection_password = $self->config->MYSQL_password();
-        $dbh = DBI->connect( $connection_string, $connection_user, $connection_password, $connection_args );
+        my $database = $self->config->MYSQL_database;
+        my $host     = $self->config->MYSQL_host;
+        my $user     = $self->config->MYSQL_user();
+        my $password = $self->config->MYSQL_password();
+        my $connection_string = "DBI:mysql:database=$database;host=$host";
+        $dbh = DBI->connect(
+            $connection_string,
+            $user,
+            $password,
+            {
+                RaiseError => 1,
+                AutoCommit => 1
+            }
+        );
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );
         return $dbh;

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -34,10 +34,10 @@ sub dbh {
         return $dbh;
     }
     else {
-        my $connection_string   = sprintf( 'DBI:mysql:database=%s;host=%s', $self->config->MySQL_database, $self->config->MySQL_host );
+        my $connection_string   = sprintf( 'DBI:mysql:database=%s;host=%s', $self->config->MYSQL_database, $self->config->MYSQL_host );
         my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-        my $connection_user     = $self->config->MySQL_user();
-        my $connection_password = $self->config->MySQL_password();
+        my $connection_user     = $self->config->MYSQL_user();
+        my $connection_password = $self->config->MYSQL_password();
         $dbh = DBI->connect( $connection_string, $connection_user, $connection_password, $connection_args );
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -34,7 +34,7 @@ sub dbh {
         return $dbh;
     }
     else {
-        my $connection_string   = $self->config->DB_connection_string( 'mysql' );
+        my $connection_string   = sprintf( 'DBI:mysql:database=%s;host=%s', $self->config->MySQL_database, $self->config->MySQL_host );
         my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
         my $connection_user     = $self->config->MySQL_user();
         my $connection_password = $self->config->MySQL_password();

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -6,9 +6,9 @@ use Moose;
 use 5.14.2;
 
 use DBI qw(:utils);
-use JSON::PP;
 use Digest::MD5 qw(md5_hex);
 use Encode;
+use JSON::PP;
 
 use Zonemaster::Backend::DB;
 use Zonemaster::Backend::Config;
@@ -34,11 +34,20 @@ sub dbh {
         return $dbh;
     }
     else {
-        my $connection_string   = sprintf( 'DBI:Pg:database=%s;host=%s', $self->config->POSTGRESQL_database, $self->config->POSTGRESQL_host );
-        my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-        my $connection_user     = $self->config->POSTGRESQL_user();
-        my $connection_password = $self->config->POSTGRESQL_password();
-        $dbh = DBI->connect( $connection_string, $connection_user, $connection_password, $connection_args );
+        my $database = $self->config->POSTGRESQL_database;
+        my $host     = $self->config->POSTGRESQL_host;
+        my $user     = $self->config->POSTGRESQL_user;
+        my $password = $self->config->POSTGRESQL_password;
+        my $connection_string = "DBI:Pg:database=$database;host=$host";
+        $dbh = DBI->connect(
+            $connection_string,
+            $user,
+            $password,
+            {
+                RaiseError => 1,
+                AutoCommit => 1
+            }
+        );
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );
         return $dbh;

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -34,10 +34,10 @@ sub dbh {
         return $dbh;
     }
     else {
-        my $connection_string   = sprintf( 'DBI:Pg:database=%s;host=%s', $self->config->PostgreSQL_database, $self->config->PostgreSQL_host );
+        my $connection_string   = sprintf( 'DBI:Pg:database=%s;host=%s', $self->config->POSTGRESQL_database, $self->config->POSTGRESQL_host );
         my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-        my $connection_user     = $self->config->PostgreSQL_user();
-        my $connection_password = $self->config->PostgreSQL_password();
+        my $connection_user     = $self->config->POSTGRESQL_user();
+        my $connection_password = $self->config->POSTGRESQL_password();
         $dbh = DBI->connect( $connection_string, $connection_user, $connection_password, $connection_args );
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -9,6 +9,7 @@ use DBI qw(:utils);
 use Digest::MD5 qw(md5_hex);
 use Encode;
 use JSON::PP;
+use Log::Any qw($log);
 
 use Zonemaster::Backend::DB;
 use Zonemaster::Backend::Config;
@@ -38,9 +39,10 @@ sub dbh {
         my $host     = $self->config->POSTGRESQL_host;
         my $user     = $self->config->POSTGRESQL_user;
         my $password = $self->config->POSTGRESQL_password;
-        my $connection_string = "DBI:Pg:database=$database;host=$host";
+
+        $log->notice( "Connecting to PostgreSQL: database=$database host=$host user=$user" ) if $log->is_notice;
         $dbh = DBI->connect(
-            $connection_string,
+            "DBI:Pg:database=$database;host=$host",
             $user,
             $password,
             {
@@ -48,6 +50,7 @@ sub dbh {
                 AutoCommit => 1
             }
         );
+
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );
         return $dbh;

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -36,8 +36,8 @@ sub dbh {
     else {
         my $connection_string   = $self->config->DB_connection_string( 'postgresql' );
         my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
-        my $connection_user     = $self->config->DB_user();
-        my $connection_password = $self->config->DB_password();
+        my $connection_user     = $self->config->PostgreSQL_user();
+        my $connection_password = $self->config->PostgreSQL_password();
         $dbh = DBI->connect( $connection_string, $connection_user, $connection_password, $connection_args );
         $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -34,7 +34,7 @@ sub dbh {
         return $dbh;
     }
     else {
-        my $connection_string   = $self->config->DB_connection_string( 'postgresql' );
+        my $connection_string   = sprintf( 'DBI:Pg:database=%s;host=%s', $self->config->PostgreSQL_database, $self->config->PostgreSQL_host );
         my $connection_args     = { RaiseError => 1, AutoCommit => 1 };
         my $connection_user     = $self->config->PostgreSQL_user();
         my $connection_password = $self->config->PostgreSQL_password();

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -31,7 +31,8 @@ sub BUILD {
     my ( $self ) = @_;
 
     if ( !defined $self->dbh ) {
-        my $connection_string = $self->config->DB_connection_string( 'sqlite' );
+        my $connection_string = sprintf( 'DBI:SQLite:dbname=%s', $self->config->SQLite_file );
+
         $log->debug( "Connection string: " . $connection_string );
 
         my $dbh = DBI->connect(

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -31,7 +31,7 @@ sub BUILD {
     my ( $self ) = @_;
 
     if ( !defined $self->dbh ) {
-        my $connection_string = sprintf( 'DBI:SQLite:dbname=%s', $self->config->SQLite_file );
+        my $connection_string = sprintf( 'DBI:SQLite:dbname=%s', $self->config->SQLITE_file );
 
         $log->debug( "Connection string: " . $connection_string );
 

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -33,18 +33,15 @@ sub BUILD {
     if ( !defined $self->dbh ) {
         my $file = $self->config->SQLITE_file;
 
-        my $connection_string = "DBI:SQLite:dbname=$file";
-        $log->debug( "SQLite opening: " . $connection_string );
-
+        $log->notice( "Opening SQLite: file=$file" ) if $log->is_notice;
         my $dbh = DBI->connect(
-            $connection_string,
+            "DBI:SQLite:dbname=$file",
             undef, undef,
             {
                 AutoCommit => 1,
                 RaiseError => 1,
             }
         );
-        $log->debug( "Database filename: " . $dbh->sqlite_db_filename );
 
         $self->dbh( $dbh );
     }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -31,7 +31,7 @@ sub BUILD {
     my ( $self ) = @_;
 
     if ( !defined $self->dbh ) {
-        my $file = $self->config->SQLITE_file;
+        my $file = $self->config->SQLITE_database_file;
 
         $log->notice( "Opening SQLite: file=$file" ) if $log->is_notice;
         my $dbh = DBI->connect(

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -5,12 +5,12 @@ our $VERSION = '1.1.0';
 use Moose;
 use 5.14.2;
 
-use DBI qw(:utils);
-use JSON::PP;
-use Digest::MD5 qw(md5_hex);
-use Log::Any qw( $log );
-use Encode;
 use Data::Dumper;
+use DBI qw(:utils);
+use Digest::MD5 qw(md5_hex);
+use Encode;
+use JSON::PP;
+use Log::Any qw( $log );
 
 use Zonemaster::Backend::Config;
 
@@ -31,9 +31,10 @@ sub BUILD {
     my ( $self ) = @_;
 
     if ( !defined $self->dbh ) {
-        my $connection_string = sprintf( 'DBI:SQLite:dbname=%s', $self->config->SQLITE_file );
+        my $file = $self->config->SQLITE_file;
 
-        $log->debug( "Connection string: " . $connection_string );
+        my $connection_string = "DBI:SQLite:dbname=$file";
+        $log->debug( "SQLite opening: " . $connection_string );
 
         my $dbh = DBI->connect(
             $connection_string,
@@ -42,7 +43,7 @@ sub BUILD {
                 AutoCommit => 1,
                 RaiseError => 1,
             }
-        ) or die $DBI::errstr;
+        );
         $log->debug( "Database filename: " . $dbh->sqlite_db_filename );
 
         $self->dbh( $dbh );

--- a/script/create_db_mysql.pl
+++ b/script/create_db_mysql.pl
@@ -7,14 +7,13 @@ use Encode;
 use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB::MySQL;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
-my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
-my $db_name = Zonemaster::Backend::Config->load_config()->DB_name();
-my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
-
-my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
+my $config = Zonemaster::Backend::Config->load_config();
+if ( $config->BackendDBType() ne 'MySQL' ) {
+    die "The configuration file does not contain the MySQL backend";
+}
+my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;
 
 sub create_db {
 

--- a/script/create_db_postgresql_9.3.pl
+++ b/script/create_db_postgresql_9.3.pl
@@ -7,13 +7,14 @@ use Encode;
 use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB::PostgreSQL;
 
-die "The configuration file does not contain the PostgreSQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'postgresql');
-my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
-my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
-my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
-
-my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
+my $config = Zonemaster::Backend::Config->load_config();
+if ( $config->BackendDBType() ne 'PostgreSQL' ) {
+    die "The configuration file does not contain the MySQL backend";
+}
+my $dbh     = Zonemaster::Backend::DB::PostgreSQL->new( { config => $config } )->dbh;
+my $db_user = $config->POSTGRESQL_user;
 
 sub create_db {
 

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -54,18 +54,19 @@ Log::Any::Adapter->set(
     ),
 );
 
+my $config = Zonemaster::Backend::Config->load_config();
+
 builder {
     enable sub {
         my $app = shift;
 
         # Make sure we can connect to the database
-        Zonemaster::Backend::Config->load_config()->new_DB();
+        $config->new_DB();
 
         return $app;
     };
 };
 
-my $config = Zonemaster::Backend::Config->load_config;
 my $handler = Zonemaster::Backend::RPCAPI->new( { config => $config } );
 
 my $router = router {

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -18,7 +18,7 @@ password = zonemaster
 database = zonemaster
 
 [SQLITE]
-file = /var/lib/zonemaster/db.sqlite
+database_file = /var/lib/zonemaster/db.sqlite
 
 [ZONEMASTER]
 max_zonemaster_execution_time            = 300

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -3,11 +3,22 @@
 
 [DB]
 engine            = MySQL
-user              = zonemaster
-password          = zonemaster
-database_host     = localhost
-database_name     = zonemaster
 polling_interval  = 0.5
+
+[MYSQL]
+host     = localhost
+user     = zonemaster
+password = zonemaster
+database = zonemaster
+
+[POSTGRESQL]
+host     = localhost
+user     = zonemaster
+password = zonemaster
+database = zonemaster
+
+[SQLITE]
+file = /var/lib/zonemaster/db.sqlite
 
 [ZONEMASTER]
 max_zonemaster_execution_time            = 300

--- a/share/create_db_sqlite.pl
+++ b/share/create_db_sqlite.pl
@@ -9,12 +9,9 @@ use DBI qw(:utils);
 use Zonemaster::Backend::Config;
 use Zonemaster::Backend::DB::SQLite;
 
-die "The configuration file does not contain the SQLite backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'sqlite');
-my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
-my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
-my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
-
 my $config = Zonemaster::Backend::Config->load_config();
-
+if ( $config->BackendDBType() ne 'SQLite' ) {
+    die "The configuration file does not contain the SQLite backend";
+}
 my $db = Zonemaster::Backend::DB::SQLite->new( { config => $config } );
 $db->create_db();

--- a/share/patch_mysql_db_zonemaster_backend_ver_1.0.3.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_1.0.3.pl
@@ -7,14 +7,13 @@ use Encode;
 use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB::MySQL;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
-my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
-my $db_name = Zonemaster::Backend::Config->load_config()->DB_name();
-my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
-
-my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
+my $config = Zonemaster::Backend::Config->load_config();
+if ( $config->BackendDBType() ne 'MySQL' ) {
+    die "The configuration file does not contain the MySQL backend";
+}
+my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;
 
 sub patch_db {
 

--- a/share/patch_mysql_db_zonemaster_backend_ver_5.0.0.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_5.0.0.pl
@@ -7,14 +7,13 @@ use Encode;
 use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB::MySQL;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
-my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
-my $db_name = Zonemaster::Backend::Config->load_config()->DB_name();
-my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
-
-my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
+my $config = Zonemaster::Backend::Config->load_config();
+if ( $config->BackendDBType() ne 'MySQL' ) {
+    die "The configuration file does not contain the MySQL backend";
+}
+my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;
 
 sub patch_db {
     ####################################################################

--- a/share/patch_mysql_db_zonemaster_backend_ver_5.0.2.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_5.0.2.pl
@@ -7,14 +7,13 @@ use Encode;
 use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB::MySQL;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
-my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
-my $db_name = Zonemaster::Backend::Config->load_config()->DB_name();
-my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
-
-my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
+my $config = Zonemaster::Backend::Config->load_config();
+if ( $config->BackendDBType() ne 'MySQL' ) {
+    die "The configuration file does not contain the MySQL backend";
+}
+my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;
 
 sub patch_db {
     ############################################################################

--- a/share/patch_postgresql_db_zonemaster_backend_ver_1.0.3.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_1.0.3.pl
@@ -7,14 +7,13 @@ use Encode;
 use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB::MySQL;
 
-die "The configuration file does not contain the MySQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'mysql');
-my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
-my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
-my $db_name = Zonemaster::Backend::Config->load_config()->DB_name();
-my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
-
-my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
+my $config = Zonemaster::Backend::Config->load_config();
+if ( $config->BackendDBType() ne 'MySQL' ) {
+    die "The configuration file does not contain the MySQL backend";
+}
+my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;
 
 sub patch_db {
 

--- a/share/patch_postgresql_db_zonemaster_backend_ver_5.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_5.0.0.pl
@@ -7,14 +7,13 @@ use Encode;
 use DBI qw(:utils);
 
 use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB::PostgreSQL;
 
-die "The configuration file does not contain the PostgreSQL backend" unless (lc(Zonemaster::Backend::Config->load_config()->BackendDBType()) eq 'postgresql');
-my $db_user = Zonemaster::Backend::Config->load_config()->DB_user();
-my $db_password = Zonemaster::Backend::Config->load_config()->DB_password();
-my $db_name = Zonemaster::Backend::Config->load_config()->DB_name();
-my $connection_string = Zonemaster::Backend::Config->load_config()->DB_connection_string();
-
-my $dbh = DBI->connect( $connection_string, $db_user, $db_password, { RaiseError => 1, AutoCommit => 1 } );
+my $config = Zonemaster::Backend::Config->load_config();
+if ( $config->BackendDBType() ne 'PostgreSQL' ) {
+    die "The configuration file does not contain the PostgreSQL backend";
+}
+my $dbh = Zonemaster::Backend::DB::PostgreSQL->new( { config => $config } )->dbh;
 
 sub patch_db {
 

--- a/share/travis_mysql_backend_config.ini
+++ b/share/travis_mysql_backend_config.ini
@@ -1,13 +1,13 @@
 [DB]
 engine=MySQL
-# Next three lines are not used by the SQLite backend
-user=travis_zm
-password=travis_zonemaster
-database_host=localhost
-# If using SQLite, database_name is the full filename for the db
-database_name=travis_zonemaster
 polling_interval=0.5
 #seconds
+
+[MYSQL]
+user=travis_zm
+password=travis_zonemaster
+host=localhost
+database=travis_zonemaster
 
 [ZONEMASTER]
 max_zonemaster_execution_time=300

--- a/share/travis_postgresql_backend_config.ini
+++ b/share/travis_postgresql_backend_config.ini
@@ -1,13 +1,13 @@
 [DB]
 engine=PostgreSQL
-# Next three lines are not used by the SQLite backend
-user=travis_zonemaster
-password=travis_zonemaster
-database_host=localhost
-# If using SQLite, database_name is the full filename for the db
-database_name=travis_zonemaster
 polling_interval=0.5
 #seconds
+
+[POSTGRESQL]
+user=travis_zonemaster
+password=travis_zonemaster
+host=localhost
+database=travis_zonemaster
 
 [ZONEMASTER]
 max_zonemaster_execution_time=300

--- a/share/travis_sqlite_backend_config.ini
+++ b/share/travis_sqlite_backend_config.ini
@@ -4,7 +4,7 @@ polling_interval=0.5
 #seconds
 
 [SQLITE]
-file=/tmp/zonemaster
+database_file=/tmp/zonemaster
 
 [ZONEMASTER]
 max_zonemaster_execution_time=300

--- a/share/travis_sqlite_backend_config.ini
+++ b/share/travis_sqlite_backend_config.ini
@@ -1,13 +1,10 @@
 [DB]
 engine=SQLite
-# Next three lines are not used by the SQLite backend
-user=travis_zonemaster
-password=travis_zonemaster
-database_host=localhost
-# If using SQLite, database_name is the full filename for the db
-database_name=/tmp/zonemaster
 polling_interval=0.5
 #seconds
+
+[SQLITE]
+file=/tmp/zonemaster
 
 [ZONEMASTER]
 max_zonemaster_execution_time=300

--- a/share/zm-rpcapi.lsb
+++ b/share/zm-rpcapi.lsb
@@ -22,7 +22,7 @@ USER=${ZM_BACKEND_USER:-zonemaster}
 GROUP=${ZM_BACKEND_GROUP:-zonemaster}
 
 STARMAN=`PATH="$PATH:/usr/local/bin" /usr/bin/which starman`
-export ZM_BACKEND_RPCAPI_LOGLEVEL='warning' # Lowest level that will be logged
+#export ZM_BACKEND_RPCAPI_LOGLEVEL='warning'  # Set this variable to override the default log level
 
 . /lib/lsb/init-functions
 

--- a/share/zm-testagent.lsb
+++ b/share/zm-testagent.lsb
@@ -20,9 +20,9 @@ PIDFILE=${ZM_BACKEND_PIDFILE:-/var/run/zonemaster/zm-testagent.pid}
 USER=${ZM_BACKEND_USER:-zonemaster}
 GROUP=${ZM_BACKEND_GROUP:-zonemaster}
 
-#export ZM_BACKEND_TESTAGENT_LOGLEVEL='warning'  # Set this variable to override the default log level
+#export ZM_BACKEND_TESTAGENT_LOGLEVEL='info'  # Set this variable to override the default log level
 
-testagent_args="--logfile=$LOGFILE --outfile=$OUTFILE --pidfile=$PIDFILE --user=$USER --group=$GROUP"
+testagent_args="--loglevel=$ZM_BACKEND_TESTAGENT_LOGLEVEL --logfile=$LOGFILE --outfile=$OUTFILE --pidfile=$PIDFILE --user=$USER --group=$GROUP"
 
 start () {
     $BINDIR/zonemaster_backend_testagent $testagent_args start

--- a/share/zm-testagent.lsb
+++ b/share/zm-testagent.lsb
@@ -20,9 +20,12 @@ PIDFILE=${ZM_BACKEND_PIDFILE:-/var/run/zonemaster/zm-testagent.pid}
 USER=${ZM_BACKEND_USER:-zonemaster}
 GROUP=${ZM_BACKEND_GROUP:-zonemaster}
 
-#export ZM_BACKEND_TESTAGENT_LOGLEVEL='info'  # Set this variable to override the default log level
+#ZM_BACKEND_TESTAGENT_LOGLEVEL='info'  # Set this variable to override the default log level
 
-testagent_args="--loglevel=$ZM_BACKEND_TESTAGENT_LOGLEVEL --logfile=$LOGFILE --outfile=$OUTFILE --pidfile=$PIDFILE --user=$USER --group=$GROUP"
+testagent_args="--logfile=$LOGFILE --outfile=$OUTFILE --pidfile=$PIDFILE --user=$USER --group=$GROUP"
+if [ -n "$ZM_BACKEND_TESTAGENT_LOGLEVEL" ] ; then
+    testagent_args="$testagent_args --loglevel=$ZM_BACKEND_TESTAGENT_LOGLEVEL"
+fi
 
 start () {
     $BINDIR/zonemaster_backend_testagent $testagent_args start

--- a/share/zm-testagent.lsb
+++ b/share/zm-testagent.lsb
@@ -20,6 +20,8 @@ PIDFILE=${ZM_BACKEND_PIDFILE:-/var/run/zonemaster/zm-testagent.pid}
 USER=${ZM_BACKEND_USER:-zonemaster}
 GROUP=${ZM_BACKEND_GROUP:-zonemaster}
 
+#export ZM_BACKEND_TESTAGENT_LOGLEVEL='warning'  # Set this variable to override the default log level
+
 testagent_args="--logfile=$LOGFILE --outfile=$OUTFILE --pidfile=$PIDFILE --user=$USER --group=$GROUP"
 
 start () {

--- a/share/zm_rpcapi-bsd
+++ b/share/zm_rpcapi-bsd
@@ -18,7 +18,7 @@ load_rc_config $name
 : ${zm_rpcapi_listen="127.0.0.1:5000"}
 
 export ZONEMASTER_BACKEND_CONFIG_FILE="/usr/local/etc/zonemaster/backend_config.ini"
-export ZM_BACKEND_RPCAPI_LOGLEVEL='warning' # Lowest level that will be logged
+#export ZM_BACKEND_RPCAPI_LOGLEVEL='warning'  # Set this variable to override the default log level
 
 command="/usr/local/bin/starman"
 command_args="--daemonize --user=${zm_rpcapi_user} --group=${zm_rpcapi_group} --pid=${zm_rpcapi_pidfile} --error-log=${zm_rpcapi_logfile} --listen=${zm_rpcapi_listen} --app /usr/local/bin/zonemaster_backend_rpcapi.psgi"

--- a/share/zm_testagent-bsd
+++ b/share/zm_testagent-bsd
@@ -16,10 +16,13 @@ load_rc_config $name
 : ${zm_testagent_pidfile="/var/run/zonemaster/${name}.pid"}
 
 export ZONEMASTER_BACKEND_CONFIG_FILE="/usr/local/etc/zonemaster/backend_config.ini"
-#export ZM_BACKEND_TESTAGENT_LOGLEVEL='info'  # Set this variable to override the default log level
+#ZM_BACKEND_TESTAGENT_LOGLEVEL='info'  # Set this variable to override the default log level
 
 command="/usr/local/bin/zonemaster_backend_testagent"
-command_args="--loglevel=${ZM_BACKEND_TESTAGENT_LOGLEVEL} --user=${zm_testagent_user} --group=${zm_testagent_group} --pidfile=${zm_testagent_pidfile}"
+command_args="--user=${zm_testagent_user} --group=${zm_testagent_group} --pidfile=${zm_testagent_pidfile}"
+if [ -n "$ZM_BACKEND_TESTAGENT_LOGLEVEL" ] ; then
+    command_args="$testagent_args --loglevel=$ZM_BACKEND_TESTAGENT_LOGLEVEL"
+fi
 pidfile="${zm_testagent_pidfile}"
 procname="/usr/local/bin/perl"
 required_files="/usr/local/etc/zonemaster/backend_config.ini"

--- a/share/zm_testagent-bsd
+++ b/share/zm_testagent-bsd
@@ -16,10 +16,10 @@ load_rc_config $name
 : ${zm_testagent_pidfile="/var/run/zonemaster/${name}.pid"}
 
 export ZONEMASTER_BACKEND_CONFIG_FILE="/usr/local/etc/zonemaster/backend_config.ini"
-#export ZM_BACKEND_TESTAGENT_LOGLEVEL='warning'  # Set this variable to override the default log level
+#export ZM_BACKEND_TESTAGENT_LOGLEVEL='info'  # Set this variable to override the default log level
 
 command="/usr/local/bin/zonemaster_backend_testagent"
-command_args="--user=${zm_testagent_user} --group=${zm_testagent_group} --pidfile=${zm_testagent_pidfile}"
+command_args="--loglevel=${ZM_BACKEND_TESTAGENT_LOGLEVEL} --user=${zm_testagent_user} --group=${zm_testagent_group} --pidfile=${zm_testagent_pidfile}"
 pidfile="${zm_testagent_pidfile}"
 procname="/usr/local/bin/perl"
 required_files="/usr/local/etc/zonemaster/backend_config.ini"

--- a/share/zm_testagent-bsd
+++ b/share/zm_testagent-bsd
@@ -16,6 +16,7 @@ load_rc_config $name
 : ${zm_testagent_pidfile="/var/run/zonemaster/${name}.pid"}
 
 export ZONEMASTER_BACKEND_CONFIG_FILE="/usr/local/etc/zonemaster/backend_config.ini"
+#export ZM_BACKEND_TESTAGENT_LOGLEVEL='warning'  # Set this variable to override the default log level
 
 command="/usr/local/bin/zonemaster_backend_testagent"
 command_args="--user=${zm_testagent_user} --group=${zm_testagent_group} --pidfile=${zm_testagent_pidfile}"


### PR DESCRIPTION
## Purpose

This PR is about having separate a separate config section for each db engine.


## Context

Fixes #719.

As @matsduf pointed out, PR #717 must be merged before this is merged or else there is a risk of filling up the log files.


## Changes

Config format:
* New sections are added. The new section names are upper-case-only for consistency with previous sections.
* The old properties are deprecated.

Implementation:
* New accessor methods for the properties are added to Config.pm. They're named after the config section and property name, with an underscore in between. There is some precedence for this naming scheme in Config.pm.
* If the new properties are absent in the config file, the old ones are used as fallbacks to make sure old config files keep working.
* The accessors for the old properties are removed.
* The DB_connection_string() method didn't really belong in the Config module so I inlined it into the DB modules.

Installation:
* Newly obsolete steps in the installation instruction are cleaned up.
* The included config file is updated to the new format.

CI:
* The backend config files for travis are updated to the new format.

Database initialization:
* The initialization scripts now use the adapter class - they used to read accessors on the config object and construct its own handle. (Note that the SQLite initialization script is only used in the installation instruction while the MySQL and PostgreSQL dittos are only used for CI.)

Database upgrade:
* The database upgrade scripts are updated the same way as the database initialization scripts.

Logging:
* It's now possible to override ZM_BACKEND_RPCAPI_LOGLEVEL and ZM_BACKEND_TESTAGENT_LOGLEVEL when starting the daemons using the supplied init scripts.
* Logging of database connections is now more informative.
* Log messages emitted during the loading for the config file during startup is now output to the terminal (instead of being silently ignored).

## How to test this PR

This is a new feature, so older versions of Zonemaster need not be tested.

For more convenient testing of the database settings, set ZM_BACKEND_RPCAPI_LOGLEVEL and ZM_BACKEND_TESTAGENT_LOGLEVEL to notice or lower.

For each database engine:
1. Get the source from this PR.
   ```sh
   git clone --origin mattias-p --branch 719-db-sections https://github.com/mattias-p/zonemaster-backend.git
   cd zonemaster-backend
   ```
2. Verify that both daemons can be installed and that the SQLite database initialization works.
   1. Install Backend for according to the installation instruction, but instead of `cpanm Zonemaster::Backend` run `cpanm .`.
3. Verify that the installation uses the new configuration format.
      ```sh
      cat /etc/zonemaster/backend_config.ini
      ```
4. Verify that both daemons can be started using the old configuration format.
   1. Copy the share/backend_config.ini from the current develop branch into /etc/zonemaster.
      ```sh
      git remote add origin https://github.com/zonemaster/zonemaster-backend.git
      git fetch origin
      git checkout origin/develop
      sudo install -v -m 640 -g zonemaster share/backend_config.ini /etc/zonemaster/
      ```
   2. Update the DB.engine property for the current database engine according to the installation instruction.
   3. Stop the daemons.
      ```sh
      sudo service stop zm-rpcapi
      sudo sercive status zm-rpcapi
      sudo service stop zm-testagent
      sudo sercive status zm-testagent
      ```
   4. Start the daemons.
      ```sh
      sudo service start zm-rpcapi
      sudo sercive status zm-rpcapi
      sudo service start zm-testagent
      sudo sercive status zm-testagent
      ```
5. Verify that deprecation warnings are emitted to the log files of both rpcapi and testagent if the old configurations properties are present when the configuration file is loaded.
   ```sh
   cat /var/log/zonemaster/zm-testagent.log | grep deprecated
   journalctl -u zm-rpcapi.service | grep deprecated
   ```