### PR TITLE
Validate simple properties

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -59,6 +59,7 @@ over this.
 ### polling_interval
 
 Time in seconds between database lookups by Test Agent.
+Default value: `0.5`.
 
 
 ## MYSQL section
@@ -264,20 +265,27 @@ Number of time a test is allowed to be run again if unfinished after
 
 used -> todo
 
+Default value: `20`.
+
 ### number_of_processes_for_batch_testing
 
 used -> todo
+
+Default value: `20`.
 
 ### lock_on_queue
 
 Integer working as a label to associate a test to a specific Test Agent.
 
+Default value: `0`.
+
 ### age_reuse_previous_test
 
-Positiv integer (in seconds) for how old a previous test of the same
-zone name and parameters must be before we start a new test. Internally
-the value is converted to whole minutes. If the conversion results in
-zero minutes, then the default value (600 seconds) is used.
+Positive integer (in seconds) for how old a previous test of the same
+zone name and parameters must be before we start a new test.
+Default value: `600`.
+
+Internally the value is converted to the nearest whole number of minutes.
 
 --------
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -84,7 +84,7 @@ sub parse {
         $obj->{_DB_engine} = $engine;
     }
 
-    $obj->{_DB_polling_interval}                                 = $ini->val( 'DB',         'polling_interval',                         undef );
+    $obj->{_DB_polling_interval}                                 = $ini->val( 'DB',         'polling_interval',                         '0.5' );
     $obj->{_MYSQL_host}                                          = $ini->val( 'MYSQL',      'host',                                     undef );
     $obj->{_MYSQL_user}                                          = $ini->val( 'MYSQL',      'user',                                     undef );
     $obj->{_MYSQL_password}                                      = $ini->val( 'MYSQL',      'password',                                 undef );
