### PR TITLE
Uniform config property getter methods

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -252,34 +252,49 @@ The ZONEMASTER section has several keys :
 
 ### max_zonemaster_execution_time
 
-Time in seconds before reporting an unfinished test as failed. Default
-value: `600`.
+An integer.
+Time in seconds before reporting an unfinished test as failed.
+Default value: `600`.
 
 ### maximal_number_of_retries
 
+An integer.
 Number of time a test is allowed to be run again if unfinished after
-`max_zonemaster_execution_time`. Default value: `0`.
+`max_zonemaster_execution_time`.
+Default value: `0`.
+
+This option is experimental and all edge cases are not fully tested.
+Do not use it (keep the default value "0"), or use it with care.
 
 ### number_of_processes_for_frontend_testing
+
+A positive integer.
 
 used -> todo
 
 ### number_of_processes_for_batch_testing
 
+An integer.
+
 used -> todo
 
 ### lock_on_queue
 
-Integer working as a label to associate a test to a specific Test Agent.
+An integer.
+A label to associate a test to a specific Test Agent.
+Default value: `0`.
 
 ### age_reuse_previous_test
 
-Positiv integer (in seconds) for how old a previous test of the same
-zone name and parameters must be before we start a new test. Internally
-the value is converted to whole minutes. If the conversion results in
-zero minutes, then the default value (600 seconds) is used.
+Positive integer.
+How old (in seconds) a previous test of the same zone name and parameters must
+be before we start a new test.
+Default value: `600`.
 
---------
+Internally the value is converted to whole minutes.
+If the conversion results in zero minutes, then the default value is used.
+
+
 
 [DB.database_host]:                   #database_host
 [DB.database_name]:                   #database_name

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -59,6 +59,7 @@ over this.
 ### polling_interval
 
 Time in seconds between database lookups by Test Agent.
+Default value: `0.5`.
 
 
 ## MYSQL section
@@ -272,11 +273,15 @@ A positive integer.
 
 used -> todo
 
+Default value: `20`.
+
 ### number_of_processes_for_batch_testing
 
 An integer.
 
 used -> todo
