### PR TITLE
Parse config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ addons:
     - libfile-slurp-perl
     - libhtml-parser-perl
     - libio-captureoutput-perl
+    - libio-stringy-perl
     - libjson-pp-perl
     - libjson-rpc-perl
     - liblog-any-adapter-dispatch-perl
@@ -75,6 +76,7 @@ addons:
     - librole-tiny-perl
     - librouter-simple-perl
     - libstring-shellquote-perl
+    - libtest-nowarnings-perl
     - libtry-tiny-perl
     - starman
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,14 @@ language: perl
 jobs:
   include:
   # Cover MySQL and PostgreSQL with the latest supported Perl version
-  - perl: "5.32"
+  - perl: "5.32.0"
     env: TARGET=MySQL ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_mysql_backend_config.ini
     services: mysql
-  - perl: "5.32"
+  - perl: "5.32.0"
     env: TARGET=PostgreSQL ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_postgresql_backend_config.ini
     services: postgresql
   # Cover all Perl versions with SQLite
-  - perl: "5.32"
+  - perl: "5.32.0"
     env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
   - perl: "5.30"
     env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -36,6 +36,7 @@ requires
   ;
 
 test_requires 'DBD::SQLite';
+test_requires 'Test::NoWarnings';
 
 recommends 'DBD::mysql';
 recommends 'DBD::Pg';

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -60,7 +60,7 @@ for Zonemaster::Backend, see the [declaration of prerequisites].
 Install dependencies available from binary packages:
 
 ```sh
-sudo yum install jq perl-Class-Method-Modifiers perl-Config-IniFiles perl-DBD-SQLite perl-DBI perl-HTML-Parser perl-JSON-RPC perl-libwww-perl perl-Log-Dispatch perl-Net-Server perl-Parallel-ForkManager perl-Plack perl-Plack-Test perl-Role-Tiny perl-Router-Simple perl-String-ShellQuote perl-Test-Warn redhat-lsb-core
+sudo yum install jq perl-Class-Method-Modifiers perl-Config-IniFiles perl-DBD-SQLite perl-DBI perl-HTML-Parser perl-JSON-RPC perl-libwww-perl perl-Log-Dispatch perl-Net-Server perl-Parallel-ForkManager perl-Plack perl-Plack-Test perl-Role-Tiny perl-Router-Simple perl-String-ShellQuote perl-Test-NoWarnings perl-Test-Warn redhat-lsb-core
 ```
 
 > **Note:** perl-Net-Server and perl-Test-Warn are listed here even though they
@@ -268,8 +268,11 @@ sv_SE.utf8
 Install dependencies available from binary packages:
 
 ```sh
-sudo apt install jq libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libjson-pp-perl libjson-rpc-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtry-tiny-perl starman
+sudo apt install jq libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libio-stringy-perl libjson-pp-perl libjson-rpc-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtest-nowarnings-perl libtry-tiny-perl starman
 ```
+
+> **Note**: libio-stringy-perl is listed here even though it's not a direct
+> dependency. It's an undeclared dependency of libconfig-inifiles-perl.
 
 Install dependencies not available from binary packages:
 
@@ -444,7 +447,7 @@ su -l
 Install dependencies available from binary packages:
 
 ```sh
-pkg install jq p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote p5-DBD-SQLite p5-Log-Dispatch p5-Log-Any p5-Log-Any-Adapter-Dispatch p5-JSON-Validator p5-YAML-LibYAML
+pkg install jq p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote p5-DBD-SQLite p5-Log-Dispatch p5-Log-Any p5-Log-Any-Adapter-Dispatch p5-JSON-Validator p5-YAML-LibYAML p5-Test-NoWarnings
 ```
 <!-- JSON::Validator requires YAML::PP, but p5-JSON-Validator currently lacks a dependency on p5-YAML-LibYAML -->
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -1,9 +1,9 @@
 package Zonemaster::Backend::Config;