@@ -96,9 +96,9 @@ sub parse {
     $obj->{_SQLITE_database_file}                                = $ini->val( 'SQLITE',     'database_file',                            undef );
     $obj->{_ZONEMASTER_max_zonemaster_execution_time}            = $ini->val( 'ZONEMASTER', 'max_zonemaster_execution_time',            '600' );
     $obj->{_ZONEMASTER_maximal_number_of_retries}                = $ini->val( 'ZONEMASTER', 'maximal_number_of_retries',                '0' );
-    $obj->{_ZONEMASTER_number_of_processes_for_frontend_testing} = $ini->val( 'ZONEMASTER', 'number_of_processes_for_frontend_testing', undef );
-    $obj->{_ZONEMASTER_number_of_processes_for_batch_testing}    = $ini->val( 'ZONEMASTER', 'number_of_processes_for_batch_testing',    undef );
-    $obj->{_ZONEMASTER_lock_on_queue}                            = $ini->val( 'ZONEMASTER', 'lock_on_queue',                            undef );
+    $obj->{_ZONEMASTER_number_of_processes_for_frontend_testing} = $ini->val( 'ZONEMASTER', 'number_of_processes_for_frontend_testing', '20' );
+    $obj->{_ZONEMASTER_number_of_processes_for_batch_testing}    = $ini->val( 'ZONEMASTER', 'number_of_processes_for_batch_testing',    '20' );
+    $obj->{_ZONEMASTER_lock_on_queue}                            = $ini->val( 'ZONEMASTER', 'lock_on_queue',                            '0' );
     $obj->{_ZONEMASTER_age_reuse_previous_test}                  = $ini->val( 'ZONEMASTER', 'age_reuse_previous_test',                  '600' );
 
     $obj->{_LANGUAGE_locale} = {};
@@ -394,6 +394,12 @@ sub ListLanguageTags {
     return @langtags;
 }
 
+=head2 PollingInterval
+
+Default value: 0.
+
+=cut
+
 sub PollingInterval {
     my ($self) = @_;
 
@@ -430,7 +436,7 @@ L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuratio
 
 =head3 RETURNS
 
-Positive integer.
+Positive integer, default 20.
 
 =cut
 
@@ -450,7 +456,7 @@ L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuratio
 
 =head3 RETURNS
 
-Integer.
+Integer, default 20.
 
 =cut
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -47,6 +47,23 @@ sub ZONEMASTER_number_of_processes_for_frontend_testing { return $_[0]->{_ZONEMA
 sub ZONEMASTER_number_of_processes_for_batch_testing    { return $_[0]->{_ZONEMASTER_number_of_processes_for_batch_testing}; }
 sub ZONEMASTER_age_reuse_previous_test                  { return $_[0]->{_ZONEMASTER_age_reuse_previous_test}; }
 
+sub _set_DB_engine                                           { $_[0]->{_DB_engine}                                           = _check_engine_type( $_[1] )      // die "Invalid value for DB.engine: $_[1]\n";                                           return; }
+sub _set_DB_polling_interval                                 { $_[0]->{_DB_polling_interval}                                 = _check_positive_real( $_[1] )    // die "Invalid value for DB.polling_interval: $_[1]\n";                                 return; }
+sub _set_MYSQL_host                                          { $_[0]->{_MYSQL_host}                                          = _check_hostname( $_[1] )         // die "Invalid value for MYSQL.host: $_[1]\n";                                          return; }
+sub _set_MYSQL_user                                          { $_[0]->{_MYSQL_user}                                          = _check_mariadb_ident( $_[1] )    // die "Invalid value for MYSQL.user: $_[1]\n";                                          return; }
+sub _set_MYSQL_password                                      { $_[0]->{_MYSQL_password}                                      = _check_password( $_[1] )         // die "Invalid value for MYSQL.password: $_[1]\n";                                      return; }
+sub _set_MYSQL_database                                      { $_[0]->{_MYSQL_database}                                      = _check_mariadb_ident( $_[1] )    // die "Invalid value for MYSQL.database: $_[1]\n";                                      return; }
+sub _set_POSTGRESQL_host                                     { $_[0]->{_POSTGRESQL_host}                                     = _check_hostname( $_[1] )         // die "Invalid value for POSTGRESQL.host: $_[1]\n";                                     return; }
+sub _set_POSTGRESQL_user                                     { $_[0]->{_POSTGRESQL_user}                                     = _check_postgresql_ident( $_[1] ) // die "Invalid value for POSTGRESQL.user: $_[1]\n";                                     return; }
+sub _set_POSTGRESQL_password                                 { $_[0]->{_POSTGRESQL_password}                                 = _check_password( $_[1] )         // die "Invalid value for POSTGRESQL.password: $_[1]\n";                                 return; }
+sub _set_POSTGRESQL_database                                 { $_[0]->{_POSTGRESQL_database}                                 = _check_postgresql_ident( $_[1] ) // die "Invalid value for POSTGRESQL.database: $_[1]\n";                                 return; }
+sub _set_SQLITE_database_file                                { $_[0]->{_SQLITE_database_file}                                = _check_abs_path( $_[1] )         // die "Invalid value for SQLITE.database_file: $_[1]\n";                                return; }
+sub _set_ZONEMASTER_max_zonemaster_execution_time            { $_[0]->{_ZONEMASTER_max_zonemaster_execution_time}            = _check_unsigned_int( $_[1] )     // die "Invalid value for ZONEMASTER.max_zonemaster_execution_time: $_[1]\n";            return; }
+sub _set_ZONEMASTER_maximal_number_of_retries                { $_[0]->{_ZONEMASTER_maximal_number_of_retries}                = _check_unsigned_int( $_[1] )     // die "Invalid value for ZONEMASTER.maximal_number_of_retries: $_[1]\n";                return; }
+sub _set_ZONEMASTER_lock_on_queue                            { $_[0]->{_ZONEMASTER_lock_on_queue}                            = _check_unsigned_int( $_[1] )     // die "Invalid value for ZONEMASTER.lock_on_queue: $_[1]\n";                            return; }
+sub _set_ZONEMASTER_number_of_processes_for_frontend_testing { $_[0]->{_ZONEMASTER_number_of_processes_for_frontend_testing} = _check_positive_int( $_[1] )     // die "Invalid value for ZONEMASTER.number_of_processes_for_frontend_testing: $_[1]\n"; return; }
+sub _set_ZONEMASTER_number_of_processes_for_batch_testing    { $_[0]->{_ZONEMASTER_number_of_processes_for_batch_testing}    = _check_positive_int( $_[1] )     // die "Invalid value for ZONEMASTER.number_of_processes_for_batch_testing: $_[1]\n";    return; }
+sub _set_ZONEMASTER_age_reuse_previous_test                  { $_[0]->{_ZONEMASTER_age_reuse_previous_test}                  = _check_positive_int( $_[1] )     // die "Invalid value for ZONEMASTER.age_reuse_previous_test: $_[1]\n";                  return; }
 
 =head2 load_config
 
@@ -63,6 +80,14 @@ Throws an exception if the given configuration file contains errors.
 In a valid config file:
 
 =over 4
+
+=item
+
+All property values are valid, and
+
+=item
+
+all required properties are present, and
 
 =item
 
@@ -106,6 +131,7 @@ Throws an exception if the given configuration file contains errors.
 
 =cut
 
+
 sub parse {
     my ( $class, $text ) = @_;
 
@@ -142,22 +168,58 @@ sub parse {
         $obj->{_DB_engine} = $engine;
     }
 
-    $obj->{_DB_polling_interval}                                 = $get_and_clear->( 'DB',         'polling_interval' )                         // '0.5';
-    $obj->{_MYSQL_host}                                          = $get_and_clear->( 'MYSQL',      'host' )                                     // undef;
-    $obj->{_MYSQL_user}                                          = $get_and_clear->( 'MYSQL',      'user' )                                     // undef;
-    $obj->{_MYSQL_password}                                      = $get_and_clear->( 'MYSQL',      'password' )                                 // undef;
-    $obj->{_MYSQL_database}                                      = $get_and_clear->( 'MYSQL',      'database' )                                 // undef;
-    $obj->{_POSTGRESQL_host}                                     = $get_and_clear->( 'POSTGRESQL', 'host' )                                     // undef;
-    $obj->{_POSTGRESQL_user}                                     = $get_and_clear->( 'POSTGRESQL', 'user' )                                     // undef;
-    $obj->{_POSTGRESQL_password}                                 = $get_and_clear->( 'POSTGRESQL', 'password' )                                 // undef;
-    $obj->{_POSTGRESQL_database}                                 = $get_and_clear->( 'POSTGRESQL', 'database' )                                 // undef;
-    $obj->{_SQLITE_database_file}                                = $get_and_clear->( 'SQLITE',     'database_file' )                            // undef;
-    $obj->{_ZONEMASTER_max_zonemaster_execution_time}            = $get_and_clear->( 'ZONEMASTER', 'max_zonemaster_execution_time' )            // '600';
-    $obj->{_ZONEMASTER_maximal_number_of_retries}                = $get_and_clear->( 'ZONEMASTER', 'maximal_number_of_retries' )                // '0';
-    $obj->{_ZONEMASTER_number_of_processes_for_frontend_testing} = $get_and_clear->( 'ZONEMASTER', 'number_of_processes_for_frontend_testing' ) // '20';
-    $obj->{_ZONEMASTER_number_of_processes_for_batch_testing}    = $get_and_clear->( 'ZONEMASTER', 'number_of_processes_for_batch_testing' )    // '20';
-    $obj->{_ZONEMASTER_lock_on_queue}                            = $get_and_clear->( 'ZONEMASTER', 'lock_on_queue' )                            // '0';
-    $obj->{_ZONEMASTER_age_reuse_previous_test}                  = $get_and_clear->( 'ZONEMASTER', 'age_reuse_previous_test' )                  // '600';
+    # Validate, untaint, normalize and store property values or defaults
+    if ( defined( my $value = $get_and_clear->( 'DB', 'engine' ) ) ) {
+        $obj->_set_DB_engine( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'DB', 'polling_interval' ) // '0.5' ) ) {
+        $obj->_set_DB_polling_interval( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'MYSQL', 'host' ) ) ) {
+        $obj->_set_MYSQL_host( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'MYSQL', 'user' ) ) ) {
+        $obj->_set_MYSQL_user( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'MYSQL', 'password' ) ) ) {
+        $obj->_set_MYSQL_password( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'MYSQL', 'database' ) ) ) {
+        $obj->_set_MYSQL_database( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'POSTGRESQL', 'host' ) ) ) {
+        $obj->_set_POSTGRESQL_host( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'POSTGRESQL', 'user' ) ) ) {
+        $obj->_set_POSTGRESQL_user( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'POSTGRESQL', 'password' ) ) ) {
+        $obj->_set_POSTGRESQL_password( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'POSTGRESQL', 'database' ) ) ) {
+        $obj->_set_POSTGRESQL_database( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'SQLITE', 'database_file' ) ) ) {
+        $obj->_set_SQLITE_database_file( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'max_zonemaster_execution_time' ) // '600' ) ) {
+        $obj->_set_ZONEMASTER_max_zonemaster_execution_time( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'maximal_number_of_retries' ) // '0' ) ) {
+        $obj->_set_ZONEMASTER_maximal_number_of_retries( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_processes_for_frontend_testing' ) // '20' ) ) {
+        $obj->_set_ZONEMASTER_number_of_processes_for_frontend_testing( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_processes_for_batch_testing' ) // '20' ) ) {
+        $obj->_set_ZONEMASTER_number_of_processes_for_batch_testing( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'lock_on_queue' ) // '0' ) ) {
+        $obj->_set_ZONEMASTER_lock_on_queue( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'age_reuse_previous_test' ) // '600' ) ) {
+        $obj->_set_ZONEMASTER_age_reuse_previous_test( $value );
+    }
 
     $obj->{_LANGUAGE_locale} = {};
     for my $locale_tag ( split /\s+/, $get_and_clear->( 'LANGUAGE', 'locale' ) || 'en_US' ) {
@@ -181,58 +243,96 @@ sub parse {
         $obj->{_private_profiles}{lc $name} = $get_and_clear->( 'PRIVATE PROFILES', $name );
     }
 
+    # Check required propertys (part 1/2)
+    die "config: missing required property DB.engine\n"
+      if !defined $obj->DB_engine;
+
     # Handle deprecated properties
     my @warnings;
     if ( defined( my $value = $get_and_clear->( 'DB', 'database_host' ) ) ) {
         push @warnings, "Use of deprecated config property DB.database_host. Use MYSQL.host or POSTGRESQL.host instead.";
 
-        $obj->{_MYSQL_host} = $value
+        $obj->_set_MYSQL_host( $value )
           if $obj->DB_engine eq 'MySQL' && !defined $obj->MYSQL_host;
 
-        $obj->{_POSTGRESQL_host} = $value
+        $obj->_set_POSTGRESQL_host( $value )
           if $obj->DB_engine eq 'PostgreSQL' && !defined $obj->POSTGRESQL_host;
     }
+
     if ( defined( my $value = $get_and_clear->( 'DB', 'user' ) ) ) {
         push @warnings, "Use of deprecated config property DB.user. Use MYSQL.user or POSTGRESQL.user instead.";
 
-        $obj->{_MYSQL_user} = $value
+        $obj->_set_MYSQL_user( $value )
           if $obj->DB_engine eq 'MySQL' && !defined $obj->MYSQL_user;
 
-        $obj->{_POSTGRESQL_user} = $value
+        $obj->_set_POSTGRESQL_user( $value )
           if $obj->DB_engine eq 'PostgreSQL' && !defined $obj->POSTGRESQL_user;
     }
+
     if ( defined( my $value = $get_and_clear->( 'DB', 'password' ) ) ) {
         push @warnings, "Use of deprecated config property DB.password. Use MYSQL.password or POSTGRESQL.password instead.";
 
-        $obj->{_MYSQL_password} = $value
+        $obj->_set_MYSQL_password( $value )
           if $obj->DB_engine eq 'MySQL' && !defined $obj->MYSQL_password;
 
-        $obj->{_POSTGRESQL_password} = $value
+        $obj->_set_POSTGRESQL_password( $value )
           if $obj->DB_engine eq 'PostgreSQL' && !defined $obj->POSTGRESQL_password;
     }
     if ( defined( my $value = $get_and_clear->( 'DB', 'database_name' ) ) ) {
         push @warnings, "Use of deprecated config property DB.database_name. Use MYSQL.database, POSTGRESQL.database or SQLITE.database_file instead.";
 
-        $obj->{_MYSQL_database} = $value
+        $obj->_set_MYSQL_database( $value )
           if $obj->DB_engine eq 'MySQL' && !defined $obj->MYSQL_database;
 
-        $obj->{_POSTGRESQL_database} = $value
+        $obj->_set_POSTGRESQL_database( $value )
           if $obj->DB_engine eq 'PostgreSQL' && !defined $obj->POSTGRESQL_database;
 
-        $obj->{_SQLITE_database_file} = $value
+        $obj->_set_SQLITE_database_file( $value )
           if $obj->DB_engine eq 'SQLite' && !defined $obj->SQLITE_database_file;
     }
     if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_professes_for_frontend_testing' ) ) ) {
         push @warnings, "Use of deprecated config property ZONEMASTER.number_of_professes_for_frontend_testing. Use ZONEMASTER.number_of_processes_for_frontend_testing instead.";
 
-        $obj->{_ZONEMASTER_number_of_processes_for_frontend_testing} = $value
+        $obj->_set_ZONEMASTER_maximal_number_of_processes_for_frontend_testing( $value )
           if !defined $obj->NumberOfProcessesForFrontendTesting;
     }
     if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_professes_for_batch_testing' ) ) ) {
         push @warnings, "Use of deprecated config property ZONEMASTER.number_of_professes_for_batch_testing. Use ZONEMASTER.number_of_processes_for_batch_testing instead.";
 
-        $obj->{_ZONEMASTER_number_of_processes_for_batch_testing} = $value
+        $obj->_set_ZONEMASTER_maximal_number_of_processes_for_batch_testing( $value )
           if !defined $obj->NumberOfProcessesForBatchTesting;
+    }
+
+    # Check required propertys (part 2/2)
+    if ( $obj->DB_engine eq 'MySQL' ) {
+        die "config: missing required property MYSQL.host (required when DB.engine = MySQL and DB.database_host is unset)\n"
+          if !defined $obj->MYSQL_host;
+
+        die "config: missing required property MYSQL.user (required when DB.engine = MySQL and DB.user is unset)\n"
+          if !defined $obj->MYSQL_user;
+
+        die "config: missing required property MYSQL.password (required when DB.engine = MySQL and DB.password is unset)\n"
+          if !defined $obj->MYSQL_password;
+
+        die "config: missing required property MYSQL.database (required when DB.engine = MySQL and DB.database_name is unset)\n"
+          if !defined $obj->MYSQL_database;
+    }
+    elsif ( $obj->DB_engine eq 'PostgreSQL' ) {
+        die "config: missing required property POSTGRESQL.host (required when DB.engine = PostgreSQL and DB.database_host is unset)\n"
+          if !defined $obj->POSTGRESQL_host;
+
+        die "config: missing required property POSTGRESQL.user (required when DB.engine = PostgreSQL and DB.user is unset)\n"
+          if !defined $obj->POSTGRESQL_user;
+
+        die "config: missing required property POSTGRESQL.password (required when DB.engine = PostgreSQL and DB.password is unset)\n"
+          if !defined $obj->POSTGRESQL_password;
+
+        die "config: missing required property POSTGRESQL.database (required when DB.engine = PostgreSQL and DB.database_name is unset)\n"
+          if !defined $obj->POSTGRESQL_database;
+    }
+    elsif ( $obj->DB_engine eq 'SQLite' ) {
+        die "config: missing required property SQLITE.database_file (required when DB.engine = SQLite and DB.database_name is unset)\n"
+          if !defined $obj->SQLITE_database_file;
     }
 
     # Check unknown property names
@@ -257,17 +357,121 @@ sub parse {
 sub check_db {
     my ( $self, $db ) = @_;
 
-    if ( lc $db eq 'sqlite' ) {
+    return _check_engine_type( $db )    #
+      // die "Unknown database '$db', should be one of SQLite, MySQL or PostgreSQL\n";
+}
+
+sub _check_engine_type {
+    my ( $value ) = @_;
+
+    $value = lc $value;
+
+    if ( $value eq 'sqlite' ) {
         return 'SQLite';
     }
-    elsif ( lc $db eq 'postgresql' ) {
+    elsif ( $value eq 'postgresql' ) {
         return 'PostgreSQL';
     }
-    elsif ( lc $db eq 'mysql' ) {
+    elsif ( $value eq 'mysql' ) {
         return 'MySQL';
     }
     else {
-        die "Unknown database '$db', should be one of SQLite, MySQL or PostgreSQL\n";
+        return;
+    }
+}
+
+sub _check_positive_real {
+    my ( $value ) = @_;
+
+    if ( $value =~ qr/^((?:0|[1-9][0-9]{0,14})(?:\.[0-9]{1,6})?)$/i ) {
+        return 0.0 + $1;
+    }
+    else {
+        return;
+    }
+}
+
+sub _check_mariadb_ident {
+    my ( $value ) = @_;
+
+    # See: https://mariadb.com/kb/en/identifier-names/#unquoted
+    if ( $value =~ qr/^([0-9,a-z,A-Z\$_\x{0080}-\x{FFFF}]+)$/u ) {
+        return $1;
+    }
+    else {
+        return;
+    }
+}
+
+sub _check_postgresql_ident {
+    my ( $value ) = @_;
+
+    # See: https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+    if ( $value =~ qr/^([\pL_][\pL_\d\$]*)$/u ) {
+        return $1;
+    }
+    else {
+        return;
+    }
+}
+
+sub _check_hostname {
+    my ( $value ) = @_;
+
+    if ( $value =~ qr/^([A-Za-z0-9-.]{1,254})$/ ) {
+        return $1;
+    }
+    else {
+        return;
+    }
+}
+
+sub _check_password {
+    my ( $value ) = @_;
+
+    if ( $value =~ qr/^([\x21-\x7e]{0,1024})$/ ) {
+        return $1;
+    }
+    else {
+        return;
+    }
+}
+
+sub _check_abs_path {
+    my ( $value ) = @_;
+
+    if ( File::Spec->file_name_is_absolute( $value ) ) {
+        $value =~ qr/(.*)/;
+        return $1;
+    }
+    else {
+        return;
+    }
+}
+
+sub _check_unsigned_int {
+    my ( $value ) = @_;
+
+    # Integer precision limit for double-precision floating point numbers,
+    # rounded down to nearest whole decimal digit.
+    if ( $value =~ qr/^(0|[1-9][0-9]{0,14})$/i ) {
+        return 0 + $1;
+    }
+    else {
+        return;
+    }
+}
+
+sub _check_positive_int {
+    my ( $value ) = @_;
+
+    # Integer precision limit for double-precision floating point numbers,
+    # rounded down to nearest whole decimal digit.
+    if ( $value =~ qr/^([1-9][0-9]{0,14})$/i ) {
+        return 0 + $1;
+    }
+    else {
+        return;
     }
 }
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -47,23 +47,23 @@ sub ZONEMASTER_number_of_processes_for_frontend_testing { return $_[0]->{_ZONEMA
 sub ZONEMASTER_number_of_processes_for_batch_testing    { return $_[0]->{_ZONEMASTER_number_of_processes_for_batch_testing}; }
 sub ZONEMASTER_age_reuse_previous_test                  { return $_[0]->{_ZONEMASTER_age_reuse_previous_test}; }
 
-sub _set_DB_engine                                           { $_[0]->{_DB_engine}                                           = _check_engine_type( $_[1] )      // die "Invalid value for DB.engine: $_[1]\n";                                           return; }
-sub _set_DB_polling_interval                                 { $_[0]->{_DB_polling_interval}                                 = _check_positive_real( $_[1] )    // die "Invalid value for DB.polling_interval: $_[1]\n";                                 return; }
-sub _set_MYSQL_host                                          { $_[0]->{_MYSQL_host}                                          = _check_hostname( $_[1] )         // die "Invalid value for MYSQL.host: $_[1]\n";                                          return; }
-sub _set_MYSQL_user                                          { $_[0]->{_MYSQL_user}                                          = _check_mariadb_ident( $_[1] )    // die "Invalid value for MYSQL.user: $_[1]\n";                                          return; }
-sub _set_MYSQL_password                                      { $_[0]->{_MYSQL_password}                                      = _check_password( $_[1] )         // die "Invalid value for MYSQL.password: $_[1]\n";                                      return; }
-sub _set_MYSQL_database                                      { $_[0]->{_MYSQL_database}                                      = _check_mariadb_ident( $_[1] )    // die "Invalid value for MYSQL.database: $_[1]\n";                                      return; }
-sub _set_POSTGRESQL_host                                     { $_[0]->{_POSTGRESQL_host}                                     = _check_hostname( $_[1] )         // die "Invalid value for POSTGRESQL.host: $_[1]\n";                                     return; }
-sub _set_POSTGRESQL_user                                     { $_[0]->{_POSTGRESQL_user}                                     = _check_postgresql_ident( $_[1] ) // die "Invalid value for POSTGRESQL.user: $_[1]\n";                                     return; }
-sub _set_POSTGRESQL_password                                 { $_[0]->{_POSTGRESQL_password}                                 = _check_password( $_[1] )         // die "Invalid value for POSTGRESQL.password: $_[1]\n";                                 return; }
-sub _set_POSTGRESQL_database                                 { $_[0]->{_POSTGRESQL_database}                                 = _check_postgresql_ident( $_[1] ) // die "Invalid value for POSTGRESQL.database: $_[1]\n";                                 return; }
-sub _set_SQLITE_database_file                                { $_[0]->{_SQLITE_database_file}                                = _check_abs_path( $_[1] )         // die "Invalid value for SQLITE.database_file: $_[1]\n";                                return; }
-sub _set_ZONEMASTER_max_zonemaster_execution_time            { $_[0]->{_ZONEMASTER_max_zonemaster_execution_time}            = _check_unsigned_int( $_[1] )     // die "Invalid value for ZONEMASTER.max_zonemaster_execution_time: $_[1]\n";            return; }
-sub _set_ZONEMASTER_maximal_number_of_retries                { $_[0]->{_ZONEMASTER_maximal_number_of_retries}                = _check_unsigned_int( $_[1] )     // die "Invalid value for ZONEMASTER.maximal_number_of_retries: $_[1]\n";                return; }
-sub _set_ZONEMASTER_lock_on_queue                            { $_[0]->{_ZONEMASTER_lock_on_queue}                            = _check_unsigned_int( $_[1] )     // die "Invalid value for ZONEMASTER.lock_on_queue: $_[1]\n";                            return; }
-sub _set_ZONEMASTER_number_of_processes_for_frontend_testing { $_[0]->{_ZONEMASTER_number_of_processes_for_frontend_testing} = _check_positive_int( $_[1] )     // die "Invalid value for ZONEMASTER.number_of_processes_for_frontend_testing: $_[1]\n"; return; }
-sub _set_ZONEMASTER_number_of_processes_for_batch_testing    { $_[0]->{_ZONEMASTER_number_of_processes_for_batch_testing}    = _check_positive_int( $_[1] )     // die "Invalid value for ZONEMASTER.number_of_processes_for_batch_testing: $_[1]\n";    return; }
-sub _set_ZONEMASTER_age_reuse_previous_test                  { $_[0]->{_ZONEMASTER_age_reuse_previous_test}                  = _check_positive_int( $_[1] )     // die "Invalid value for ZONEMASTER.age_reuse_previous_test: $_[1]\n";                  return; }
+sub _set_DB_engine           { $_[0]->{_DB_engine}           = _check_engine_type( $_[1] )      // die "Invalid value for DB.engine: $_[1]\n";           return; }
+sub _set_DB_polling_interval { $_[0]->{_DB_polling_interval} = _check_positive_real( $_[1] )    // die "Invalid value for DB.polling_interval: $_[1]\n"; return; }
+sub _set_MYSQL_host          { $_[0]->{_MYSQL_host}          = _check_hostname( $_[1] )         // die "Invalid value for MYSQL.host: $_[1]\n";          return; }
+sub _set_MYSQL_user          { $_[0]->{_MYSQL_user}          = _check_mariadb_ident( $_[1] )    // die "Invalid value for MYSQL.user: $_[1]\n";          return; }
+sub _set_MYSQL_password      { $_[0]->{_MYSQL_password}      = _check_password( $_[1] )         // die "Invalid value for MYSQL.password: $_[1]\n";      return; }
+sub _set_MYSQL_database      { $_[0]->{_MYSQL_database}      = _check_mariadb_ident( $_[1] )    // die "Invalid value for MYSQL.database: $_[1]\n";      return; }
+sub _set_POSTGRESQL_host     { $_[0]->{_POSTGRESQL_host}     = _check_hostname( $_[1] )         // die "Invalid value for POSTGRESQL.host: $_[1]\n";     return; }
+sub _set_POSTGRESQL_user     { $_[0]->{_POSTGRESQL_user}     = _check_postgresql_ident( $_[1] ) // die "Invalid value for POSTGRESQL.user: $_[1]\n";     return; }
+sub _set_POSTGRESQL_password { $_[0]->{_POSTGRESQL_password} = _check_password( $_[1] )         // die "Invalid value for POSTGRESQL.password: $_[1]\n"; return; }
+sub _set_POSTGRESQL_database { $_[0]->{_POSTGRESQL_database} = _check_postgresql_ident( $_[1] ) // die "Invalid value for POSTGRESQL.database: $_[1]\n"; return; }
+sub _set_SQLITE_database_file { $_[0]->{_SQLITE_database_file} = _check_abs_path( $_[1] ) // _check_empty_string( $_[1] ) // die "Invalid value for SQLITE.database_file: $_[1]\n"; return; }
+sub _set_ZONEMASTER_max_zonemaster_execution_time            { $_[0]->{_ZONEMASTER_max_zonemaster_execution_time}            = _check_unsigned_int( $_[1] ) // die "Invalid value for ZONEMASTER.max_zonemaster_execution_time: $_[1]\n";            return; }
+sub _set_ZONEMASTER_maximal_number_of_retries                { $_[0]->{_ZONEMASTER_maximal_number_of_retries}                = _check_unsigned_int( $_[1] ) // die "Invalid value for ZONEMASTER.maximal_number_of_retries: $_[1]\n";                return; }
+sub _set_ZONEMASTER_lock_on_queue                            { $_[0]->{_ZONEMASTER_lock_on_queue}                            = _check_unsigned_int( $_[1] ) // die "Invalid value for ZONEMASTER.lock_on_queue: $_[1]\n";                            return; }
+sub _set_ZONEMASTER_number_of_processes_for_frontend_testing { $_[0]->{_ZONEMASTER_number_of_processes_for_frontend_testing} = _check_positive_int( $_[1] ) // die "Invalid value for ZONEMASTER.number_of_processes_for_frontend_testing: $_[1]\n"; return; }
+sub _set_ZONEMASTER_number_of_processes_for_batch_testing    { $_[0]->{_ZONEMASTER_number_of_processes_for_batch_testing}    = _check_positive_int( $_[1] ) // die "Invalid value for ZONEMASTER.number_of_processes_for_batch_testing: $_[1]\n";    return; }
+sub _set_ZONEMASTER_age_reuse_previous_test                  { $_[0]->{_ZONEMASTER_age_reuse_previous_test}                  = _check_positive_int( $_[1] ) // die "Invalid value for ZONEMASTER.age_reuse_previous_test: $_[1]\n";                  return; }
 
 =head2 load_config
 
@@ -168,11 +168,11 @@ sub parse {
         $obj->{_DB_engine} = $engine;
     }
 
-    # Validate, untaint, normalize and store property values or defaults
+    # Validate, untaint, normalize and store property values
     if ( defined( my $value = $get_and_clear->( 'DB', 'engine' ) ) ) {
         $obj->_set_DB_engine( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'DB', 'polling_interval' ) // '0.5' ) ) {
+    if ( defined( my $value = $get_and_clear->( 'DB', 'polling_interval' ) ) ) {
         $obj->_set_DB_polling_interval( $value );
     }
     if ( defined( my $value = $get_and_clear->( 'MYSQL', 'host' ) ) ) {
@@ -202,22 +202,22 @@ sub parse {
     if ( defined( my $value = $get_and_clear->( 'SQLITE', 'database_file' ) ) ) {
         $obj->_set_SQLITE_database_file( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'max_zonemaster_execution_time' ) // '600' ) ) {
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'max_zonemaster_execution_time' ) ) ) {
         $obj->_set_ZONEMASTER_max_zonemaster_execution_time( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'maximal_number_of_retries' ) // '0' ) ) {
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'maximal_number_of_retries' ) ) ) {
         $obj->_set_ZONEMASTER_maximal_number_of_retries( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_processes_for_frontend_testing' ) // '20' ) ) {
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_processes_for_frontend_testing' ) ) ) {
         $obj->_set_ZONEMASTER_number_of_processes_for_frontend_testing( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_processes_for_batch_testing' ) // '20' ) ) {
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_processes_for_batch_testing' ) ) ) {
         $obj->_set_ZONEMASTER_number_of_processes_for_batch_testing( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'lock_on_queue' ) // '0' ) ) {
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'lock_on_queue' ) ) ) {
         $obj->_set_ZONEMASTER_lock_on_queue( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'age_reuse_previous_test' ) // '600' ) ) {
+    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'age_reuse_previous_test' ) ) ) {
         $obj->_set_ZONEMASTER_age_reuse_previous_test( $value );
     }
 
@@ -301,6 +301,32 @@ sub parse {
 
         $obj->_set_ZONEMASTER_maximal_number_of_processes_for_batch_testing( $value )
           if !defined $obj->NumberOfProcessesForBatchTesting;
+    }
+
+    # Assign defaults
+    if ( !defined $obj->DB_polling_interval ) {
+        $obj->_set_DB_polling_interval( '0.5' );
+    }
+    if ( !defined $obj->SQLITE_database_file ) {
+        $obj->_set_SQLITE_database_file( '' );
+    }
+    if ( !defined $obj->ZONEMASTER_max_zonemaster_execution_time ) {
+        $obj->_set_ZONEMASTER_max_zonemaster_execution_time( '600' );
+    }
+    if ( !defined $obj->ZONEMASTER_maximal_number_of_retries ) {
+        $obj->_set_ZONEMASTER_maximal_number_of_retries( '0' );
+    }
+    if ( !defined $obj->ZONEMASTER_number_of_processes_for_frontend_testing ) {
+        $obj->_set_ZONEMASTER_number_of_processes_for_frontend_testing( '20' );
+    }
+    if ( !defined $obj->ZONEMASTER_number_of_processes_for_batch_testing ) {
+        $obj->_set_ZONEMASTER_number_of_processes_for_batch_testing( '20' );
+    }
+    if ( !defined $obj->ZONEMASTER_lock_on_queue ) {
+        $obj->_set_ZONEMASTER_lock_on_queue( '0' );
+    }
+    if ( !defined $obj->ZONEMASTER_age_reuse_previous_test ) {
+        $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
     }
 
     # Check required propertys (part 2/2)
@@ -443,6 +469,17 @@ sub _check_abs_path {
     if ( File::Spec->file_name_is_absolute( $value ) ) {
         $value =~ qr/(.*)/;
         return $1;
+    }
+    else {
+        return;
+    }
+}
+
+sub _check_empty_string {
+    my ( $value ) = @_;
+
+    if ( $value eq "" ) {
+        return "";
     }
     else {
         return;

--- a/share/travis_sqlite_backend_config.ini
+++ b/share/travis_sqlite_backend_config.ini
@@ -4,7 +4,7 @@ polling_interval=0.5
 #seconds
 
 [SQLITE]
-database_file=/tmp/zonemaster
+database_file=
 
 [ZONEMASTER]
 max_zonemaster_execution_time=300

--- a/t/config.t
+++ b/t/config.t
@@ -147,6 +147,34 @@ subtest 'Everything but NoWarnings' => sub {
         my $text = q{
             [DB]
             engine = Excel
+
+            [SQLITE]
+            databse_file = /var/db/zonemaster.sqlite
+
+            [ZNMEOTAESR]
+            lock_on_queue = 1
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{section.*ZNMEOTAESR}, 'die: Invalid section name';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+            pnlilog_iatnvrel = 0.5
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{property.*pnlilog_iatnvrel}, 'die: Invalid property name';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = Excel
         };
         Zonemaster::Backend::Config->parse( $text );
     }

--- a/t/config.t
+++ b/t/config.t
@@ -184,6 +184,364 @@ subtest 'Everything but NoWarnings' => sub {
         my $text = q{
             [DB]
             engine = SQLite
+            polling_interval = hourly
+
+            [SQLITE]
+            databse_file = /var/db/zonemaster.sqlite
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{DB\.polling_interval.*hourly}, 'die: Invalid DB.polling_inteval value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = MySQL
+
+            [MYSQL]
+            host = /dev/null
+            user = zonemaster_user
+            password = zonemaster_password
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{MYSQL\.host.*/dev/null}, 'die: Invalid MYSQL.host value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = MySQL
+
+            [MYSQL]
+            host = zonemaster-host
+            user = Robert'); DROP TABLE Students;--
+            password = zonemaster_password
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{MYSQL\.user.*Robert'\); DROP TABLE Students;--}, 'die: Invalid MYSQL.user value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = MySQL
+
+            [MYSQL]
+            host = zonemaster-host
+            user = zonemaster_user
+            password = pass word with spaces
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{MYSQL\.password.*pass word with spaces}, 'die: Invalid MYSQL.password value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = MySQL
+
+            [MYSQL]
+            host = zonemaster-host
+            user = zonemaster_user
+            password = zonemaster_password
+            database = |)/-\'|'/-\|3/-\$[-
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{MYSQL\.database.*|\)/-\'|'/-\\|3/-\\$[-}, 'die: Invalid MYSQL.database value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = PostgreSQL
+
+            [POSTGRESQL]
+            host = /dev/null
+            user = zonemaster_user
+            password = zonemaster_password
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{POSTGRESQL\.host.*/dev/null}, 'die: Invalid POSTGRESQL.host value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = PostgreSQL
+
+            [POSTGRESQL]
+            host = zonemaster-host
+            user = Robert'); DROP TABLE Students;--
+            password = zonemaster_password
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{POSTGRESQL\.user.*Robert'\); DROP TABLE Students;--}, 'die: Invalid POSTGRESQL.user value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = PostgreSQL
+
+            [POSTGRESQL]
+            host = zonemaster-host
+            user = zonemaster_user
+            password = pass word with spaces
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{POSTGRESQL\.password.*pass word with spaces}, 'die: Invalid POSTGRESQL.password value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = PostgreSQL
+
+            [POSTGRESQL]
+            host = zonemaster-host
+            user = zonemaster_user
+            password = zonemaster_password
+            database = |)/-\'|'/-\|3/-\$[-
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{POSTGRESQL\.database.*|\)/-\'|'/-\\|3/-\\$[-}, 'die: Invalid POSTGRESQL.database value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = ./relative/path/to/zonemaster.sqlite
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{SQLITE\.database_file.*\./relative/path/to/zonemaster.sqlite}, 'die: Invalid SQLITE.database_file value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [ZONEMASTER]
+            max_zonemaster_execution_time = -1
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{ZONEMASTER\.max_zonemaster_execution_time.*-1}, 'die: Invalid ZONEMASTER.max_zonemaster_execution_time value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [ZONEMASTER]
+            maximal_number_of_retries = -1
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{ZONEMASTER\.maximal_number_of_retries.*-1}, 'die: Invalid ZONEMASTER.maximal_number_of_retries value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [ZONEMASTER]
+            lock_on_queue = -1
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{ZONEMASTER\.lock_on_queue.*-1}, 'die: Invalid ZONEMASTER.lock_on_queue value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [ZONEMASTER]
+            number_of_processes_for_frontend_testing = 0
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{ZONEMASTER\.number_of_processes_for_frontend_testing.*0}, 'die: Invalid ZONEMASTER.number_of_processes_for_frontend_testing value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [ZONEMASTER]
+            number_of_processes_for_batch_testing = 0
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{ZONEMASTER\.number_of_processes_for_batch_testing.*0}, 'die: Invalid ZONEMASTER.number_of_processes_for_batch_testing value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [ZONEMASTER]
+            age_reuse_previous_test = 0
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr{ZONEMASTER\.age_reuse_previous_test.*0}, 'die: Invalid ZONEMASTER.age_reuse_previous_test value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = MySQL
+
+            [MYSQL]
+            user = zonemaster_user
+            password = zonemaster_password
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/MYSQL\.host/, 'die: Missing MYSQL.host value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = MySQL
+
+            [MYSQL]
+            host = zonemaster-host
+            password = zonemaster_password
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/MYSQL\.user/, 'die: Missing MYSQL.user value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = MySQL
+
+            [MYSQL]
+            host = zonemaster-host
+            user = zonemaster_user
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/MYSQL\.password/, 'die: Missing MYSQL.password value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = MySQL
+
+            [MYSQL]
+            host = zonemaster-host
+            user = zonemaster_user
+            password = zonemaster_password
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/MYSQL\.database/, 'die: Missing MYSQL.database value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = PostgreSQL
+
+            [POSTGRESQL]
+            user = zonemaster_user
+            password = zonemaster_password
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/POSTGRESQL\.host/, 'die: Missing POSTGRESQL.host value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = PostgreSQL
+
+            [POSTGRESQL]
+            host = zonemaster-host
+            password = zonemaster_password
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/POSTGRESQL\.user/, 'die: Missing POSTGRESQL.user value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = PostgreSQL
+
+            [POSTGRESQL]
+            host = zonemaster-host
+            user = zonemaster_user
+            database = zonemaster_database
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/POSTGRESQL\.password/, 'die: Missing POSTGRESQL.password value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = PostgreSQL
+
+            [POSTGRESQL]
+            host = zonemaster-host
+            user = zonemaster_user
+            password = zonemaster_password
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/POSTGRESQL\.database/, 'die: Missing POSTGRESQL.database value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/SQLITE\.database_file/, 'die: Missing SQLITE.database_file value';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
 
             [SQLITE]
             database_file = /var/db/zonemaster.sqlite

--- a/t/config.t
+++ b/t/config.t
@@ -71,9 +71,13 @@ subtest 'Everything but NoWarnings' => sub {
             database_file = /var/db/zonemaster.sqlite
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
-        is $config->MaxZonemasterExecutionTime, 600, 'default: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->maximal_number_of_retries,  0,   'default: ZONEMASTER.maximal_number_of_retries';
-        is $config->age_reuse_previous_test,    600, 'default: ZONEMASTER.age_reuse_previous_test';
+        cmp_ok abs( $config->PollingInterval - 0.5 ), '<', 0.000001, 'default: DB.polling_interval';
+        is $config->MaxZonemasterExecutionTime,          600, 'default: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->maximal_number_of_retries,           0,   'default: ZONEMASTER.maximal_number_of_retries';
+        is $config->NumberOfProcessesForFrontendTesting, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->NumberOfProcessesForBatchTesting,    20,  'default: ZONEMASTER.number_of_processes_for_batch_testing';
+        is $config->lock_on_queue,                       0,   'default: ZONEMASTER.lock_on_queue';
+        is $config->age_reuse_previous_test,             600, 'default: ZONEMASTER.age_reuse_previous_test';
     };
 
     lives_and {

--- a/t/config.t
+++ b/t/config.t
@@ -66,12 +66,10 @@ subtest 'Everything but NoWarnings' => sub {
         my $text = q{
             [DB]
             engine = SQLite
-
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
         cmp_ok abs( $config->DB_polling_interval - 0.5 ), '<', 0.000001, 'default: DB.polling_interval';
+        is $config->SQLITE_database_file,                                '',  'default: SQLITE.database_file';
         is $config->ZONEMASTER_max_zonemaster_execution_time,            600, 'default: ZONEMASTER.max_zonemaster_execution_time';
         is $config->ZONEMASTER_maximal_number_of_retries,                0,   'default: ZONEMASTER.maximal_number_of_retries';
         is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
@@ -163,9 +161,6 @@ subtest 'Everything but NoWarnings' => sub {
             [DB]
             engine = SQLite
             pnlilog_iatnvrel = 0.5
-
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
         };
         Zonemaster::Backend::Config->parse( $text );
     }
@@ -330,9 +325,6 @@ subtest 'Everything but NoWarnings' => sub {
             [DB]
             engine = SQLite
 
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
-
             [ZONEMASTER]
             max_zonemaster_execution_time = -1
         };
@@ -344,9 +336,6 @@ subtest 'Everything but NoWarnings' => sub {
         my $text = q{
             [DB]
             engine = SQLite
-
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
 
             [ZONEMASTER]
             maximal_number_of_retries = -1
@@ -360,9 +349,6 @@ subtest 'Everything but NoWarnings' => sub {
             [DB]
             engine = SQLite
 
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
-
             [ZONEMASTER]
             lock_on_queue = -1
         };
@@ -374,9 +360,6 @@ subtest 'Everything but NoWarnings' => sub {
         my $text = q{
             [DB]
             engine = SQLite
-
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
 
             [ZONEMASTER]
             number_of_processes_for_frontend_testing = 0
@@ -390,9 +373,6 @@ subtest 'Everything but NoWarnings' => sub {
             [DB]
             engine = SQLite
 
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
-
             [ZONEMASTER]
             number_of_processes_for_batch_testing = 0
         };
@@ -404,9 +384,6 @@ subtest 'Everything but NoWarnings' => sub {
         my $text = q{
             [DB]
             engine = SQLite
-
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
 
             [ZONEMASTER]
             age_reuse_previous_test = 0
@@ -532,20 +509,6 @@ subtest 'Everything but NoWarnings' => sub {
             [DB]
             engine = SQLite
 
-            [SQLITE]
-        };
-        Zonemaster::Backend::Config->parse( $text );
-    }
-    qr/SQLITE\.database_file/, 'die: Missing SQLITE.database_file value';
-
-    throws_ok {
-        my $text = q{
-            [DB]
-            engine = SQLite
-
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
-
             [LANGUAGE]
             locale = English
         };
@@ -557,9 +520,6 @@ subtest 'Everything but NoWarnings' => sub {
         my $text = q{
             [DB]
             engine = SQLite
-
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
 
             [LANGUAGE]
             locale = en_US en_US

--- a/t/config.t
+++ b/t/config.t
@@ -43,23 +43,23 @@ subtest 'Everything but NoWarnings' => sub {
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
         isa_ok $config, 'Zonemaster::Backend::Config', 'parse() return value';
-        is $config->BackendDBType,                       'SQLite',                    'set: DB.engine';
-        is $config->PollingInterval,                     1.5,                         'set: DB.polling_interval';
-        is $config->MYSQL_host,                          'mysql-host',                'set: MYSQL.host';
-        is $config->MYSQL_user,                          'mysql_user',                'set: MYSQL.user';
-        is $config->MYSQL_password,                      'mysql_password',            'set: MYSQL.password';
-        is $config->MYSQL_database,                      'mysql_database',            'set: MYSQL.database';
-        is $config->POSTGRESQL_host,                     'postgresql-host',           'set: POSTGRESQL.host';
-        is $config->POSTGRESQL_user,                     'postgresql_user',           'set: POSTGRESQL.user';
-        is $config->POSTGRESQL_password,                 'postgresql_password',       'set: POSTGRESQL.password';
-        is $config->POSTGRESQL_database,                 'postgresql_database',       'set: POSTGRESQL.database';
-        is $config->SQLITE_database_file,                '/var/db/zonemaster.sqlite', 'set: SQLITE.database_file';
-        is $config->MaxZonemasterExecutionTime,          1200,                        'set: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->maximal_number_of_retries,           2,                           'set: ZONEMASTER.maximal_number_of_retries';
-        is $config->NumberOfProcessesForFrontendTesting, 30,                          'set: ZONEMASTER.number_of_processes_for_frontend_testing';
-        is $config->NumberOfProcessesForBatchTesting,    40,                          'set: ZONEMASTER.number_of_processes_for_batch_testing';
-        is $config->lock_on_queue,                       1,                           'set: ZONEMASTER.lock_on_queue';
-        is $config->age_reuse_previous_test,             800,                         'set: ZONEMASTER.age_reuse_previous_test';
+        is $config->DB_engine,                                           'SQLite',                    'set: DB.engine';
+        is $config->DB_polling_interval,                                 1.5,                         'set: DB.polling_interval';
+        is $config->MYSQL_host,                                          'mysql-host',                'set: MYSQL.host';
+        is $config->MYSQL_user,                                          'mysql_user',                'set: MYSQL.user';
+        is $config->MYSQL_password,                                      'mysql_password',            'set: MYSQL.password';
+        is $config->MYSQL_database,                                      'mysql_database',            'set: MYSQL.database';
+        is $config->POSTGRESQL_host,                                     'postgresql-host',           'set: POSTGRESQL.host';
+        is $config->POSTGRESQL_user,                                     'postgresql_user',           'set: POSTGRESQL.user';
+        is $config->POSTGRESQL_password,                                 'postgresql_password',       'set: POSTGRESQL.password';
+        is $config->POSTGRESQL_database,                                 'postgresql_database',       'set: POSTGRESQL.database';
+        is $config->SQLITE_database_file,                                '/var/db/zonemaster.sqlite', 'set: SQLITE.database_file';
+        is $config->ZONEMASTER_max_zonemaster_execution_time,            1200,                        'set: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->ZONEMASTER_maximal_number_of_retries,                2,                           'set: ZONEMASTER.maximal_number_of_retries';
+        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 30,                          'set: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    40,                          'set: ZONEMASTER.number_of_processes_for_batch_testing';
+        is $config->ZONEMASTER_lock_on_queue,                            1,                           'set: ZONEMASTER.lock_on_queue';
+        is $config->ZONEMASTER_age_reuse_previous_test,                  800,                         'set: ZONEMASTER.age_reuse_previous_test';
     };
 
     lives_and {
@@ -71,13 +71,13 @@ subtest 'Everything but NoWarnings' => sub {
             database_file = /var/db/zonemaster.sqlite
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
-        cmp_ok abs( $config->PollingInterval - 0.5 ), '<', 0.000001, 'default: DB.polling_interval';
-        is $config->MaxZonemasterExecutionTime,          600, 'default: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->maximal_number_of_retries,           0,   'default: ZONEMASTER.maximal_number_of_retries';
-        is $config->NumberOfProcessesForFrontendTesting, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
-        is $config->NumberOfProcessesForBatchTesting,    20,  'default: ZONEMASTER.number_of_processes_for_batch_testing';
-        is $config->lock_on_queue,                       0,   'default: ZONEMASTER.lock_on_queue';
-        is $config->age_reuse_previous_test,             600, 'default: ZONEMASTER.age_reuse_previous_test';
+        cmp_ok abs( $config->DB_polling_interval - 0.5 ), '<', 0.000001, 'default: DB.polling_interval';
+        is $config->ZONEMASTER_max_zonemaster_execution_time,            600, 'default: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->ZONEMASTER_maximal_number_of_retries,                0,   'default: ZONEMASTER.maximal_number_of_retries';
+        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    20,  'default: ZONEMASTER.number_of_processes_for_batch_testing';
+        is $config->ZONEMASTER_lock_on_queue,                            0,   'default: ZONEMASTER.lock_on_queue';
+        is $config->ZONEMASTER_age_reuse_previous_test,                  600, 'default: ZONEMASTER.age_reuse_previous_test';
     };
 
     lives_and {

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -22,10 +22,11 @@ unless ($ENV{ZONEMASTER_BACKEND_CONFIG_FILE}) {
 use_ok( 'Zonemaster::Backend::RPCAPI' );
 
 # Create Zonemaster::Backend::RPCAPI object
+my $config = Zonemaster::Backend::Config->load_config();
 my $engine = Zonemaster::Backend::RPCAPI->new(
     {
-        dbtype => 'SQLite',
-        config => Zonemaster::Backend::Config->load_config(),
+        dbtype => $config->DB_engine,
+        config => $config,
     }
 );
 isa_ok( $engine, 'Zonemaster::Backend::RPCAPI' );


### PR DESCRIPTION
## Context

This is a work in progress. It's a continuation of #745 and those commits are included here.

The updates to t/config.t should be complete, but I'm not sure about the implementation and documentation.

This PR adds a validation framework for individual values. But in RPCAPI we're already using JSON::Validator and I'm not happy about the duplication but right now I haven't got further than this. 

Documentation also needs a lot more work.


## Scope

Included:
* Default values to all simple config properties (except the database connection-related ones where it doesn't make sense).
* New accessor methods for all simple properties with a uniform naming scheme.
* Reject configs with unrecognized sections and properties.
* Validate simple properties.

Excluded:
* Validation of complex properties like LANGUAGE.locale are postponed to facilitate better reviewing of the simpler (but more voluminous) properties.
* Cleaning up of old (and redundant) accessor methods is postponed until a later PR. That way it'll be easier to review this one.