### PR TITLE
SQLite: keep creation_time in UTC in test_results

### DIFF
--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -266,7 +266,7 @@ sub test_results {
     }
 
     my $result;
-    my ( $hrefs ) = $self->dbh->selectall_hashref( "SELECT id, hash_id, datetime(creation_time,'localtime') AS creation_time, params, results FROM test_results WHERE hash_id=?", 'hash_id', undef, $test_id );
+    my ( $hrefs ) = $self->dbh->selectall_hashref( "SELECT id, hash_id, creation_time, params, results FROM test_results WHERE hash_id=?", 'hash_id', undef, $test_id );
     $result            = $hrefs->{$test_id};
     $result->{params}  = decode_json( $result->{params} );
     $result->{results} = decode_json( $result->{results} );


### PR DESCRIPTION
With MySQL and PostgreSQL the `test_results` method converts the `creation_time` to UTC before returning it because it is stored in the local timezone. SQLite already stores the timestamp in UTC according to https://www.sqlite.org/lang_createtable.html

> If the default value of a column is CURRENT_TIME, CURRENT_DATE or CURRENT_TIMESTAMP, then the value used in the new row is a text representation of the current UTC date and/or time.

Therefore SQLite should not convert its `creation_time` field before returning it to be consistent with other databases. (I realize the documentation does not say anything on the timezone to use, I think this should be updated).

## How to test this PR

Independently to this PR, create a test with the PostgreSQL database and retrieve its `creation_time` :

```
$ date; zmb start_domain_test --domain example.com
Wed 31 Mar 2021 01:29:45 PM CEST
{"id":1,"jsonrpc":"2.0","result":"d148502b8a7f77b1"}

$ zmb get_test_results --lang en --testid d148502b8a7f77b1 | jq '.result.creation_time'
"2021-03-31 11:29:45.854403"
```

PostgreSQL returns the time in UTC.

Now before the PR, change to SQLite and create a test :

```
$ date; zmb start_domain_test --domain example.com
Wed 31 Mar 2021 01:34:50 PM CEST
{"result":"f80fc531882630ed","jsonrpc":"2.0","id":1}

$ zmb get_test_results --lang en --testid f80fc531882630ed | jq '.result.creation_time'
"2021-03-31 13:34:50"
```

With this PR, the output should be a UTC time (the RPCAPI daemon needs to be restarted)
```
$ zmb get_test_results --lang en --testid f80fc531882630ed | jq '.result.creation_time'
"2021-03-31 11:34:50"
```