-our $VERSION = '1.1.0';
-
 use strict;
 use warnings;
 use 5.14.2;
+
+our $VERSION = '1.1.0';
 
 use Config;
 use Config::IniFiles;
@@ -29,29 +29,30 @@ Readonly my @SIG_NAME => split ' ', $Config{sig_name};
 =cut
 
 sub load_config {
-    my ( $class, $params ) = @_;
-    my $self = {};
+    my ( $class ) = @_;
 
+    my $obj = bless( {}, $class );
+
+    # Load file
     $log->notice( "Loading config: $path" );
 
-    $self->{cfg} = Config::IniFiles->new( -file => $path );
-    die "UNABLE TO LOAD $path ERRORS:[".join('; ', @Config::IniFiles::errors)."] \n" unless ( $self->{cfg} );
-    bless( $self, $class );
+    $obj->{cfg} = Config::IniFiles->new( -file => $path )
+      or die "UNABLE TO LOAD $path ERRORS:[" . join( '; ', @Config::IniFiles::errors ) . "]\n";
 
-    if ( defined $self->{cfg}->val( 'DB', 'database_host' ) ) {
+    if ( defined $obj->{cfg}->val( 'DB', 'database_host' ) ) {
         $log->warning( "Use of deprecated config property DB.database_host. Use MYSQL.host or POSTGRESQL.host instead." );
     }
-    if ( defined $self->{cfg}->val( 'DB', 'user' ) ) {
+    if ( defined $obj->{cfg}->val( 'DB', 'user' ) ) {
         $log->warning( "Use of deprecated config property DB.user. Use MYSQL.user or POSTGRESQL.user instead." );
     }
-    if ( defined $self->{cfg}->val( 'DB', 'password' ) ) {
+    if ( defined $obj->{cfg}->val( 'DB', 'password' ) ) {
         $log->warning( "Use of deprecated config property DB.password. Use MYSQL.password or POSTGRESQL.password instead." );
     }
-    if ( defined $self->{cfg}->val( 'DB', 'database_name' ) ) {
+    if ( defined $obj->{cfg}->val( 'DB', 'database_name' ) ) {
         $log->warning( "Use of deprecated config property DB.database_name. Use MYSQL.database, POSTGRESQL.database or SQLITE.database_file instead." );
     }
 
-    return $self;
+    return $obj;
 }
 
 sub check_db {

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -412,9 +412,9 @@ L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuratio
 
 =head3 RETURNS
 
-A scalar value of the number of minutes old the previous test with the same
+A scalar value of the number of seconds old the previous test with the same
 parameters can be when it is reused instead of starting a new test (default
-10). Note that it returns in minutes, whereas the input is in seconds.
+600).
 
 =cut
 
@@ -423,7 +423,6 @@ sub age_reuse_previous_test {
     my $default = 600; # in seconds
     my $val = $self->{cfg}->val( 'ZONEMASTER', 'age_reuse_previous_test', $default );
     $val = ($val > 0) ? $val : 0;
-    $val = int ( ($val / 60) + 0.5); # in minutes
     return $val;
 }
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -60,6 +60,7 @@ file.
     );
 
 Throws an exception if the given configuration file contains errors.
+Unrecognized sections and properties are silently ignored.
 
 =cut
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -122,45 +122,45 @@ sub parse {
         $obj->{_private_profiles}{lc $name} = $ini->val( 'PRIVATE PROFILES', $name );
     }
 
-    # Handle deprecated properties and precedence
+    # Handle deprecated properties
     if ( defined( my $value = $ini->val( 'DB', 'database_host' ) ) ) {
         $log->warning( "Use of deprecated config property DB.database_host. Use MYSQL.host or POSTGRESQL.host instead." );
 
         $obj->{_MYSQL_host} = $value
-          if !defined $obj->MYSQL_host;
+          if $obj->BackendDBType eq 'MySQL' && !defined $obj->MYSQL_host;
 
         $obj->{_POSTGRESQL_host} = $value
-          if !defined $obj->POSTGRESQL_host;
+          if $obj->BackendDBType eq 'PostgreSQL' && !defined $obj->POSTGRESQL_host;
     }
     if ( defined( my $value = $ini->val( 'DB', 'user' ) ) ) {
         $log->warning( "Use of deprecated config property DB.user. Use MYSQL.user or POSTGRESQL.user instead." );
 
         $obj->{_MYSQL_user} = $value
-          if !defined $obj->MYSQL_user;
+          if $obj->BackendDBType eq 'MySQL' && !defined $obj->MYSQL_user;
 
         $obj->{_POSTGRESQL_user} = $value
-          if !defined $obj->POSTGRESQL_user;
+          if $obj->BackendDBType eq 'PostgreSQL' && !defined $obj->POSTGRESQL_user;
     }
     if ( defined( my $value = $ini->val( 'DB', 'password' ) ) ) {
         $log->warning( "Use of deprecated config property DB.password. Use MYSQL.password or POSTGRESQL.password instead." );
 
         $obj->{_MYSQL_password} = $value
-          if !defined $obj->MYSQL_password;
+          if $obj->BackendDBType eq 'MySQL' && !defined $obj->MYSQL_password;
 
         $obj->{_POSTGRESQL_password} = $value
-          if !defined $obj->POSTGRESQL_password;
+          if $obj->BackendDBType eq 'PostgreSQL' && !defined $obj->POSTGRESQL_password;
     }
     if ( defined( my $value = $ini->val( 'DB', 'database_name' ) ) ) {
         $log->warning( "Use of deprecated config property DB.database_name. Use MYSQL.database, POSTGRESQL.database or SQLITE.database_file instead." );
 
         $obj->{_MYSQL_database} = $value
-          if !defined $obj->MYSQL_database;
+          if $obj->BackendDBType eq 'MySQL' && !defined $obj->MYSQL_database;
 
         $obj->{_POSTGRESQL_database} = $value
-          if !defined $obj->POSTGRESQL_database;
+          if $obj->BackendDBType eq 'PostgreSQL' && !defined $obj->POSTGRESQL_database;
 
         $obj->{_SQLITE_database_file} = $value
-          if !defined $obj->SQLITE_database_file;
+          if $obj->BackendDBType eq 'SQLite' && !defined $obj->SQLITE_database_file;
     }
     if ( defined( my $value = $ini->val( 'ZONEMASTER', 'number_of_professes_for_frontend_testing' ) ) ) {
         $log->warning( "Use of deprecated config property ZONEMASTER.number_of_professes_for_frontend_testing. Use ZONEMASTER.number_of_processes_for_frontend_testing instead." );

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -389,9 +389,10 @@ sub start_domain_test {
 
         $params->{priority}  //= 10;
         $params->{queue}     //= 0;
-        my $minutes_between_tests_with_same_params = $self->{config}->age_reuse_previous_test();
+        my $shelf_life_seconds = $self->{config}->age_reuse_previous_test;
+        my $shelf_life_minutes = int ( ($shelf_life_seconds / 60) + 0.5);
 
-        $result = $self->{db}->create_new_test( $params->{domain}, $params, $minutes_between_tests_with_same_params );
+        $result = $self->{db}->create_new_test( $params->{domain}, $params, $shelf_life_minutes );
     };
     if ($@) {
         handle_exception('start_domain_test', $@, '009');

--- a/share/travis_postgresql_backend_config.ini
+++ b/share/travis_postgresql_backend_config.ini
@@ -11,8 +11,8 @@ database=travis_zonemaster
 
 [ZONEMASTER]
 max_zonemaster_execution_time=300
-number_of_professes_for_frontend_testing=20
-number_of_professes_for_batch_testing=20
+number_of_processes_for_frontend_testing=20
+number_of_processes_for_batch_testing=20
 #seconds
 
 [LANGUAGE]

--- a/t/config.t
+++ b/t/config.t
@@ -19,13 +19,13 @@ subtest 'Everything but NoWarnings' => sub {
             polling_interval = 1.5
 
             [MYSQL]
-            host     = mysql_host
+            host     = mysql-host
             user     = mysql_user
             password = mysql_password
             database = mysql_database
 
             [POSTGRESQL]
-            host     = postgresql_host
+            host     = postgresql-host
             user     = postgresql_user
             password = postgresql_password
             database = postgresql_database
@@ -45,11 +45,11 @@ subtest 'Everything but NoWarnings' => sub {
         isa_ok $config, 'Zonemaster::Backend::Config', 'parse() return value';
         is $config->BackendDBType,                       'SQLite',                    'set: DB.engine';
         is $config->PollingInterval,                     1.5,                         'set: DB.polling_interval';
-        is $config->MYSQL_host,                          'mysql_host',                'set: MYSQL.host';
+        is $config->MYSQL_host,                          'mysql-host',                'set: MYSQL.host';
         is $config->MYSQL_user,                          'mysql_user',                'set: MYSQL.user';
         is $config->MYSQL_password,                      'mysql_password',            'set: MYSQL.password';
         is $config->MYSQL_database,                      'mysql_database',            'set: MYSQL.database';
-        is $config->POSTGRESQL_host,                     'postgresql_host',           'set: POSTGRESQL.host';
+        is $config->POSTGRESQL_host,                     'postgresql-host',           'set: POSTGRESQL.host';
         is $config->POSTGRESQL_user,                     'postgresql_user',           'set: POSTGRESQL.user';
         is $config->POSTGRESQL_password,                 'postgresql_password',       'set: POSTGRESQL.password';
         is $config->POSTGRESQL_database,                 'postgresql_database',       'set: POSTGRESQL.database';
@@ -80,21 +80,21 @@ subtest 'Everything but NoWarnings' => sub {
         my $text = q{
             [DB]
             engine        = SQLite
-            database_host = db_host
+            database_host = db-host
             user          = db_user
             password      = db_password
             database_name = db_database
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
-        $log->contains_ok( qr/deprecated.*DB\.database_host/, 'deprecated: DB.database_host' );
+        $log->contains_ok( qr/deprecated.*DB\.database-host/, 'deprecated: DB.database_host' );
         $log->contains_ok( qr/deprecated.*DB\.user/,          'deprecated: DB.user' );
         $log->contains_ok( qr/deprecated.*DB\.password/,      'deprecated: DB.password' );
         $log->contains_ok( qr/deprecated.*DB\.database_name/, 'deprecated: DB.database_name' );
-        is $config->MYSQL_host,           'db_host',     'fallback: MYSQL.host';
+        is $config->MYSQL_host,           'db-host',     'fallback: MYSQL.host';
         is $config->MYSQL_user,           'db_user',     'fallback: MYSQL.user';
         is $config->MYSQL_password,       'db_password', 'fallback: MYSQL.password';
         is $config->MYSQL_database,       'db_database', 'fallback: MYSQL.database';
-        is $config->POSTGRESQL_host,      'db_host',     'fallback: POSTGRESQL.host';
+        is $config->POSTGRESQL_host,      'db-host',     'fallback: POSTGRESQL.host';
         is $config->POSTGRESQL_user,      'db_user',     'fallback: POSTGRESQL.user';
         is $config->POSTGRESQL_password,  'db_password', 'fallback: POSTGRESQL.password';
         is $config->POSTGRESQL_database,  'db_database', 'fallback: POSTGRESQL.database';

--- a/t/config.t
+++ b/t/config.t
@@ -79,26 +79,58 @@ subtest 'Everything but NoWarnings' => sub {
     lives_and {
         my $text = q{
             [DB]
-            engine        = SQLite
+            engine        = MySQL
             database_host = db-host
             user          = db_user
             password      = db_password
             database_name = db_database
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
-        $log->contains_ok( qr/deprecated.*DB\.database-host/, 'deprecated: DB.database_host' );
+        $log->contains_ok( qr/deprecated.*DB\.database_host/, 'deprecated: DB.database_host' );
         $log->contains_ok( qr/deprecated.*DB\.user/,          'deprecated: DB.user' );
         $log->contains_ok( qr/deprecated.*DB\.password/,      'deprecated: DB.password' );
         $log->contains_ok( qr/deprecated.*DB\.database_name/, 'deprecated: DB.database_name' );
-        is $config->MYSQL_host,           'db-host',     'fallback: MYSQL.host';
-        is $config->MYSQL_user,           'db_user',     'fallback: MYSQL.user';
-        is $config->MYSQL_password,       'db_password', 'fallback: MYSQL.password';
-        is $config->MYSQL_database,       'db_database', 'fallback: MYSQL.database';
-        is $config->POSTGRESQL_host,      'db-host',     'fallback: POSTGRESQL.host';
-        is $config->POSTGRESQL_user,      'db_user',     'fallback: POSTGRESQL.user';
-        is $config->POSTGRESQL_password,  'db_password', 'fallback: POSTGRESQL.password';
-        is $config->POSTGRESQL_database,  'db_database', 'fallback: POSTGRESQL.database';
-        is $config->SQLITE_database_file, 'db_database', 'fallback: SQLITE.database_file';
+        is $config->MYSQL_host,     'db-host',     'fallback: MYSQL.host';
+        is $config->MYSQL_user,     'db_user',     'fallback: MYSQL.user';
+        is $config->MYSQL_password, 'db_password', 'fallback: MYSQL.password';
+        is $config->MYSQL_database, 'db_database', 'fallback: MYSQL.database';
+    };
+
+    lives_and {
+        my $text = q{
+            [DB]
+            engine        = PostgreSQL
+            database_host = db-host
+            user          = db_user
+            password      = db_password
+            database_name = db_database
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        $log->contains_ok( qr/deprecated.*DB\.database_host/, 'deprecated: DB.database_host' );
+        $log->contains_ok( qr/deprecated.*DB\.user/,          'deprecated: DB.user' );
+        $log->contains_ok( qr/deprecated.*DB\.password/,      'deprecated: DB.password' );
+        $log->contains_ok( qr/deprecated.*DB\.database_name/, 'deprecated: DB.database_name' );
+        is $config->POSTGRESQL_host,     'db-host',     'fallback: POSTGRESQL.host';
+        is $config->POSTGRESQL_user,     'db_user',     'fallback: POSTGRESQL.user';
+        is $config->POSTGRESQL_password, 'db_password', 'fallback: POSTGRESQL.password';
+        is $config->POSTGRESQL_database, 'db_database', 'fallback: POSTGRESQL.database';
+    };
+
+    lives_and {
+        my $text = q{
+            [DB]
+            engine        = SQLite
+            database_host = db-host
+            user          = db_user
+            password      = db_password
+            database_name = /var/db/zonemaster.sqlite
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        $log->contains_ok( qr/deprecated.*DB\.database_host/, 'deprecated: DB.database_host' );
+        $log->contains_ok( qr/deprecated.*DB\.user/,          'deprecated: DB.user' );
+        $log->contains_ok( qr/deprecated.*DB\.password/,      'deprecated: DB.password' );
+        $log->contains_ok( qr/deprecated.*DB\.database_name/, 'deprecated: DB.database_name' );
+        is $config->SQLITE_database_file, '/var/db/zonemaster.sqlite', 'fallback: SQLITE.database_file';
     };
 
     throws_ok {

--- a/t/config.t
+++ b/t/config.t
@@ -112,8 +112,7 @@ subtest 'Everything but NoWarnings' => sub {
             [DB]
             engine = Excel
         };
-        my $config = Zonemaster::Backend::Config->parse( $text );
-        $config->BackendDBType;
+        Zonemaster::Backend::Config->parse( $text );
     }
     qr/DB\.engine.*Excel/, 'die: Invalid DB.engine value';
 
@@ -128,8 +127,7 @@ subtest 'Everything but NoWarnings' => sub {
             [LANGUAGE]
             locale = English
         };
-        my $config = Zonemaster::Backend::Config->parse( $text );
-        $config->Language_Locale_hash;
+        Zonemaster::Backend::Config->parse( $text );
     }
     qr/LANGUAGE\.locale.*English/, 'die: Invalid locale_tag in LANGUAGE.locale';
 
@@ -144,8 +142,7 @@ subtest 'Everything but NoWarnings' => sub {
             [LANGUAGE]
             locale = en_US en_US
         };
-        my $config = Zonemaster::Backend::Config->parse( $text );
-        $config->Language_Locale_hash;
+        Zonemaster::Backend::Config->parse( $text );
     }
     qr/LANGUAGE\.locale.*en_US/, 'die: Repeated locale_tag in LANGUAGE.locale';
 };

--- a/t/config.t
+++ b/t/config.t
@@ -1,0 +1,151 @@
+use strict;
+use warnings;
+use utf8;
+
+use Test::More tests => 2;
+use Test::NoWarnings;
+use Test::Exception;
+use Log::Any::Test;    # Must come before use Log::Any
+use Log::Any qw( $log );
+
+subtest 'Everything but NoWarnings' => sub {
+
+    use_ok( 'Zonemaster::Backend::Config' );
+
+    lives_and {
+        my $text = q{
+            [DB]
+            engine           = sqlite
+            polling_interval = 1.5
+
+            [MYSQL]
+            host     = mysql_host
+            user     = mysql_user
+            password = mysql_password
+            database = mysql_database
+
+            [POSTGRESQL]
+            host     = postgresql_host
+            user     = postgresql_user
+            password = postgresql_password
+            database = postgresql_database
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [ZONEMASTER]
+            max_zonemaster_execution_time            = 1200
+            number_of_processes_for_frontend_testing = 30
+            number_of_processes_for_batch_testing    = 40
+            lock_on_queue                            = 1
+            maximal_number_of_retries                = 2
+            age_reuse_previous_test                  = 800
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        isa_ok $config, 'Zonemaster::Backend::Config', 'parse() return value';
+        is $config->BackendDBType,                       'SQLite',                    'set: DB.engine';
+        is $config->PollingInterval,                     1.5,                         'set: DB.polling_interval';
+        is $config->MYSQL_host,                          'mysql_host',                'set: MYSQL.host';
+        is $config->MYSQL_user,                          'mysql_user',                'set: MYSQL.user';
+        is $config->MYSQL_password,                      'mysql_password',            'set: MYSQL.password';
+        is $config->MYSQL_database,                      'mysql_database',            'set: MYSQL.database';
+        is $config->POSTGRESQL_host,                     'postgresql_host',           'set: POSTGRESQL.host';
+        is $config->POSTGRESQL_user,                     'postgresql_user',           'set: POSTGRESQL.user';
+        is $config->POSTGRESQL_password,                 'postgresql_password',       'set: POSTGRESQL.password';
+        is $config->POSTGRESQL_database,                 'postgresql_database',       'set: POSTGRESQL.database';
+        is $config->SQLITE_database_file,                '/var/db/zonemaster.sqlite', 'set: SQLITE.database_file';
+        is $config->MaxZonemasterExecutionTime,          1200,                        'set: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->maximal_number_of_retries,           2,                           'set: ZONEMASTER.maximal_number_of_retries';
+        is $config->NumberOfProcessesForFrontendTesting, 30,                          'set: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->NumberOfProcessesForBatchTesting,    40,                          'set: ZONEMASTER.number_of_processes_for_batch_testing';
+        is $config->lock_on_queue,                       1,                           'set: ZONEMASTER.lock_on_queue';
+        is $config->age_reuse_previous_test,             800,                         'set: ZONEMASTER.age_reuse_previous_test';
+    };
+
+    lives_and {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        is $config->MaxZonemasterExecutionTime, 600, 'default: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->maximal_number_of_retries,  0,   'default: ZONEMASTER.maximal_number_of_retries';
+        is $config->age_reuse_previous_test,    600, 'default: ZONEMASTER.age_reuse_previous_test';
+    };
+
+    lives_and {
+        my $text = q{
+            [DB]
+            engine        = SQLite
+            database_host = db_host
+            user          = db_user
+            password      = db_password
+            database_name = db_database
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        $log->contains_ok( qr/deprecated.*DB\.database_host/, 'deprecated: DB.database_host' );
+        $log->contains_ok( qr/deprecated.*DB\.user/,          'deprecated: DB.user' );
+        $log->contains_ok( qr/deprecated.*DB\.password/,      'deprecated: DB.password' );
+        $log->contains_ok( qr/deprecated.*DB\.database_name/, 'deprecated: DB.database_name' );
+        is $config->MYSQL_host,           'db_host',     'fallback: MYSQL.host';
+        is $config->MYSQL_user,           'db_user',     'fallback: MYSQL.user';
+        is $config->MYSQL_password,       'db_password', 'fallback: MYSQL.password';
+        is $config->MYSQL_database,       'db_database', 'fallback: MYSQL.database';
+        is $config->POSTGRESQL_host,      'db_host',     'fallback: POSTGRESQL.host';
+        is $config->POSTGRESQL_user,      'db_user',     'fallback: POSTGRESQL.user';
+        is $config->POSTGRESQL_password,  'db_password', 'fallback: POSTGRESQL.password';
+        is $config->POSTGRESQL_database,  'db_database', 'fallback: POSTGRESQL.database';
+        is $config->SQLITE_database_file, 'db_database', 'fallback: SQLITE.database_file';
+    };
+
+    throws_ok {
+        my $text = '{"this":"is","not":"a","valid":"ini","file":"!"}';
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/Failed to parse config/, 'die: Invalid INI format';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = Excel
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        $config->BackendDBType;
+    }
+    qr/DB\.engine.*Excel/, 'die: Invalid DB.engine value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [LANGUAGE]
+            locale = English
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        $config->Language_Locale_hash;
+    }
+    qr/LANGUAGE\.locale.*English/, 'die: Invalid locale_tag in LANGUAGE.locale';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [LANGUAGE]
+            locale = en_US en_US
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        $config->Language_Locale_hash;
+    }
+    qr/LANGUAGE\.locale.*en_US/, 'die: Repeated locale_tag in LANGUAGE.locale';
+};


### PR DESCRIPTION
## Purpose

This PR adds Zonemaster::Backend::Config->parse(). This method makes unit testing more predictable by letting unit tests embed their configuration(s) instead of having Zonemaster::Backend::Config figure out which file to open and read and risking to use another configuration than the one the developer intended.

An illustration of how such unit tests can be written is provided in t/config.t.

## Context

This PR is made as a first step towards #685, but it also provides a way to update other unit tests to make them more predictable.

## Changes

Zonemaster::Backend::Config:
* Z::B::Config->parse() is broken out from Z::B::Config->load_config().
* Existing validations are moved out from accessor methods and into parse().
* Some drive-by clean-up of the Z::B::Config code.
* A seconds-to-minutes conversion is moved away from Z::B::Config and into business logic code.

Dependencies:
* Add test dependency on Test::NoWarnings. Used in the new t/config.t. It makes unit tests fail if warnings are emitted.
* Install libio-stringy-perl on Debian. It's an undeclared dependency of libconfig-inifiles-perl.

Travis config:
* The version number of to Perl 5.32 is fixed. (Credits to @pnax for investigating.)

## How to test this PR

Run the unit tests. They're automatically run as part of CI but in principle it's a good idea to verify they also work locally.

The new t/config.t file contains tests for all important aspects of Z::B::Config->parse().
The old t/test01.t verifies that the old Z::B::Config->load_config() still works the same way.