### PR TITLE
RPCAPI catch error on missing params object

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -131,8 +131,9 @@ $json_schemas{get_host_by_name} = joi->object->strict->props(
 sub get_host_by_name {
     my ( $self, $params ) = @_;
     my @adresses;
+
     eval {
-        my $ns_name  = $params->{"hostname"};
+        my $ns_name  = $params->{hostname};
 
         @adresses = map { {$ns_name => $_->short} } $recursor->get_addresses_for($ns_name);
         @adresses = { $ns_name => '0.0.0.0' } if not @adresses;
@@ -157,7 +158,7 @@ sub get_data_from_parent_zone {
         if (ref \$params eq "SCALAR") {
             $domain = $params;
         } else {
-            $domain = $params->{"domain"};
+            $domain = $params->{domain};
         }
 
         my ( $dn, $dn_syntax ) = $self->_check_domain( $domain, 'Domain name' );
@@ -411,7 +412,7 @@ sub test_progress {
         if (ref \$params eq "SCALAR") {
             $test_id = $params;
         } else {
-            $test_id = $params->{"test_id"};
+            $test_id = $params->{test_id};
         }
 
         $result = $self->{db}->test_progress( $test_id );
@@ -429,7 +430,7 @@ $json_schemas{get_test_params} = joi->object->strict->props(
 sub get_test_params {
     my ( $self, $params ) = @_;
 
-    my $test_id = $params->{"test_id"};
+    my $test_id = $params->{test_id};
 
     my $result = 0;
 
@@ -639,7 +640,7 @@ sub get_batch_job_result {
     my $result;
 
     eval {
-        my $batch_id = $params->{"batch_id"};
+        my $batch_id = $params->{batch_id};
 
         $result = $self->{db}->get_batch_job_result($batch_id);
     };
@@ -657,7 +658,7 @@ sub jsonrpc_validate {
     my ( $self, $jsonrpc_request) = @_;
 
     my @error_rpc = $rpc_request->validate($jsonrpc_request);
-    if (!exists $jsonrpc_request->{"id"} || @error_rpc) {
+    if (!exists $jsonrpc_request->{id} || @error_rpc) {
         return {
             jsonrpc => '2.0',
             id => undef,
@@ -669,9 +670,9 @@ sub jsonrpc_validate {
         }
     }
 
-    if (exists $jsonrpc_request->{"params"}) {
+    if (exists $jsonrpc_request->{params}) {
 
-        my @error = $json_schemas{$jsonrpc_request->{"method"}}->validate($jsonrpc_request->{"params"});
+        my @error = $json_schemas{$jsonrpc_request->{method}}->validate($jsonrpc_request->{params});
         return {
                 jsonrpc => '2.0',
                 id => undef,

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -675,7 +675,7 @@ sub jsonrpc_validate {
         my @error = $json_schemas{$jsonrpc_request->{method}}->validate($jsonrpc_request->{params});
         return {
                 jsonrpc => '2.0',
-                id => undef,
+                id => $jsonrpc_request->{id},
                 error => {
                     code => '-32602',
                     message => 'Invalid method parameter(s).',

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -664,8 +664,8 @@ sub jsonrpc_validate {
             id => undef,
             error => {
                 code => '-32600',
-                message=> 'The JSON sent is not a valid request object.',
-                data => "@error_rpc\n"
+                message => 'The JSON sent is not a valid request object.',
+                data => "@error_rpc"
             }
         }
     }
@@ -678,8 +678,8 @@ sub jsonrpc_validate {
                 id => undef,
                 error => {
                     code => '-32602',
-                    message=> 'Invalid method parameter(s).',
-                    data => "@error\n"
+                    message => 'Invalid method parameter(s).',
+                    data => "@error"
                 }
             } if @error;
     }


### PR DESCRIPTION
Some RPCAPI methods require a `params` object. However not providing it results in an `Internal error` :

```
$ curl -sS -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "get_data_from_parent_zone"}' http://localhost:5000/ | jq .

{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "message": "Internal error 006 \n",
    "code": -32603
  }
}
```

But providing an erroneous `params` object give better feedback (the `domain` property is missing) :

```
$ curl -sS -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "get_data_from_parent_zone", "params": {}}' http://localhost:5000/ | jq .

{
  "jsonrpc": "2.0",
  "error": {
    "message": "Invalid method parameter(s).",
    "code": "-32602",
    "data": "/domain: Missing property.\n"
  },
  "id": null
}
```

Looking at the code, a missing `params` object is not caught before calling the right method. This PR fix this.
Because some methods do not require the `params` object (see `version_info`), the JSON schema of the method is inspected for the `required` key. If the key exists, then the `params` object should also exist.

## What does this PR do ?

* it catches missing `params` object when the desired method requires it (reusing error code `-32602`)
* it also return the request `id` if we were able to parse it, as expressed in the [JSON-RPC documentation](https://www.jsonrpc.org/specification#response_object)
* the trailing newline in the `data` property is removed
* refactor the code (remove quotes around hash property)

## A question

Two methods (`get_data_from_parent_zone` and `test_progress`) have a test on the `$params` variable. It is looking for a `SCALAR`.

```
       if (ref \$params eq "SCALAR") {
            $domain = $params;
        } else {
            $domain = $params->{"domain"};
        }
```

However, passing a scalar results in an error because of the JSON validation :

```
$ curl -sS -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "get_data_from_parent_zone", "params": "."}' http://localhost:5000/ | jq .
{
  "jsonrpc": "2.0",
  "id": null,
  "error": {
    "data": "/: Expected object - got string.\n",
    "code": "-32602",
    "message": "Invalid method parameter(s)."
  }
}
```

Do you think these tests are safe to remove ? 

## How to test this PR ?

### Catching the missing `params` object

#### Before

Call any methods that requires parameters, for instance [`get_host_by_name` (API v6.1.0)](https://github.com/zonemaster/zonemaster-backend/blob/v6.1.0/docs/API.md#api-method-get_host_by_name), without the `params` object, it does not fail (some method fail, see above) :
```
$ curl -sS -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "get_host_by_name"}' http://localhost:5000/ | jq .

{
  "jsonrpc": "2.0",
  "result": [
    {
      "": "0.0.0.0"
    }
  ],
  "id": 1
}
```

#### After

Do the same call, see the `error` property :

```
$ curl -sS -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "get_host_by_name"}' http://localhost:5000/ | jq .
{
  "id": 1,
  "error": {
    "message": "Missing 'params' object",
    "code": "-32602"
  },
  "jsonrpc": "2.0"
}
```

### Returning a valid `id`

Using the [`test_progress` (API v6.1.0)](https://github.com/zonemaster/zonemaster-backend/blob/v6.1.0/docs/API.md#api-method-test_progress) method.
#### Before

```
$ curl -sS -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "test_progress"}' http://localhost:5000/ | jq .
{
  "id": 1,
  "result": null,
  "jsonrpc": "2.0"
}
```

#### After

```
$ curl -sS -H "Content-Type: application/json" -d '{"jsonrpc": "2.0", "id": 1, "method": "test_progress"}' http://localhost:5000/ | jq .
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": "-32602",
    "message": "Missing 'params' object"
  }
}
```



By the way I noticed the Github label for `RPCAPI` has a typo, it says `RCPAPI` (it is also present [in the IssueLabels document](https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/maintenance/IssueLabels.md#labels))