### PR TITLE
Test Travis and Perl 5.32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,29 @@ language: perl
 
 jobs:
   include:
-  # Cover MySQL and PostgreSQL with the latest supported Perl version
+  - perl: "5.32.1"
+    env: TARGET=MySQL ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_mysql_backend_config.ini
+    services: mysql
+  - perl: "5.32.1"
+    env: TARGET=PostgreSQL ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_postgresql_backend_config.ini
+    services: postgresql
+  - perl: "5.32.1"
+    env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
+  - perl: "5.32.0"
+    env: TARGET=MySQL ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_mysql_backend_config.ini
+    services: mysql
+  - perl: "5.32.0"
+    env: TARGET=PostgreSQL ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_postgresql_backend_config.ini
+    services: postgresql
+  - perl: "5.32.0"
+    env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
   - perl: "5.32"
     env: TARGET=MySQL ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_mysql_backend_config.ini
     services: mysql
   - perl: "5.32"
     env: TARGET=PostgreSQL ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_postgresql_backend_config.ini
     services: postgresql
-  # Cover all Perl versions with SQLite
   - perl: "5.32"
-    env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
-  - perl: "5.30"
-    env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
-  - perl: "5.28"
-    env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
-  - perl: "5.26"
-    env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
-  - perl: "5.24"
-    env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
-  - perl: "5.22"
-    env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
-  - perl: "5.16"
     env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
 
 addons:


### PR DESCRIPTION
Just a try to see which Perl version should be defined to support 5.32 in Travis.

Do not merge.

Results :

* `- perl: "5.32.1"` : nope, Travis uses Perl 5.22 and this fails hard (I haven't investigate any further)
* `- perl: "5.32.0"` : this works, `This is perl 5, version 32, subversion 0 (v5.32.0) built for x86_64-linux`
* `- perl: "5.32"` : nope, Travis uses Perl 5.22, `This is perl 5, version 22, subversion 1 (v5.22.1) built for x86_64-linux-gnu-thread-multi`

So I think the string should be updated to `5.32.0` to make Travis use Perl 5.32