### PR TITLE
Cleaning and fixing in the continuity of #731 and #734

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -151,15 +151,11 @@ $json_schemas{get_data_from_parent_zone} = joi->object->strict->props(
 );
 sub get_data_from_parent_zone {
     my ( $self, $params ) = @_;
-    my $domain = "";
 
     my $result = eval {
         my %result;
-        if (ref \$params eq "SCALAR") {
-            $domain = $params;
-        } else {
-            $domain = $params->{domain};
-        }
+
+        my $domain = $params->{domain};
 
         my ( $dn, $dn_syntax ) = $self->_check_domain( $domain, 'Domain name' );
         return $dn_syntax if ( $dn_syntax->{status} eq 'nok' );
@@ -408,13 +404,7 @@ sub test_progress {
 
     my $result = 0;
     eval {
-        my $test_id = "";
-        if (ref \$params eq "SCALAR") {
-            $test_id = $params;
-        } else {
-            $test_id = $params->{test_id};
-        }
-
+        my $test_id = $params->{test_id};
         $result = $self->{db}->test_progress( $test_id );
     };
     if ($@) {

--- a/t/test01.t
+++ b/t/test01.t
@@ -97,7 +97,7 @@ sub run_zonemaster_test_with_backend_API {
     is( scalar( $engine->{db}->dbh->selectrow_array( qq/SELECT id FROM test_results WHERE id=$test_id/ ) ), $test_id , 'API start_domain_test -> Test inserted in the DB' );
 
     # test test_progress API
-    is( $engine->test_progress( $hash_id ), 0 , 'API test_progress -> OK');
+    is( $engine->test_progress( { test_id => $hash_id } ), 0 , 'API test_progress -> OK');
 
     if ( not $ENV{ZONEMASTER_RECORD} ) {
         Zonemaster::Engine->preload_cache( $datafile );
@@ -113,7 +113,7 @@ sub run_zonemaster_test_with_backend_API {
 
     Zonemaster::Backend::TestAgent->reset() unless ( $ENV{ZONEMASTER_RECORD} );
 
-    is( $engine->test_progress( $hash_id ), 100 , 'API test_progress -> Test finished' );
+    is( $engine->test_progress( { test_id => $hash_id } ), 100 , 'API test_progress -> Test finished' );
 
     my $test_results = $engine->get_test_results( { id => $hash_id, language => 'fr_FR' } );
     ok( defined $test_results->{id},                 'TEST1 $test_results->{id} defined' );

--- a/t/test01.t
+++ b/t/test01.t
@@ -150,7 +150,7 @@ if ( $ENV{ZONEMASTER_RECORD} ) {
 done_testing();
 
 if ( $db_backend eq 'SQLite' ) {
-    my $dbfile = 'zonemaster';
+    my $dbfile = $engine->{db}->dbh->sqlite_db_filename;
     if ( -e $dbfile and -M $dbfile < 0 and -o $dbfile ) {
         unlink $dbfile;
     }


### PR DESCRIPTION
In #731 when using SQLite, the code suggests that the database file should be deleted if it was created for the tests. I forgot to update the path to the database file. This fixes that.

In #734 , I discover some old code, I decided to not touch it at that time as `test01.t` was using it. This removes this old code and updates `test01.t` accordingly.
There are calls to `test_progress` and to `get_data_from_parent_zone` using the `SCALAR` parameter in [`CodeSnippets/client.pl` (v6.1.0)](https://github.com/zonemaster/zonemaster-backend/blob/v6.1.0/CodeSnippets/client.pl). I'm not sure how up to date this snippet is, so I haven't updated it yet. I totally can if you think it is worth it.