+
+Default value: `20`.
 
 ### lock_on_queue
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -502,9 +502,6 @@ sub lock_on_queue {
 
 =head2 maximal_number_of_retries
 
-This option is experimental and all edge cases are not fully tested.
-Do not use it (keep the default value "0"), or use it with care.
-
 =head3 INPUT
 
 'maximal_number_of_retries' from [ZONEMASTER] section in ini file. See

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -68,8 +68,9 @@ Construct a new Zonemaster::Backend::Config based on a given configuration.
 The configuration is interpreted according to the
 L<configuration format specification|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md>.
 
-Returns a new Z::B::Config instance with its properties set to values according
-to the given configuration with defaults according to the configuration format.
+Returns a new Zonemaster::Backend::Config instance with its properties set to
+values according to the given configuration with defaults according to the
+configuration format.
 
 Emits a log warning with a deprecation message for each deprecated property that
 is present.

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -69,7 +69,7 @@ The configuration is interpreted according to the
 L<configuration format specification|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md>.
 
 Returns a new Z::B::Config instance with its properties set to values according
-to the given configuration.
+to the given configuration with defaults according to the configuration format.
 
 Emits a log warning with a deprecation message for each deprecated property that
 is present.
@@ -99,7 +99,7 @@ sub parse {
         $obj->{_DB_engine} = $engine;
     }
 
-    $obj->{_DB_polling_interval}                                 = $ini->val( 'DB',         'polling_interval',                         undef );
+    $obj->{_DB_polling_interval}                                 = $ini->val( 'DB',         'polling_interval',                         '0.5' );
     $obj->{_MYSQL_host}                                          = $ini->val( 'MYSQL',      'host',                                     undef );
     $obj->{_MYSQL_user}                                          = $ini->val( 'MYSQL',      'user',                                     undef );
     $obj->{_MYSQL_password}                                      = $ini->val( 'MYSQL',      'password',                                 undef );
@@ -111,9 +111,9 @@ sub parse {
     $obj->{_SQLITE_database_file}                                = $ini->val( 'SQLITE',     'database_file',                            undef );
     $obj->{_ZONEMASTER_max_zonemaster_execution_time}            = $ini->val( 'ZONEMASTER', 'max_zonemaster_execution_time',            '600' );
     $obj->{_ZONEMASTER_maximal_number_of_retries}                = $ini->val( 'ZONEMASTER', 'maximal_number_of_retries',                '0' );
-    $obj->{_ZONEMASTER_number_of_processes_for_frontend_testing} = $ini->val( 'ZONEMASTER', 'number_of_processes_for_frontend_testing', undef );
-    $obj->{_ZONEMASTER_number_of_processes_for_batch_testing}    = $ini->val( 'ZONEMASTER', 'number_of_processes_for_batch_testing',    undef );
-    $obj->{_ZONEMASTER_lock_on_queue}                            = $ini->val( 'ZONEMASTER', 'lock_on_queue',                            undef );
+    $obj->{_ZONEMASTER_number_of_processes_for_frontend_testing} = $ini->val( 'ZONEMASTER', 'number_of_processes_for_frontend_testing', '20' );
+    $obj->{_ZONEMASTER_number_of_processes_for_batch_testing}    = $ini->val( 'ZONEMASTER', 'number_of_processes_for_batch_testing',    '20' );
+    $obj->{_ZONEMASTER_lock_on_queue}                            = $ini->val( 'ZONEMASTER', 'lock_on_queue',                            '0' );
     $obj->{_ZONEMASTER_age_reuse_previous_test}                  = $ini->val( 'ZONEMASTER', 'age_reuse_previous_test',                  '600' );
 
     $obj->{_LANGUAGE_locale} = {};
@@ -429,7 +429,7 @@ L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuratio
 
 =head3 RETURNS
 
-Integer (number of seconds), default 600.
+Integer (number of seconds).
 
 =cut
 
@@ -489,7 +489,7 @@ L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuratio
 
 =head3 RETURNS
 
-Integer (default 0).
+Integer.
 
 =cut
 
@@ -509,7 +509,7 @@ L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuratio
 
 =head3 RETURNS
 
-A scalar value of the number of retries (default 0).
+A scalar value of the number of retries.
 
 =cut
 
@@ -530,8 +530,7 @@ L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuratio
 =head3 RETURNS
 
 A scalar value of the number of seconds old the previous test with the same
-parameters can be when it is reused instead of starting a new test (default
-600).
+parameters can be when it is reused instead of starting a new test.
 
 =cut
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -143,40 +143,40 @@ sub parse {
         $log->warning( "Use of deprecated config property DB.database_host. Use MYSQL.host or POSTGRESQL.host instead." );
 
         $obj->{_MYSQL_host} = $value
-          if $obj->BackendDBType eq 'MySQL' && !defined $obj->MYSQL_host;
+          if $obj->DB_engine eq 'MySQL' && !defined $obj->MYSQL_host;
 
         $obj->{_POSTGRESQL_host} = $value
-          if $obj->BackendDBType eq 'PostgreSQL' && !defined $obj->POSTGRESQL_host;
+          if $obj->DB_engine eq 'PostgreSQL' && !defined $obj->POSTGRESQL_host;
     }
     if ( defined( my $value = $ini->val( 'DB', 'user' ) ) ) {
         $log->warning( "Use of deprecated config property DB.user. Use MYSQL.user or POSTGRESQL.user instead." );
 
         $obj->{_MYSQL_user} = $value
-          if $obj->BackendDBType eq 'MySQL' && !defined $obj->MYSQL_user;
+          if $obj->DB_engine eq 'MySQL' && !defined $obj->MYSQL_user;
 
         $obj->{_POSTGRESQL_user} = $value
-          if $obj->BackendDBType eq 'PostgreSQL' && !defined $obj->POSTGRESQL_user;
+          if $obj->DB_engine eq 'PostgreSQL' && !defined $obj->POSTGRESQL_user;
     }
     if ( defined( my $value = $ini->val( 'DB', 'password' ) ) ) {
         $log->warning( "Use of deprecated config property DB.password. Use MYSQL.password or POSTGRESQL.password instead." );
 
         $obj->{_MYSQL_password} = $value
-          if $obj->BackendDBType eq 'MySQL' && !defined $obj->MYSQL_password;
+          if $obj->DB_engine eq 'MySQL' && !defined $obj->MYSQL_password;
 
         $obj->{_POSTGRESQL_password} = $value
-          if $obj->BackendDBType eq 'PostgreSQL' && !defined $obj->POSTGRESQL_password;
+          if $obj->DB_engine eq 'PostgreSQL' && !defined $obj->POSTGRESQL_password;
     }
     if ( defined( my $value = $ini->val( 'DB', 'database_name' ) ) ) {
         $log->warning( "Use of deprecated config property DB.database_name. Use MYSQL.database, POSTGRESQL.database or SQLITE.database_file instead." );
 
         $obj->{_MYSQL_database} = $value
-          if $obj->BackendDBType eq 'MySQL' && !defined $obj->MYSQL_database;
+          if $obj->DB_engine eq 'MySQL' && !defined $obj->MYSQL_database;
 
         $obj->{_POSTGRESQL_database} = $value
-          if $obj->BackendDBType eq 'PostgreSQL' && !defined $obj->POSTGRESQL_database;
+          if $obj->DB_engine eq 'PostgreSQL' && !defined $obj->POSTGRESQL_database;
 
         $obj->{_SQLITE_database_file} = $value
-          if $obj->BackendDBType eq 'SQLite' && !defined $obj->SQLITE_database_file;
+          if $obj->DB_engine eq 'SQLite' && !defined $obj->SQLITE_database_file;
     }
     if ( defined( my $value = $ini->val( 'ZONEMASTER', 'number_of_professes_for_frontend_testing' ) ) ) {
         $log->warning( "Use of deprecated config property ZONEMASTER.number_of_professes_for_frontend_testing. Use ZONEMASTER.number_of_processes_for_frontend_testing instead." );
@@ -217,8 +217,7 @@ sub check_db {
 
 sub BackendDBType {
     my ($self) = @_;
-
-    return $self->{_DB_engine};
+    return $self->DB_engine;
 }
 
 =head2 MYSQL_database
@@ -227,13 +226,6 @@ Returns the L<MYSQL.database|https://github.com/zonemaster/zonemaster-backend/bl
 property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_name>
 property if it is unspecified.
 
-=cut
-
-sub MYSQL_database {
-    my ( $self ) = @_;
-
-    return $self->{_MYSQL_database};
-}
 
 =head2 MySQL_host
 
@@ -241,13 +233,6 @@ Returns the L<MYSQL.host|https://github.com/zonemaster/zonemaster-backend/blob/m
 property from the loaded config, or the L<DB.database_host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_host>
 property if it is unspecified.
 
-=cut
-
-sub MYSQL_host {
-    my ( $self ) = @_;
-
-    return $self->{_MYSQL_host};
-}
 
 =head2 MYSQL_password
 
@@ -255,13 +240,6 @@ Returns the L<MYSQL.password|https://github.com/zonemaster/zonemaster-backend/bl
 property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password>
 property if it is unspecified.
 
-=cut
-
-sub MYSQL_password {
-    my ( $self ) = @_;
-
-    return $self->{_MYSQL_password};
-}
 
 =head2 MYSQL_user
 
@@ -269,13 +247,6 @@ Returns the L<MYSQL.user|https://github.com/zonemaster/zonemaster-backend/blob/m
 property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user>
 property if it is unspecified.
 
-=cut
-
-sub MYSQL_user {
-    my ( $self ) = @_;
-
-    return $self->{_MYSQL_user};
-}
 
 =head2 POSTGRESQL_database
 
@@ -283,13 +254,6 @@ Returns the L<POSTGRESQL.database|https://github.com/zonemaster/zonemaster-backe
 property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_name>
 property if it is unspecified.
 
-=cut
-
-sub POSTGRESQL_database {
-    my ( $self ) = @_;
-
-    return $self->{_POSTGRESQL_database};
-}
 
 =head2 POSTGRESQL_host
 
@@ -297,13 +261,6 @@ Returns the L<POSTGRESQL.host|https://github.com/zonemaster/zonemaster-backend/b
 property from the loaded config, or the L<DB.database_host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_host>
 property if it is unspecified.
 
-=cut
-
-sub POSTGRESQL_host {
-    my ( $self ) = @_;
-
-    return $self->{_POSTGRESQL_host};
-}
 
 =head2 POSTGRESQL_password
 
@@ -311,13 +268,6 @@ Returns the L<POSTGRESQL.password|https://github.com/zonemaster/zonemaster-backe
 property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password>
 property if it is unspecified.
 
-=cut
-
-sub POSTGRESQL_password {
-    my ( $self ) = @_;
-
-    return $self->{_POSTGRESQL_password};
-}
 
 =head2 POSTGRESQL_user
 
@@ -325,13 +275,6 @@ Returns the L<POSTGRESQL.user|https://github.com/zonemaster/zonemaster-backend/b
 property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user>
 property if it is unspecified.
 
-=cut
-
-sub POSTGRESQL_user {
-    my ( $self ) = @_;
-
-    return $self->{_POSTGRESQL_user};
-}
 
 =head2 SQLITE_database_file
 
@@ -341,11 +284,24 @@ property if it is unspecified.
 
 =cut
 
-sub SQLITE_database_file {
-    my ( $self ) = @_;
+sub DB_engine                                           { return $_[0]->{_DB_engine}; }
+sub DB_polling_interval                                 { return $_[0]->{_DB_polling_interval}; }
+sub MYSQL_host                                          { return $_[0]->{_MYSQL_host}; }
+sub MYSQL_user                                          { return $_[0]->{_MYSQL_user}; }
+sub MYSQL_password                                      { return $_[0]->{_MYSQL_password}; }
+sub MYSQL_database                                      { return $_[0]->{_MYSQL_database}; }
+sub POSTGRESQL_host                                     { return $_[0]->{_POSTGRESQL_host}; }
+sub POSTGRESQL_user                                     { return $_[0]->{_POSTGRESQL_user}; }
+sub POSTGRESQL_password                                 { return $_[0]->{_POSTGRESQL_password}; }
+sub POSTGRESQL_database                                 { return $_[0]->{_POSTGRESQL_database}; }
+sub SQLITE_database_file                                { return $_[0]->{_SQLITE_database_file}; }
+sub ZONEMASTER_max_zonemaster_execution_time            { return $_[0]->{_ZONEMASTER_max_zonemaster_execution_time}; }
+sub ZONEMASTER_maximal_number_of_retries                { return $_[0]->{_ZONEMASTER_maximal_number_of_retries}; }
+sub ZONEMASTER_lock_on_queue                            { return $_[0]->{_ZONEMASTER_lock_on_queue}; }
+sub ZONEMASTER_number_of_processes_for_frontend_testing { return $_[0]->{_ZONEMASTER_number_of_processes_for_frontend_testing}; }
+sub ZONEMASTER_number_of_processes_for_batch_testing    { return $_[0]->{_ZONEMASTER_number_of_processes_for_batch_testing}; }
+sub ZONEMASTER_age_reuse_previous_test                  { return $_[0]->{_ZONEMASTER_age_reuse_previous_test}; }
 
-    return $self->{_SQLITE_database_file};
-}
 
 =head2 Language_Locale_hash
 
@@ -416,7 +372,7 @@ sub ListLanguageTags {
 sub PollingInterval {
     my ($self) = @_;
 
-    return $self->{_DB_polling_interval};
+    return $self->DB_polling_interval;
 }
 
 
@@ -436,7 +392,7 @@ Integer (number of seconds).
 sub MaxZonemasterExecutionTime {
     my ($self) = @_;
 
-    return $self->{_ZONEMASTER_max_zonemaster_execution_time};
+    return $self->ZONEMASTER_max_zonemaster_execution_time;
 }
 
 
@@ -456,7 +412,7 @@ Positive integer.
 sub NumberOfProcessesForFrontendTesting {
     my ($self) = @_;
 
-    return $self->{_ZONEMASTER_number_of_processes_for_frontend_testing};
+    return $self->ZONEMASTER_number_of_processes_for_frontend_testing;
 }
 
 
@@ -476,7 +432,7 @@ Integer.
 sub NumberOfProcessesForBatchTesting {
     my ($self) = @_;
 
-    return $self->{_ZONEMASTER_number_of_processes_for_batch_testing};
+    return $self->ZONEMASTER_number_of_processes_for_batch_testing;
 }
 
 
@@ -496,7 +452,7 @@ Integer.
 sub lock_on_queue {
     my ($self) = @_;
 
-    return $self->{_ZONEMASTER_lock_on_queue};
+    return $self->ZONEMASTER_lock_on_queue;
 }
 
 
@@ -516,7 +472,7 @@ A scalar value of the number of retries.
 sub maximal_number_of_retries {
     my ($self) = @_;
 
-    return $self->{_ZONEMASTER_maximal_number_of_retries};
+    return $self->ZONEMASTER_maximal_number_of_retries;
 }
 
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -25,7 +25,15 @@ else {
 
 Readonly my @SIG_NAME => split ' ', $Config{sig_name};
 
-=head1 SUBROUTINES
+=head1 CONSTRUCTORS
+
+=head2 load_config
+
+A wrapper around L<parse> that also determines where the config file is located
+in the file system and reads it.
+
+Throws an exception if the determined configuration file cannot be read.
+See L<parse> for details on additional parsing-related error modes.
 
 =cut
 
@@ -45,9 +53,7 @@ sub load_config {
 
 =head2 parse
 
-Parse a new Zonemaster::Backend::Config from the contents of a
-L<configuration|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md>
-file.
+Construct a new Zonemaster::Backend::Config based on a given configuration.
 
     my $config = Zonemaster::Backend::Config->parse(
         q{
@@ -59,7 +65,16 @@ file.
         }
     );
 
-Throws an exception if the given configuration file contains errors.
+The configuration is interpreted according to the
+L<configuration format specification|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md>.
+
+Returns a new Z::B::Config instance with its properties set to values according
+to the given configuration.
+
+Emits a log warning with a deprecation message for each deprecated property that
+is present.
+
+Throws an exception if the given configuration contains errors.
 Unrecognized sections and properties are silently ignored.
 
 =cut
@@ -178,6 +193,10 @@ sub parse {
 
     return $obj;
 }
+
+=head1 METHODS
+
+=cut
 
 sub check_db {
     my ( $self, $db ) = @_;

--- a/t/config.t
+++ b/t/config.t
@@ -71,9 +71,13 @@ subtest 'Everything but NoWarnings' => sub {
             database_file = /var/db/zonemaster.sqlite
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
-        is $config->MaxZonemasterExecutionTime, 600, 'default: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->maximal_number_of_retries,  0,   'default: ZONEMASTER.maximal_number_of_retries';
-        is $config->age_reuse_previous_test,    600, 'default: ZONEMASTER.age_reuse_previous_test';
+        cmp_ok abs( $config->PollingInterval - 0.5 ), '<', 0.000001, 'default: DB.polling_interval';
+        is $config->MaxZonemasterExecutionTime,          600, 'default: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->maximal_number_of_retries,           0,   'default: ZONEMASTER.maximal_number_of_retries';
+        is $config->NumberOfProcessesForFrontendTesting, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->NumberOfProcessesForBatchTesting,    20,  'default: ZONEMASTER.number_of_processes_for_batch_testing';
+        is $config->lock_on_queue,                       0,   'default: ZONEMASTER.lock_on_queue';
+        is $config->age_reuse_previous_test,             600, 'default: ZONEMASTER.age_reuse_previous_test';
     };
 
     lives_and {

--- a/t/config.t
+++ b/t/config.t
@@ -43,23 +43,23 @@ subtest 'Everything but NoWarnings' => sub {
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
         isa_ok $config, 'Zonemaster::Backend::Config', 'parse() return value';
-        is $config->BackendDBType,                       'SQLite',                    'set: DB.engine';
-        is $config->PollingInterval,                     1.5,                         'set: DB.polling_interval';
-        is $config->MYSQL_host,                          'mysql-host',                'set: MYSQL.host';
-        is $config->MYSQL_user,                          'mysql_user',                'set: MYSQL.user';
-        is $config->MYSQL_password,                      'mysql_password',            'set: MYSQL.password';
-        is $config->MYSQL_database,                      'mysql_database',            'set: MYSQL.database';
-        is $config->POSTGRESQL_host,                     'postgresql-host',           'set: POSTGRESQL.host';
-        is $config->POSTGRESQL_user,                     'postgresql_user',           'set: POSTGRESQL.user';
-        is $config->POSTGRESQL_password,                 'postgresql_password',       'set: POSTGRESQL.password';
-        is $config->POSTGRESQL_database,                 'postgresql_database',       'set: POSTGRESQL.database';
-        is $config->SQLITE_database_file,                '/var/db/zonemaster.sqlite', 'set: SQLITE.database_file';
-        is $config->MaxZonemasterExecutionTime,          1200,                        'set: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->maximal_number_of_retries,           2,                           'set: ZONEMASTER.maximal_number_of_retries';
-        is $config->NumberOfProcessesForFrontendTesting, 30,                          'set: ZONEMASTER.number_of_processes_for_frontend_testing';
-        is $config->NumberOfProcessesForBatchTesting,    40,                          'set: ZONEMASTER.number_of_processes_for_batch_testing';
-        is $config->lock_on_queue,                       1,                           'set: ZONEMASTER.lock_on_queue';
-        is $config->age_reuse_previous_test,             800,                         'set: ZONEMASTER.age_reuse_previous_test';
+        is $config->DB_engine,                                           'SQLite',                    'set: DB.engine';
+        is $config->DB_polling_interval,                                 1.5,                         'set: DB.polling_interval';
+        is $config->MYSQL_host,                                          'mysql-host',                'set: MYSQL.host';
+        is $config->MYSQL_user,                                          'mysql_user',                'set: MYSQL.user';
+        is $config->MYSQL_password,                                      'mysql_password',            'set: MYSQL.password';
+        is $config->MYSQL_database,                                      'mysql_database',            'set: MYSQL.database';
+        is $config->POSTGRESQL_host,                                     'postgresql-host',           'set: POSTGRESQL.host';
+        is $config->POSTGRESQL_user,                                     'postgresql_user',           'set: POSTGRESQL.user';
+        is $config->POSTGRESQL_password,                                 'postgresql_password',       'set: POSTGRESQL.password';
+        is $config->POSTGRESQL_database,                                 'postgresql_database',       'set: POSTGRESQL.database';
+        is $config->SQLITE_database_file,                                '/var/db/zonemaster.sqlite', 'set: SQLITE.database_file';
+        is $config->ZONEMASTER_max_zonemaster_execution_time,            1200,                        'set: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->ZONEMASTER_maximal_number_of_retries,                2,                           'set: ZONEMASTER.maximal_number_of_retries';
+        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 30,                          'set: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    40,                          'set: ZONEMASTER.number_of_processes_for_batch_testing';
+        is $config->ZONEMASTER_lock_on_queue,                            1,                           'set: ZONEMASTER.lock_on_queue';
+        is $config->ZONEMASTER_age_reuse_previous_test,                  800,                         'set: ZONEMASTER.age_reuse_previous_test';
     };
 
     lives_and {
@@ -71,13 +71,13 @@ subtest 'Everything but NoWarnings' => sub {
             database_file = /var/db/zonemaster.sqlite
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
-        cmp_ok abs( $config->PollingInterval - 0.5 ), '<', 0.000001, 'default: DB.polling_interval';
-        is $config->MaxZonemasterExecutionTime,          600, 'default: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->maximal_number_of_retries,           0,   'default: ZONEMASTER.maximal_number_of_retries';
-        is $config->NumberOfProcessesForFrontendTesting, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
-        is $config->NumberOfProcessesForBatchTesting,    20,  'default: ZONEMASTER.number_of_processes_for_batch_testing';
-        is $config->lock_on_queue,                       0,   'default: ZONEMASTER.lock_on_queue';
-        is $config->age_reuse_previous_test,             600, 'default: ZONEMASTER.age_reuse_previous_test';
+        cmp_ok abs( $config->DB_polling_interval - 0.5 ), '<', 0.000001, 'default: DB.polling_interval';
+        is $config->ZONEMASTER_max_zonemaster_execution_time,            600, 'default: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->ZONEMASTER_maximal_number_of_retries,                0,   'default: ZONEMASTER.maximal_number_of_retries';
+        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    20,  'default: ZONEMASTER.number_of_processes_for_batch_testing';
+        is $config->ZONEMASTER_lock_on_queue,                            0,   'default: ZONEMASTER.lock_on_queue';
+        is $config->ZONEMASTER_age_reuse_previous_test,                  600, 'default: ZONEMASTER.age_reuse_previous_test';
     };
 
     lives_and {

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -3,237 +3,241 @@ use warnings;
 use 5.14.2;
 use utf8;
 
+use Test::More tests => 2;
+use Test::NoWarnings;
+
 use Encode;
-use Test::More;    # see done_testing()
 use File::ShareDir qw[dist_file];
 
-my $can_use_threads = eval 'use threads; 1';
+subtest 'Everything but NoWarnings' => sub {
 
-# The configuration file should be the default
-# configuration file, unless the ENV variable below is already
-# set (e.g. for Travis). Set the ENV variable, and this must
-# be done before Zonemaster::Backend::Config is loaded.
-unless ($ENV{ZONEMASTER_BACKEND_CONFIG_FILE}) {
-       $ENV{ZONEMASTER_BACKEND_CONFIG_FILE} =
-       dist_file('Zonemaster-Backend', "backend_config.ini");
-};
+    my $can_use_threads = eval 'use threads; 1';
 
-# Require Zonemaster::Backend::RPCAPI.pm test
-use_ok( 'Zonemaster::Backend::RPCAPI' );
+    # The configuration file should be the default
+    # configuration file, unless the ENV variable below is already
+    # set (e.g. for Travis). Set the ENV variable, and this must
+    # be done before Zonemaster::Backend::Config is loaded.
+    unless ($ENV{ZONEMASTER_BACKEND_CONFIG_FILE}) {
+           $ENV{ZONEMASTER_BACKEND_CONFIG_FILE} =
+           dist_file('Zonemaster-Backend', "backend_config.ini");
+    };
 
-# Create Zonemaster::Backend::RPCAPI object
-my $engine = Zonemaster::Backend::RPCAPI->new(
-    {
-        dbtype => 'SQLite',
-        config => Zonemaster::Backend::Config->load_config(),
-    }
-);
-isa_ok( $engine, 'Zonemaster::Backend::RPCAPI' );
+    # Require Zonemaster::Backend::RPCAPI.pm test
+    use_ok( 'Zonemaster::Backend::RPCAPI' );
 
-my $frontend_params = {
-	ipv4 => 1,
-	ipv6 => 1,
-};
-
-$frontend_params->{nameservers} = [    # list of the namaserves up to 32
-	{ ns => 'ns1.nic.fr', ip => '1.2.3.4' },       # key values pairs representing nameserver => namesterver_ip
-	{ ns => 'ns2.nic.fr', ip => '192.134.4.1' },
-];
-
-subtest 'domain present' => sub {
-    my $res = $engine->validate_syntax(
+    # Create Zonemaster::Backend::RPCAPI object
+    my $config = Zonemaster::Backend::Config->load_config();
+    my $engine = Zonemaster::Backend::RPCAPI->new(
         {
-            %$frontend_params, domain => 'afnic.fr'
+            dbtype => $config->DB_engine,
+            config => $config,
         }
     );
+    isa_ok( $engine, 'Zonemaster::Backend::RPCAPI' );
 
-    is( $res->{status}, 'ok' );
-};
+    my $frontend_params = {
+        ipv4 => 1,
+        ipv6 => 1,
+    };
 
-subtest encode_utf8( 'idn domain=[é]' ) => sub {
-    my $res = $engine->validate_syntax(
-        {
-            %$frontend_params, domain => 'é'
-        }
-    );
+    $frontend_params->{nameservers} = [    # list of the namaserves up to 32
+        { ns => 'ns1.nic.fr', ip => '1.2.3.4' },       # key values pairs representing nameserver => namesterver_ip
+        { ns => 'ns2.nic.fr', ip => '192.134.4.1' },
+    ];
 
-    is( $res->{status}, 'ok' )
-        or diag( $res->{message} );
-};
+    subtest 'domain present' => sub {
+        my $res = $engine->validate_syntax(
+            {
+                %$frontend_params, domain => 'afnic.fr'
+            }
+        );
 
-subtest encode_utf8( 'idn domain=[éé]' ) => sub {
-    my $res = $engine->validate_syntax(
-        {
-            %$frontend_params, domain => 'éé'
-        }
-    );
+        is( $res->{status}, 'ok' );
+    };
 
-    is( $res->{status}, 'ok' )
-        or diag( $res->{message} );
-};
+    subtest encode_utf8( 'idn domain=[é]' ) => sub {
+        my $res = $engine->validate_syntax(
+            {
+                %$frontend_params, domain => 'é'
+            }
+        );
 
-subtest '253 characters long domain without dot' => sub {
-    my $res = $engine->validate_syntax(
-        {
-            %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com'
-        }
-    );
+        is( $res->{status}, 'ok' )
+            or diag( $res->{message} );
+    };
 
+    subtest encode_utf8( 'idn domain=[éé]' ) => sub {
+        my $res = $engine->validate_syntax(
+            {
+                %$frontend_params, domain => 'éé'
+            }
+        );
+
+        is( $res->{status}, 'ok' )
+            or diag( $res->{message} );
+    };
+
+    subtest '253 characters long domain without dot' => sub {
+        my $res = $engine->validate_syntax(
+            {
+                %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com'
+            }
+        );
+
+        is(
+            $res->{status}, 'ok'
+        ) or diag( $res->{message} );
+    };
+
+    subtest '254 characters long domain with trailing dot' => sub {
+        my $res = $engine->validate_syntax(
+            {
+                %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.'
+            }
+        );
+
+        is(
+            $res->{status}, 'ok'
+        ) or diag( $res->{message} );
+    };
+
+    subtest '254 characters long domain without trailing dot' => sub {
+        my $res = $engine->validate_syntax(
+            {
+                %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club'
+            }
+        );
+
+        is(
+            $res->{status}, 'nok'
+        ) or diag( $res->{message} );
+    };
+
+    subtest '63 characters long domain label' => sub {
+        my $res = $engine->validate_syntax(
+            {
+                %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789-63.fr'
+            }
+        );
+
+        is( $res->{status}, 'ok' )
+            or diag( $res->{message} );
+    };
+
+    subtest '64 characters long domain label' => sub {
+        my $res = $engine->validate_syntax(
+            {
+                %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789--64.fr'
+            }
+        );
+
+        is( $res->{status}, 'nok')
+            or diag( $res->{message} );
+    };
+
+    #TEST NS
+    $frontend_params->{domain} = 'afnic.fr';
+    $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
+
+    # domain present?
+    $frontend_params->{nameservers}->[0]->{ns} = 'afnic.fr';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', 'domain present' );
+
+    # idn
+    $frontend_params->{nameservers}->[0]->{ns} = 'é';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[é]' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    # idn
+    $frontend_params->{nameservers}->[0]->{ns} = 'éé';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[éé]' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    # 253 characters long domain without dot
+    $frontend_params->{nameservers}->[0]->{ns} =
+    '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com';
     is(
-        $res->{status}, 'ok'
-    ) or diag( $res->{message} );
-};
+        $engine->validate_syntax( $frontend_params )->{status}, 'ok',
+        encode_utf8( '253 characters long domain without dot' )
+    ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
-subtest '254 characters long domain with trailing dot' => sub {
-    my $res = $engine->validate_syntax(
-        {
-            %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.'
-        }
-    );
-
+    # 254 characters long domain with trailing dot
+    $frontend_params->{nameservers}->[0]->{ns} =
+    '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.';
     is(
-        $res->{status}, 'ok'
-    ) or diag( $res->{message} );
-};
+        $engine->validate_syntax( $frontend_params )->{status}, 'ok',
+        encode_utf8( '254 characters long domain with trailing dot' )
+    ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
 
-subtest '254 characters long domain without trailing dot' => sub {
-    my $res = $engine->validate_syntax(
-        {
-            %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club'
-        }
-    );
-
+    # 254 characters long domain without trailing
+    $frontend_params->{nameservers}->[0]->{ns} =
+    '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club';
     is(
-        $res->{status}, 'nok'
-    ) or diag( $res->{message} );
+        $engine->validate_syntax( $frontend_params )->{status}, 'nok',
+        encode_utf8( '254 characters long domain without trailing dot' )
+    ) or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    # 63 characters long domain label
+    $frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-63.fr';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok',
+        encode_utf8( '63 characters long domain label' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    # 64 characters long domain label
+    $frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-64-.fr';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'nok',
+        encode_utf8( '64 characters long domain label' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    # DELEGATED TEST
+    delete( $frontend_params->{nameservers} );
+
+    $frontend_params->{domain} = 'afnic.fr';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'delegated domain exists' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    # IP ADDRESS FORMAT
+    $frontend_params->{domain} = 'afnic.fr';
+    $frontend_params->{nameservers}->[0]->{ns} = 'ns1.nic.fr';
+
+    $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid IPV4' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4444';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid IPV4' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    $frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bb';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid IPV6' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    $frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bbffffff';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid IPV6' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    # DS
+    $frontend_params->{domain}                 = 'afnic.fr';
+    $frontend_params->{nameservers}->[0]->{ns} = 'ns1.nic.fr';
+    $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
+
+    $frontend_params->{ds_info}->[0]->{algorithm} = 1;
+    $frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid Algorithm Type [numeric format]' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    $frontend_params->{ds_info}->[0]->{algorithm} = 'a';
+    $frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid Algorithm Type' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    $frontend_params->{ds_info}->[0]->{algorithm} = 1;
+    $frontend_params->{ds_info}->[0]->{digest}    = '01234567890123456789012345678901234567890';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid digest length' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
+
+    $frontend_params->{ds_info}->[0]->{algorithm} = 1;
+    $frontend_params->{ds_info}->[0]->{digest}    = 'Z123456789012345678901234567890123456789';
+    is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid digest format' ) )
+        or diag( $engine->validate_syntax( $frontend_params )->{message} );
 };
-
-subtest '63 characters long domain label' => sub {
-    my $res = $engine->validate_syntax(
-        {
-            %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789-63.fr'
-        }
-    );
-
-    is( $res->{status}, 'ok' )
-        or diag( $res->{message} );
-};
-
-subtest '64 characters long domain label' => sub {
-    my $res = $engine->validate_syntax(
-        {
-            %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789--64.fr'
-        }
-    );
-
-    is( $res->{status}, 'nok')
-        or diag( $res->{message} );
-};
-
-#TEST NS
-$frontend_params->{domain} = 'afnic.fr';
-$frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
-
-# domain present?
-$frontend_params->{nameservers}->[0]->{ns} = 'afnic.fr';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', 'domain present' );
-
-# idn
-$frontend_params->{nameservers}->[0]->{ns} = 'é';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[é]' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-# idn
-$frontend_params->{nameservers}->[0]->{ns} = 'éé';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[éé]' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-# 253 characters long domain without dot
-$frontend_params->{nameservers}->[0]->{ns} =
-'123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com';
-is(
-	$engine->validate_syntax( $frontend_params )->{status}, 'ok',
-	encode_utf8( '253 characters long domain without dot' )
-) or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-# 254 characters long domain with trailing dot
-$frontend_params->{nameservers}->[0]->{ns} =
-'123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.';
-is(
-	$engine->validate_syntax( $frontend_params )->{status}, 'ok',
-	encode_utf8( '254 characters long domain with trailing dot' )
-) or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-# 254 characters long domain without trailing
-$frontend_params->{nameservers}->[0]->{ns} =
-'123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club';
-is(
-	$engine->validate_syntax( $frontend_params )->{status}, 'nok',
-	encode_utf8( '254 characters long domain without trailing dot' )
-) or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-# 63 characters long domain label
-$frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-63.fr';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok',
-	encode_utf8( '63 characters long domain label' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-# 64 characters long domain label
-$frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-64-.fr';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'nok',
-	encode_utf8( '64 characters long domain label' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-# DELEGATED TEST
-delete( $frontend_params->{nameservers} );
-
-$frontend_params->{domain} = 'afnic.fr';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'delegated domain exists' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-# IP ADDRESS FORMAT
-$frontend_params->{domain} = 'afnic.fr';
-$frontend_params->{nameservers}->[0]->{ns} = 'ns1.nic.fr';
-
-$frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid IPV4' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-$frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4444';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid IPV4' ) )
-	or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-$frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bb';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid IPV6' ) )
-    or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-$frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bbffffff';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid IPV6' ) )
-    or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-# DS
-$frontend_params->{domain}                 = 'afnic.fr';
-$frontend_params->{nameservers}->[0]->{ns} = 'ns1.nic.fr';
-$frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
-
-$frontend_params->{ds_info}->[0]->{algorithm} = 1;
-$frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid Algorithm Type [numeric format]' ) )
-    or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-$frontend_params->{ds_info}->[0]->{algorithm} = 'a';
-$frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid Algorithm Type' ) )
-    or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-$frontend_params->{ds_info}->[0]->{algorithm} = 1;
-$frontend_params->{ds_info}->[0]->{digest}    = '01234567890123456789012345678901234567890';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid digest length' ) )
-    or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-$frontend_params->{ds_info}->[0]->{algorithm} = 1;
-$frontend_params->{ds_info}->[0]->{digest}    = 'Z123456789012345678901234567890123456789';
-is( $engine->validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid digest format' ) )
-    or diag( $engine->validate_syntax( $frontend_params )->{message} );
-
-done_testing();


### PR DESCRIPTION
## Context

This PR lays some groundwork for #685.
It also fixes a warning that was noted by @pnax in https://github.com/zonemaster/zonemaster-backend/pull/745#pullrequestreview-638608629.

## Scope

* No behavioral changes with regard to validation.
* No documentation changes to property getters.
* No code changes with regard to complex properties.
* New property getters are introduced, but the old ones are kept in place. Call sites aren't updated to use the new ones either. At first I wanted to include this cleanup in the PR, but the surface area was large enough that I'm leaving that for a follow-up PR.

## Changes

Format specification:
* Some details are included that were previously only documented in the POD of the getter methods.
* Simple properties undergo minor editing to make them more structurally similar to each other.

Implementation:
* Uniform getter methods are added for all simple properties.
* Defaults are added to all simple properties where it makes sense.
* All uniform getter method implementations are gathered up into a table-like section. IMHO the code is more readable this way as opposed to having each method placed next to its own POD. Pod::Coverage is still able to help us make sure all the methods are documented. Nothing interesting is going on in the method implementations anyway.
* The `SUBROUTINES` POD heading is replaced with `CONSTRUCTORS` and `METHODS`.

Extra:
* t/test_validate_syntax.t:
  1. The warning from https://github.com/zonemaster/zonemaster-backend/pull/745#pullrequestreview-638608629 is fixed
  2. The test now fails if it emits any warnings

## How to test this PR

1. Verify that t/confg.t contains unit tests for all default values in the format specification.
2. Verify that t/test_validate_syntax.t uses Test::NoWarnings.