### PR TITLE
Use uniform accessors

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -297,9 +297,10 @@ Default value: `0`.
 
 ### age_reuse_previous_test
 
-Positive integer.
-
+A positive integer.
 The shelf life of a test in seconds after its creation.
+Default value: `600`.
+
 If a new test is requested for the same zone name and parameters within the
 shelf life of a previous test result, that test result is reused.
 Otherwise a new test request is enqueued.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -298,9 +298,11 @@ Default value: `0`.
 ### age_reuse_previous_test
 
 Positive integer.
-How old (in seconds) a previous test of the same zone name and parameters can be
-when it is reused instead of starting a new test.
-Default value: `600`.
+
+The shelf life of a test in seconds after its creation.
+If a new test is requested for the same zone name and parameters within the
+shelf life of a previous test result, that test result is reused.
+Otherwise a new test request is enqueued.
 
 Internally the value is converted to whole minutes.
 If the conversion results in zero minutes, then the default value is used.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -298,8 +298,8 @@ Default value: `0`.
 ### age_reuse_previous_test
 
 Positive integer.
-How old (in seconds) a previous test of the same zone name and parameters must
-be before we start a new test.
+How old (in seconds) a previous test of the same zone name and parameters can be
+when it is reused instead of starting a new test.
 Default value: `600`.
 
 Internally the value is converted to whole minutes.

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -463,25 +463,11 @@ Returns one of C<"SQLite">, C<"PostgreSQL"> or C<"MySQL">.
 Get the value of L<DB.polling_interval|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#polling_interval>.
 
 
-=head2 MaxZonemasterExecutionTime
+=head2 ZONEMASTER_max_zonemaster_execution_time
 
-=head3 INPUT
+Get the value of L<ZONEMASTER.max_zonemaster_execution_time|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#max_zonemaster_execution_time>.
 
-'max_zonemaster_execution_time' from [ZONEMASTER] section in ini file. See
-L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#max_zonemaster_execution_time>.
-
-=head3 RETURNS
-
-Integer (number of seconds).
-
-=cut
-
-sub MaxZonemasterExecutionTime {
-    my ($self) = @_;
-
-    return $self->ZONEMASTER_max_zonemaster_execution_time;
-}
-
+Returns an integer (number of seconds).
 
 
 =head2 ZONEMASTER_number_of_processes_for_frontend_testing
@@ -500,44 +486,20 @@ L<ZONEMASTER.number_of_processes_for_batch_testing|https://github.com/zonemaster
 Returns an integer.
 
 
-=head2 lock_on_queue
+=head2 ZONEMASTER_lock_on_queue
 
-=head3 INPUT
+Get the value of
+L<ZONEMASTER.lock_on_queue|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#lock_on_queue>.
 
-'lock_on_queue' from [ZONEMASTER] section in ini file. See
-L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#lock_on_queue>.
-
-=head3 RETURNS
-
-Integer.
-
-=cut
-
-sub lock_on_queue {
-    my ($self) = @_;
-
-    return $self->ZONEMASTER_lock_on_queue;
-}
+Returns an integer.
 
 
-=head2 maximal_number_of_retries
+=head2 ZONEMASTER_maximal_number_of_retries
 
-=head3 INPUT
+Get the value of
+L<ZONEMASTER.maximal_number_of_retries|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#maximal_number_of_retries>.
 
-'maximal_number_of_retries' from [ZONEMASTER] section in ini file. See
-L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#maximal_number_of_retries>.
-
-=head3 RETURNS
-
-A scalar value of the number of retries.
-
-=cut
-
-sub maximal_number_of_retries {
-    my ($self) = @_;
-
-    return $self->ZONEMASTER_maximal_number_of_retries;
-}
+Returns an integer.
 
 
 =head2 ZONEMASTER_age_reuse_previous_test
@@ -643,7 +605,7 @@ The values of the following attributes affect the construction of the returned o
 
 =over
 
-=item MaxZonemasterExecutionTime
+=item ZONEMASTER_max_zonemaster_execution_time
 
 =item ZONEMASTER_number_of_processes_for_batch_testing
 
@@ -662,7 +624,7 @@ sub new_PM {
 
     my $maximum_processes = $self->ZONEMASTER_number_of_processes_for_frontend_testing + $self->ZONEMASTER_number_of_processes_for_batch_testing;
 
-    my $timeout = $self->MaxZonemasterExecutionTime();
+    my $timeout = $self->ZONEMASTER_max_zonemaster_execution_time;
 
     my %times;
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -563,26 +563,14 @@ sub maximal_number_of_retries {
 }
 
 
-=head2 age_reuse_previous_test
+=head2 ZONEMASTER_age_reuse_previous_test
 
-=head3 INPUT
+Get the value of
+L<ZONEMASTER.age_reuse_previous_test|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#age_reuse_previous_test>.
 
-'age_reuse_previous_test' from [ZONEMASTER] section in ini file (in seconds). See
-L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#age_reuse_previous_test>.
-
-=head3 RETURNS
-
-A scalar value of the number of seconds old the previous test with the same
-parameters can be when it is reused instead of starting a new test.
+Returns an integer.
 
 =cut
-
-sub age_reuse_previous_test {
-    my ($self) = @_;
-
-    return $self->{_ZONEMASTER_age_reuse_previous_test};
-}
-
 
 sub ReadProfilesInfo {
     my ($self) = @_;

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -449,7 +449,7 @@ Get the value of L<DB.polling_interval|https://github.com/zonemaster/zonemaster-
 
 Get the value of L<ZONEMASTER.max_zonemaster_execution_time|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#max_zonemaster_execution_time>.
 
-Returns an integer (number of seconds).
+Returns an integer.
 
 
 =head2 ZONEMASTER_number_of_processes_for_frontend_testing

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -281,6 +281,14 @@ sub parse {
 
 =head1 METHODS
 
+=head2 check_db
+
+Returns a normalized string based on the supported databases.
+
+=head3 EXCEPTION
+
+Dies if the value is not one of SQLite, PostgreSQL or MySQL.
+
 =cut
 
 sub check_db {
@@ -299,6 +307,18 @@ sub check_db {
         die "Unknown database '$db', should be one of SQLite, MySQL or PostgreSQL\n";
     }
 }
+
+
+=head2 DB_engine
+
+Get the value of L<DB.engine|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#polling_interval>.
+
+Returns one of C<"SQLite">, C<"PostgreSQL"> or C<"MySQL">.
+
+
+=head2 DB_polling_interval
+
+Get the value of L<DB.polling_interval|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#polling_interval>.
 
 
 =head2 MYSQL_database
@@ -344,6 +364,53 @@ Get the value of L<POSTGRESQL.user|https://github.com/zonemaster/zonemaster-back
 =head2 SQLITE_database_file
 
 Get the value of L<SQLITE.database_file|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_file>.
+
+
+=head2 ZONEMASTER_max_zonemaster_execution_time
+
+Get the value of L<ZONEMASTER.max_zonemaster_execution_time|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#max_zonemaster_execution_time>.
+
+Returns an integer.
+
+
+=head2 ZONEMASTER_number_of_processes_for_frontend_testing
+
+Get the value of
+L<ZONEMASTER.number_of_processes_for_frontend_testing|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#number_of_processes_for_frontend_testing>.
+
+Returns a positive integer.
+
+
+=head2 ZONEMASTER_number_of_processes_for_batch_testing
+
+Get the value of
+L<ZONEMASTER.number_of_processes_for_batch_testing|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#number_of_processes_for_batch_testing>.
+
+Returns an integer.
+
+
+=head2 ZONEMASTER_lock_on_queue
+
+Get the value of
+L<ZONEMASTER.lock_on_queue|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#lock_on_queue>.
+
+Returns an integer.
+
+
+=head2 ZONEMASTER_maximal_number_of_retries
+
+Get the value of
+L<ZONEMASTER.maximal_number_of_retries|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#maximal_number_of_retries>.
+
+Returns an integer.
+
+
+=head2 ZONEMASTER_age_reuse_previous_test
+
+Get the value of
+L<ZONEMASTER.age_reuse_previous_test|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#age_reuse_previous_test>.
+
+Returns an integer.
 
 =cut
 
@@ -432,67 +499,6 @@ sub ListLanguageTags {
     return @langtags;
 }
 
-
-=head2 DB_engine
-
-Get the value of L<DB.engine|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#polling_interval>.
-
-Returns one of C<"SQLite">, C<"PostgreSQL"> or C<"MySQL">.
-
-
-=head2 DB_polling_interval
-
-Get the value of L<DB.polling_interval|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#polling_interval>.
-
-
-=head2 ZONEMASTER_max_zonemaster_execution_time
-
-Get the value of L<ZONEMASTER.max_zonemaster_execution_time|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#max_zonemaster_execution_time>.
-
-Returns an integer.
-
-
-=head2 ZONEMASTER_number_of_processes_for_frontend_testing
-
-Get the value of
-L<ZONEMASTER.number_of_processes_for_frontend_testing|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#number_of_processes_for_frontend_testing>.
-
-Returns a positive integer.
-
-
-=head2 ZONEMASTER_number_of_processes_for_batch_testing
-
-Get the value of
-L<ZONEMASTER.number_of_processes_for_batch_testing|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#number_of_processes_for_batch_testing>.
-
-Returns an integer.
-
-
-=head2 ZONEMASTER_lock_on_queue
-
-Get the value of
-L<ZONEMASTER.lock_on_queue|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#lock_on_queue>.
-
-Returns an integer.
-
-
-=head2 ZONEMASTER_maximal_number_of_retries
-
-Get the value of
-L<ZONEMASTER.maximal_number_of_retries|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#maximal_number_of_retries>.
-
-Returns an integer.
-
-
-=head2 ZONEMASTER_age_reuse_previous_test
-
-Get the value of
-L<ZONEMASTER.age_reuse_previous_test|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#age_reuse_previous_test>.
-
-Returns an integer.
-
-=cut
-
 sub ReadProfilesInfo {
     my ($self) = @_;
 
@@ -515,14 +521,6 @@ sub ListPublicProfiles {
 
     return keys %{ $self->{_public_profiles} };
 }
-
-=head2 check_db
-
-Returns a normalized string based on the supported databases.
-
-=head3 EXCEPTION
-
-Dies if the value is not one of SQLite, PostgreSQL or MySQL.
 
 =head2 new_DB
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -483,44 +483,21 @@ sub MaxZonemasterExecutionTime {
 }
 
 
-=head2 NumberOfProcessesForFrontendTesting
 
-=head3 INPUT
+=head2 ZONEMASTER_number_of_processes_for_frontend_testing
 
-'number_of_processes_for_frontend_testing' from [ZONEMASTER] section in ini file. See
-L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#number_of_processes_for_frontend_testing>.
+Get the value of
+L<ZONEMASTER.number_of_processes_for_frontend_testing|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#number_of_processes_for_frontend_testing>.
 
-=head3 RETURNS
-
-Positive integer.
-
-=cut
-
-sub NumberOfProcessesForFrontendTesting {
-    my ($self) = @_;
-
-    return $self->ZONEMASTER_number_of_processes_for_frontend_testing;
-}
+Returns a positive integer.
 
 
-=head2 NumberOfProcessesForBatchTesting
+=head2 ZONEMASTER_number_of_processes_for_batch_testing
 
-=head3 INPUT
+Get the value of
+L<ZONEMASTER.number_of_processes_for_batch_testing|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#number_of_processes_for_batch_testing>.
 
-'number_of_processes_for_batch_testing' from [ZONEMASTER] section in ini file. See
-L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#number_of_processes_for_batch_testing>.
-
-=head3 RETURNS
-
-Integer.
-
-=cut
-
-sub NumberOfProcessesForBatchTesting {
-    my ($self) = @_;
-
-    return $self->ZONEMASTER_number_of_processes_for_batch_testing;
-}
+Returns an integer.
 
 
 =head2 lock_on_queue
@@ -668,9 +645,9 @@ The values of the following attributes affect the construction of the returned o
 
 =item MaxZonemasterExecutionTime
 
-=item NumberOfProcessesForBatchTesting
+=item ZONEMASTER_number_of_processes_for_batch_testing
 
-=item NumberOfProcessesForFrontendTesting
+=item ZONEMASTER_number_of_processes_for_frontend_testing
 
 =back
 
@@ -683,7 +660,7 @@ A configured L<Parallel::ForkManager> object.
 sub new_PM {
     my $self = shift;
 
-    my $maximum_processes = $self->NumberOfProcessesForFrontendTesting() + $self->NumberOfProcessesForBatchTesting();
+    my $maximum_processes = $self->ZONEMASTER_number_of_processes_for_frontend_testing + $self->ZONEMASTER_number_of_processes_for_batch_testing;
 
     my $timeout = $self->MaxZonemasterExecutionTime();
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -228,17 +228,6 @@ sub parse {
           if !defined $obj->NumberOfProcessesForBatchTesting;
     }
 
-    # Check unknown property names
-    my @unrecognized;
-    for my $section ( $ini->Sections ) {
-        for my $param ( $ini->Parameters( $section ) ) {
-            push @unrecognized, "$section.$param";
-        }
-    }
-    if ( @unrecognized ) {
-        die "config: unrecognized property(s): " . join( ", ", sort @unrecognized ) . "\n";
-    }
-
     # Check required propertys (part 2/2)
     if ( $obj->DB_engine eq 'MySQL' ) {
         die "config: missing required property MYSQL.host (required when DB.engine = MySQL and DB.database_host is unset)\n"
@@ -269,6 +258,19 @@ sub parse {
     elsif ( $obj->DB_engine eq 'SQLite' ) {
         die "config: missing required property SQLITE.database_file (required when DB.engine = SQLite and DB.database_name is unset)\n"
           if !defined $obj->SQLITE_database_file;
+    }
+
+    # Check unknown property names
+    {
+        my @unrecognized;
+        for my $section ( $ini->Sections ) {
+            for my $param ( $ini->Parameters( $section ) ) {
+                push @unrecognized, "$section.$param";
+            }
+        }
+        if ( @unrecognized ) {
+            die "config: unrecognized property(s): " . join( ", ", sort @unrecognized ) . "\n";
+        }
     }
 
     # Emit deprecation warnings

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -303,65 +303,47 @@ sub check_db {
 
 =head2 MYSQL_database
 
-Returns the L<MYSQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database>
-property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_name>
-property if it is unspecified.
+Get the value of L<MYSQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database>.
 
 
 =head2 MySQL_host
 
-Returns the L<MYSQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#host>
-property from the loaded config, or the L<DB.database_host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_host>
-property if it is unspecified.
+Get the value of L<MYSQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#host>.
 
 
 =head2 MYSQL_password
 
-Returns the L<MYSQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password-1>
-property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password>
-property if it is unspecified.
+Get the value of L<MYSQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password-1>.
 
 
 =head2 MYSQL_user
 
-Returns the L<MYSQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user-1>
-property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user>
-property if it is unspecified.
+Get the value of L<MYSQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user-1>.
 
 
 =head2 POSTGRESQL_database
 
-Returns the L<POSTGRESQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database-1>
-property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_name>
-property if it is unspecified.
+Get the value of L<POSTGRESQL.database|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database-1>.
 
 
 =head2 POSTGRESQL_host
 
-Returns the L<POSTGRESQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#host-1>
-property from the loaded config, or the L<DB.database_host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_host>
-property if it is unspecified.
+Get the value of L<POSTGRESQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#host-1>.
 
 
 =head2 POSTGRESQL_password
 
-Returns the L<POSTGRESQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password-2>
-property from the loaded config, or the L<DB.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password>
-property if it is unspecified.
+Get the value of L<POSTGRESQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password-2>.
 
 
 =head2 POSTGRESQL_user
 
-Returns the L<POSTGRESQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user-2>
-property from the loaded config, or the L<DB.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user>
-property if it is unspecified.
+Get the value of L<POSTGRESQL.user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#user-2>.
 
 
 =head2 SQLITE_database_file
 
-Returns the L<SQLITE.database_file|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_file>
-property from the loaded config, or the L<DB.database_name|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_name>
-property if it is unspecified.
+Get the value of L<SQLITE.database_file|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#database_file>.
 
 =cut
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -300,10 +300,6 @@ sub check_db {
     }
 }
 
-sub BackendDBType {
-    my ($self) = @_;
-    return $self->DB_engine;
-}
 
 =head2 MYSQL_database
 
@@ -453,6 +449,13 @@ sub ListLanguageTags {
     }
     return @langtags;
 }
+
+
+=head2 DB_engine
+
+Get the value of L<DB.engine|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#polling_interval>.
+
+Returns one of C<"SQLite">, C<"PostgreSQL"> or C<"MySQL">.
 
 
 =head2 DB_polling_interval
@@ -612,14 +615,6 @@ Returns a normalized string based on the supported databases.
 
 Dies if the value is not one of SQLite, PostgreSQL or MySQL.
 
-=head2 BackendDBType
-
-Returns a normalized string based on the DB.engine value in the config.
-
-=head3 EXCEPTION
-
-Dies if the value of DB.engine is unrecognized.
-
 =head2 new_DB
 
 Create a new database adapter object according to configuration.
@@ -629,7 +624,7 @@ The adapter connects to the database before it is returned.
 =head3 INPUT
 
 The database adapter class is selected based on the return value of
-BackendDBType().
+L<DB_engine>.
 The database adapter class constructor is called without arguments and is
 expected to configure itself according to available global configuration.
 
@@ -655,7 +650,7 @@ sub new_DB {
     my ($self) = @_;
 
     # Get DB type from config
-    my $dbtype = $self->BackendDBType();
+    my $dbtype = $self->DB_engine;
     if (!defined $dbtype) {
         die "Unrecognized DB.engine in backend config";
     }

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -454,11 +454,10 @@ sub ListLanguageTags {
     return @langtags;
 }
 
-sub PollingInterval {
-    my ($self) = @_;
 
-    return $self->DB_polling_interval;
-}
+=head2 DB_polling_interval
+
+Get the value of L<DB.polling_interval|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#polling_interval>.
 
 
 =head2 MaxZonemasterExecutionTime

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -311,7 +311,7 @@ sub check_db {
 
 =head2 DB_engine
 
-Get the value of L<DB.engine|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#polling_interval>.
+Get the value of L<DB.engine|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#engine>.
 
 Returns one of C<"SQLite">, C<"PostgreSQL"> or C<"MySQL">.
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -56,7 +56,7 @@ sub get_test_request {
     
     
     my ( $id, $hash_id );
-    my $lock_on_queue = $self->config->lock_on_queue();
+    my $lock_on_queue = $self->config->ZONEMASTER_lock_on_queue;
     if ( defined $lock_on_queue ) {
         ( $id, $hash_id ) = $dbh->selectrow_array( qq[ SELECT id, hash_id FROM test_results WHERE progress=0 AND queue=? ORDER BY priority DESC, id ASC LIMIT 1 ], undef, $lock_on_queue );
     }
@@ -107,7 +107,7 @@ sub process_unfinished_tests {
     my $sth1 = $self->select_unfinished_tests();
         
     while ( my $h = $sth1->fetchrow_hashref ) {
-        if ( $h->{nb_retries} < $self->config->maximal_number_of_retries() ) {
+        if ( $h->{nb_retries} < $self->config->ZONEMASTER_maximal_number_of_retries ) {
             $self->schedule_for_retry($h->{hash_id});
         }
         else {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -12,12 +12,12 @@ use Data::Dumper;
 requires qw(
   add_api_user_to_db
   add_batch_job
-  build_process_unfinished_tests_select_query
   create_new_batch_job
   create_new_test
   get_test_history
   get_test_params
   process_unfinished_tests_give_up
+  select_unfinished_tests
   test_progress
   test_results
   user_authorized
@@ -104,12 +104,8 @@ sub get_batch_job_result {
 sub process_unfinished_tests {
     my ( $self ) = @_;
     
-    my $dbh = $self->dbh;
-    
-    my $query = $self->build_process_unfinished_tests_select_query();
+    my $sth1 = $self->select_unfinished_tests();
         
-    my $sth1 = $dbh->prepare( $query );
-    $sth1->execute( );
     while ( my $h = $sth1->fetchrow_hashref ) {
         if ( $h->{nb_retries} < $self->config->maximal_number_of_retries() ) {
             $self->schedule_for_retry($h->{hash_id});

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -9,8 +9,20 @@ use 5.14.2;
 use JSON::PP;
 use Data::Dumper;
 
-requires 'add_api_user_to_db', 'user_exists_in_db', 'user_authorized', 'test_progress', 'test_results',
-  'create_new_batch_job', 'create_new_test', 'get_test_params', 'get_test_history', 'add_batch_job', 'build_process_unfinished_tests_select_query', 'process_unfinished_tests_give_up';
+requires qw(
+  add_api_user_to_db
+  add_batch_job
+  build_process_unfinished_tests_select_query
+  create_new_batch_job
+  create_new_test
+  get_test_history
+  get_test_params
+  process_unfinished_tests_give_up
+  test_progress
+  test_results
+  user_authorized
+  user_exists_in_db
+);
 
 sub user_exists {
     my ( $self, $user ) = @_;

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -339,7 +339,7 @@ sub add_batch_job {
 sub select_unfinished_tests {
     my ( $self ) = @_;
 
-    if ($self->config->lock_on_queue()) {
+    if ( $self->config->ZONEMASTER_lock_on_queue ) {
         my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
@@ -349,9 +349,9 @@ sub select_unfinished_tests {
             AND progress < 100
             AND queue = ?" );
         $sth->execute(    #
-            $self->config->MaxZonemasterExecutionTime,
-            $self->config->maximal_number_of_retries,
-            $self->config->lock_on_queue,
+            $self->config->ZONEMASTER_max_zonemaster_execution_time,
+            $self->config->ZONEMASTER_maximal_number_of_retries,
+            $self->config->ZONEMASTER_lock_on_queue,
         );
         return $sth;
     }
@@ -364,8 +364,8 @@ sub select_unfinished_tests {
             AND progress > 0
             AND progress < 100" );
         $sth->execute(    #
-            $self->config->MaxZonemasterExecutionTime,
-            $self->config->maximal_number_of_retries,
+            $self->config->ZONEMASTER_max_zonemaster_execution_time,
+            $self->config->ZONEMASTER_maximal_number_of_retries,
         );
         return $sth;
     }

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -343,23 +343,30 @@ sub select_unfinished_tests {
         my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
-            WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ".$self->config->MaxZonemasterExecutionTime()." SECOND)
-            AND nb_retries <= ".$self->config->maximal_number_of_retries()."
+            WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ? SECOND)
+            AND nb_retries <= ?
             AND progress > 0
             AND progress < 100
-            AND queue = ".$self->config->lock_on_queue() );
-        $sth->execute();
+            AND queue = ?" );
+        $sth->execute(    #
+            $self->config->MaxZonemasterExecutionTime,
+            $self->config->maximal_number_of_retries,
+            $self->config->lock_on_queue,
+        );
         return $sth;
     }
     else {
         my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
-            WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ".$self->config->MaxZonemasterExecutionTime()." SECOND)
-            AND nb_retries <= ".$self->config->maximal_number_of_retries()."
+            WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ? SECOND)
+            AND nb_retries <= ?
             AND progress > 0
             AND progress < 100" );
-        $sth->execute();
+        $sth->execute(    #
+            $self->config->MaxZonemasterExecutionTime,
+            $self->config->maximal_number_of_retries,
+        );
         return $sth;
     }
 }

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -338,13 +338,13 @@ sub add_batch_job {
 
 sub build_process_unfinished_tests_select_query {
     my ( $self ) = @_;
-    
+
     if ($self->config->lock_on_queue()) {
         return "
             SELECT hash_id, results, nb_retries
-            FROM test_results 
-            WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ".$self->config->MaxZonemasterExecutionTime()." SECOND) 
-            AND nb_retries <= ".$self->config->maximal_number_of_retries()." 
+            FROM test_results
+            WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ".$self->config->MaxZonemasterExecutionTime()." SECOND)
+            AND nb_retries <= ".$self->config->maximal_number_of_retries()."
             AND progress > 0
             AND progress < 100
             AND queue = ".$self->config->lock_on_queue();
@@ -352,9 +352,9 @@ sub build_process_unfinished_tests_select_query {
     else {
         return "
             SELECT hash_id, results, nb_retries
-            FROM test_results 
-            WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ".$self->config->MaxZonemasterExecutionTime()." SECOND) 
-            AND nb_retries <= ".$self->config->maximal_number_of_retries()." 
+            FROM test_results
+            WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ".$self->config->MaxZonemasterExecutionTime()." SECOND)
+            AND nb_retries <= ".$self->config->maximal_number_of_retries()."
             AND progress > 0
             AND progress < 100";
     }

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -336,27 +336,31 @@ sub add_batch_job {
     return $batch_id;
 }
 
-sub build_process_unfinished_tests_select_query {
+sub select_unfinished_tests {
     my ( $self ) = @_;
 
     if ($self->config->lock_on_queue()) {
-        return "
+        my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
             WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ".$self->config->MaxZonemasterExecutionTime()." SECOND)
             AND nb_retries <= ".$self->config->maximal_number_of_retries()."
             AND progress > 0
             AND progress < 100
-            AND queue = ".$self->config->lock_on_queue();
+            AND queue = ".$self->config->lock_on_queue() );
+        $sth->execute();
+        return $sth;
     }
     else {
-        return "
+        my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
             WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ".$self->config->MaxZonemasterExecutionTime()." SECOND)
             AND nb_retries <= ".$self->config->maximal_number_of_retries()."
             AND progress > 0
-            AND progress < 100";
+            AND progress < 100" );
+        $sth->execute();
+        return $sth;
     }
 }
 

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -317,7 +317,7 @@ sub add_batch_job {
 sub select_unfinished_tests {
     my ( $self ) = @_;
 
-    if ($self->config->lock_on_queue()) {
+    if ( $self->config->ZONEMASTER_lock_on_queue ) {
         my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
@@ -327,9 +327,9 @@ sub select_unfinished_tests {
             AND progress < 100
             AND queue = ?" );
         $sth->execute(    #
-            sprintf( "%d seconds", $self->config->MaxZonemasterExecutionTime ),
-            $self->config->maximal_number_of_retries,
-            $self->config->lock_on_queue,
+            sprintf( "%d seconds", $self->config->ZONEMASTER_max_zonemaster_execution_time ),
+            $self->config->ZONEMASTER_maximal_number_of_retries,
+            $self->config->ZONEMASTER_lock_on_queue,
         );
         return $sth;
     }
@@ -342,8 +342,8 @@ sub select_unfinished_tests {
             AND progress > 0
             AND progress < 100" );
         $sth->execute(    #
-            sprintf( "%d seconds", $self->config->MaxZonemasterExecutionTime ),
-            $self->config->maximal_number_of_retries,
+            sprintf( "%d seconds", $self->config->ZONEMASTER_max_zonemaster_execution_time ),
+            $self->config->ZONEMASTER_maximal_number_of_retries,
         );
         return $sth;
     }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -142,16 +142,23 @@ sub create_new_test {
     my $priority = $test_params->{priority};
     my $queue = $test_params->{queue};
 
-    my $query =
-        "INSERT INTO test_results (batch_id, priority, queue, params_deterministic_hash, params) SELECT "
-      . $dbh->quote( $batch_id ) . ", "
-      . $dbh->quote( $priority ) . ", "
-      . $dbh->quote( $queue ) . ", "
-      . $dbh->quote( $test_params_deterministic_hash ) . ", "
-      . $dbh->quote( $encoded_params )
-      . " WHERE NOT EXISTS (SELECT * FROM test_results WHERE params_deterministic_hash='$test_params_deterministic_hash' AND creation_time > NOW()-'$minutes_between_tests_with_same_params minutes'::interval)";
-
-    my $nb_inserted = $dbh->do( $query );
+    my $sth = $dbh->prepare( "
+        INSERT INTO test_results (batch_id, priority, queue, params_deterministic_hash, params)
+        SELECT ?, ?, ?, ?, ?
+        WHERE NOT EXISTS (
+            SELECT * FROM test_results
+            WHERE params_deterministic_hash = ?
+              AND creation_time > NOW() - ?::interval
+        )" );
+    my $nb_inserted = $sth->execute(    #
+        $batch_id,
+        $priority,
+        $queue,
+        $test_params_deterministic_hash,
+        $encoded_params,
+        $test_params_deterministic_hash,
+        sprintf( "%d minutes", $minutes_between_tests_with_same_params ),
+    );
 
     my ( undef, $hash_id ) = $dbh->selectrow_array(
         "SELECT id,hash_id FROM test_results WHERE params_deterministic_hash=? ORDER BY id DESC LIMIT 1", undef, $test_params_deterministic_hash );
@@ -314,23 +321,30 @@ sub select_unfinished_tests {
         my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
-            WHERE test_start_time < NOW() - '".$self->config->MaxZonemasterExecutionTime()." seconds'::interval
-            AND nb_retries <= ".$self->config->maximal_number_of_retries()."
+            WHERE test_start_time < NOW() - ?::interval
+            AND nb_retries <= ?
             AND progress > 0
             AND progress < 100
-            AND queue=".$self->config->lock_on_queue() );
-        $sth->execute();
+            AND queue = ?" );
+        $sth->execute(    #
+            sprintf( "%d seconds", $self->config->MaxZonemasterExecutionTime ),
+            $self->config->maximal_number_of_retries,
+            $self->config->lock_on_queue,
+        );
         return $sth;
     }
     else {
         my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
-            WHERE test_start_time < NOW() - '".$self->config->MaxZonemasterExecutionTime()." seconds'::interval
-            AND nb_retries <= ".$self->config->maximal_number_of_retries()."
+            WHERE test_start_time < NOW() - ?::interval
+            AND nb_retries <= ?
             AND progress > 0
             AND progress < 100" );
-        $sth->execute();
+        $sth->execute(    #
+            sprintf( "%d seconds", $self->config->MaxZonemasterExecutionTime ),
+            $self->config->maximal_number_of_retries,
+        );
         return $sth;
     }
 }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -309,12 +309,13 @@ sub add_batch_job {
 
 sub build_process_unfinished_tests_select_query {
     my ( $self ) = @_;
-    
+
     if ($self->config->lock_on_queue()) {
         return "
             SELECT hash_id, results, nb_retries
-            FROM test_results 
-            WHERE test_start_time < NOW() - '".$self->config->MaxZonemasterExecutionTime()." seconds'::interval AND nb_retries <= ".$self->config->maximal_number_of_retries()."
+            FROM test_results
+            WHERE test_start_time < NOW() - '".$self->config->MaxZonemasterExecutionTime()." seconds'::interval
+            AND nb_retries <= ".$self->config->maximal_number_of_retries()."
             AND progress > 0
             AND progress < 100
             AND queue=".$self->config->lock_on_queue();
@@ -322,8 +323,9 @@ sub build_process_unfinished_tests_select_query {
     else {
         return "
             SELECT hash_id, results, nb_retries
-            FROM test_results 
-            WHERE test_start_time < NOW() - '".$self->config->MaxZonemasterExecutionTime()." seconds'::interval AND nb_retries <= ".$self->config->maximal_number_of_retries()."
+            FROM test_results
+            WHERE test_start_time < NOW() - '".$self->config->MaxZonemasterExecutionTime()." seconds'::interval
+            AND nb_retries <= ".$self->config->maximal_number_of_retries()."
             AND progress > 0
             AND progress < 100";
     }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -307,27 +307,31 @@ sub add_batch_job {
     return $batch_id;
 }
 
-sub build_process_unfinished_tests_select_query {
+sub select_unfinished_tests {
     my ( $self ) = @_;
 
     if ($self->config->lock_on_queue()) {
-        return "
+        my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
             WHERE test_start_time < NOW() - '".$self->config->MaxZonemasterExecutionTime()." seconds'::interval
             AND nb_retries <= ".$self->config->maximal_number_of_retries()."
             AND progress > 0
             AND progress < 100
-            AND queue=".$self->config->lock_on_queue();
+            AND queue=".$self->config->lock_on_queue() );
+        $sth->execute();
+        return $sth;
     }
     else {
-        return "
+        my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
             WHERE test_start_time < NOW() - '".$self->config->MaxZonemasterExecutionTime()." seconds'::interval
             AND nb_retries <= ".$self->config->maximal_number_of_retries()."
             AND progress > 0
-            AND progress < 100";
+            AND progress < 100" );
+        $sth->execute();
+        return $sth;
     }
 }
 

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -375,7 +375,7 @@ sub add_batch_job {
 sub select_unfinished_tests {
     my ( $self ) = @_;
 
-    if ($self->config->lock_on_queue()) {
+    if ( $self->config->ZONEMASTER_lock_on_queue ) {
         my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
@@ -385,9 +385,9 @@ sub select_unfinished_tests {
             AND progress < 100
             AND queue=?" );
         $sth->execute(    #
-            sprintf( "-%d seconds", $self->config->MaxZonemasterExecutionTime ),
-            $self->config->maximal_number_of_retries,
-            $self->config->lock_on_queue,
+            sprintf( "-%d seconds", $self->config->ZONEMASTER_max_zonemaster_execution_time ),
+            $self->config->ZONEMASTER_maximal_number_of_retries,
+            $self->config->ZONEMASTER_lock_on_queue,
         );
         return $sth;
     }
@@ -400,8 +400,8 @@ sub select_unfinished_tests {
             AND progress > 0
             AND progress < 100" );
         $sth->execute(    #
-            sprintf( "-%d seconds", $self->config->MaxZonemasterExecutionTime ),
-            $self->config->maximal_number_of_retries,
+            sprintf( "-%d seconds", $self->config->ZONEMASTER_max_zonemaster_execution_time ),
+            $self->config->ZONEMASTER_maximal_number_of_retries,
         );
         return $sth;
     }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -372,27 +372,27 @@ sub add_batch_job {
 }
 
 sub build_process_unfinished_tests_select_query {
-     my ( $self ) = @_;
-     
-     if ($self->config->lock_on_queue()) {
-          return "
-               SELECT hash_id, results, nb_retries
-               FROM test_results 
-               WHERE test_start_time < DATETIME('now', '-".$self->config->MaxZonemasterExecutionTime()." seconds')
-               AND nb_retries <= ".$self->config->maximal_number_of_retries()." 
-               AND progress > 0
-               AND progress < 100
-               AND queue=".$self->config->lock_on_queue();
-     }
-     else {
-          return "
-               SELECT hash_id, results, nb_retries
-               FROM test_results 
-               WHERE test_start_time < DATETIME('now', '-".$self->config->MaxZonemasterExecutionTime()." seconds')
-               AND nb_retries <= ".$self->config->maximal_number_of_retries()." 
-               AND progress > 0
-               AND progress < 100";
-     }
+    my ( $self ) = @_;
+
+    if ($self->config->lock_on_queue()) {
+        return "
+            SELECT hash_id, results, nb_retries
+            FROM test_results
+            WHERE test_start_time < DATETIME('now', '-".$self->config->MaxZonemasterExecutionTime()." seconds')
+            AND nb_retries <= ".$self->config->maximal_number_of_retries()."
+            AND progress > 0
+            AND progress < 100
+            AND queue=".$self->config->lock_on_queue();
+    }
+    else {
+        return "
+            SELECT hash_id, results, nb_retries
+            FROM test_results
+            WHERE test_start_time < DATETIME('now', '-".$self->config->MaxZonemasterExecutionTime()." seconds')
+            AND nb_retries <= ".$self->config->maximal_number_of_retries()."
+            AND progress > 0
+            AND progress < 100";
+    }
 }
 
 sub process_unfinished_tests_give_up {

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -383,7 +383,7 @@ sub select_unfinished_tests {
             AND nb_retries <= ?
             AND progress > 0
             AND progress < 100
-            AND queue=?" );
+            AND queue = ?" );
         $sth->execute(    #
             sprintf( "-%d seconds", $self->config->ZONEMASTER_max_zonemaster_execution_time ),
             $self->config->ZONEMASTER_maximal_number_of_retries,

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -371,27 +371,31 @@ sub add_batch_job {
     return $batch_id;
 }
 
-sub build_process_unfinished_tests_select_query {
+sub select_unfinished_tests {
     my ( $self ) = @_;
 
     if ($self->config->lock_on_queue()) {
-        return "
+        my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
             WHERE test_start_time < DATETIME('now', '-".$self->config->MaxZonemasterExecutionTime()." seconds')
             AND nb_retries <= ".$self->config->maximal_number_of_retries()."
             AND progress > 0
             AND progress < 100
-            AND queue=".$self->config->lock_on_queue();
+            AND queue=".$self->config->lock_on_queue() );
+        $sth->execute();
+        return $sth;
     }
     else {
-        return "
+        my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
             WHERE test_start_time < DATETIME('now', '-".$self->config->MaxZonemasterExecutionTime()." seconds')
             AND nb_retries <= ".$self->config->maximal_number_of_retries()."
             AND progress > 0
-            AND progress < 100";
+            AND progress < 100" );
+        $sth->execute();
+        return $sth;
     }
 }
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -50,7 +50,7 @@ sub new {
     if ( $params->{dbtype} ) {
         $dbtype = $self->{config}->check_db($params->{dbtype});
     } else {
-        $dbtype = $self->{config}->BackendDBType();
+        $dbtype = $self->{config}->DB_engine;
     }
 
     $self->_init_db($dbtype);

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -385,7 +385,7 @@ sub start_domain_test {
 
         $params->{priority}  //= 10;
         $params->{queue}     //= 0;
-        my $shelf_life_seconds = $self->{config}->age_reuse_previous_test;
+        my $shelf_life_seconds = $self->{config}->ZONEMASTER_age_reuse_previous_test;
         my $shelf_life_minutes = int ( ($shelf_life_seconds / 60) + 0.5);
 
         $result = $self->{db}->create_new_test( $params->{domain}, $params, $shelf_life_minutes );

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -32,7 +32,7 @@ sub new {
         $dbtype = $self->{config}->check_db($params->{dbtype});
     }
     else {
-        $dbtype = $self->{config}->BackendDBType();
+        $dbtype = $self->{config}->DB_engine;
     }
 
     my $backend_module = "Zonemaster::Backend::DB::" . $dbtype;

--- a/script/create_db_mysql.pl
+++ b/script/create_db_mysql.pl
@@ -10,7 +10,7 @@ use Zonemaster::Backend::Config;
 use Zonemaster::Backend::DB::MySQL;
 
 my $config = Zonemaster::Backend::Config->load_config();
-if ( $config->BackendDBType() ne 'MySQL' ) {
+if ( $config->DB_engine ne 'MySQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
 my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;

--- a/script/create_db_postgresql_9.3.pl
+++ b/script/create_db_postgresql_9.3.pl
@@ -10,7 +10,7 @@ use Zonemaster::Backend::Config;
 use Zonemaster::Backend::DB::PostgreSQL;
 
 my $config = Zonemaster::Backend::Config->load_config();
-if ( $config->BackendDBType() ne 'PostgreSQL' ) {
+if ( $config->DB_engine ne 'PostgreSQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
 my $dbh     = Zonemaster::Backend::DB::PostgreSQL->new( { config => $config } )->dbh;

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -151,7 +151,7 @@ sub main {
             }
         }
         else {
-            sleep $self->config->PollingInterval();
+            sleep $self->config->DB_polling_interval;
         }
     }
 

--- a/share/create_db_sqlite.pl
+++ b/share/create_db_sqlite.pl
@@ -10,7 +10,7 @@ use Zonemaster::Backend::Config;
 use Zonemaster::Backend::DB::SQLite;
 
 my $config = Zonemaster::Backend::Config->load_config();
-if ( $config->BackendDBType() ne 'SQLite' ) {
+if ( $config->DB_engine ne 'SQLite' ) {
     die "The configuration file does not contain the SQLite backend";
 }
 my $db = Zonemaster::Backend::DB::SQLite->new( { config => $config } );

--- a/share/patch_mysql_db_zonemaster_backend_ver_1.0.3.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_1.0.3.pl
@@ -10,7 +10,7 @@ use Zonemaster::Backend::Config;
 use Zonemaster::Backend::DB::MySQL;
 
 my $config = Zonemaster::Backend::Config->load_config();
-if ( $config->BackendDBType() ne 'MySQL' ) {
+if ( $config->DB_engine ne 'MySQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
 my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;

--- a/share/patch_mysql_db_zonemaster_backend_ver_5.0.0.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_5.0.0.pl
@@ -10,7 +10,7 @@ use Zonemaster::Backend::Config;
 use Zonemaster::Backend::DB::MySQL;
 
 my $config = Zonemaster::Backend::Config->load_config();
-if ( $config->BackendDBType() ne 'MySQL' ) {
+if ( $config->DB_engine ne 'MySQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
 my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;

--- a/share/patch_mysql_db_zonemaster_backend_ver_5.0.2.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_5.0.2.pl
@@ -10,7 +10,7 @@ use Zonemaster::Backend::Config;
 use Zonemaster::Backend::DB::MySQL;
 
 my $config = Zonemaster::Backend::Config->load_config();
-if ( $config->BackendDBType() ne 'MySQL' ) {
+if ( $config->DB_engine ne 'MySQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
 my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;

--- a/share/patch_postgresql_db_zonemaster_backend_ver_1.0.3.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_1.0.3.pl
@@ -10,7 +10,7 @@ use Zonemaster::Backend::Config;
 use Zonemaster::Backend::DB::MySQL;
 
 my $config = Zonemaster::Backend::Config->load_config();
-if ( $config->BackendDBType() ne 'MySQL' ) {
+if ( $config->DB_engine ne 'MySQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
 my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;

--- a/share/patch_postgresql_db_zonemaster_backend_ver_5.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_5.0.0.pl
@@ -10,7 +10,7 @@ use Zonemaster::Backend::Config;
 use Zonemaster::Backend::DB::PostgreSQL;
 
 my $config = Zonemaster::Backend::Config->load_config();
-if ( $config->BackendDBType() ne 'PostgreSQL' ) {
+if ( $config->DB_engine ne 'PostgreSQL' ) {
     die "The configuration file does not contain the PostgreSQL backend";
 }
 my $dbh = Zonemaster::Backend::DB::PostgreSQL->new( { config => $config } )->dbh;

--- a/t/config.t
+++ b/t/config.t
@@ -137,6 +137,23 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->SQLITE_database_file, '/var/db/zonemaster.sqlite', 'fallback: SQLITE.database_file';
     };
 
+    lives_and {
+        my $text = q{
+            [DB]
+            engine = SQLite
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+            [ZONEMASTER]
+            number_of_professes_for_frontend_testing = 21
+            number_of_professes_for_batch_testing    = 22
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        $log->contains_ok( qr/deprecated.*ZONEMASTER\.number_of_professes_for_frontend_testing/, 'deprecated: ZONEMASTER.number_of_professes_for_frontend_testing' );
+        $log->contains_ok( qr/deprecated.*ZONEMASTER\.number_of_professes_for_batch_testing/,    'deprecated: ZONEMASTER.number_of_professes_for_batch_testing' );
+        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, '21', 'fallback: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    '22', 'fallback: ZONEMASTER.number_of_processes_for_batch_testing';
+    };
+
     throws_ok {
         my $text = '{"this":"is","not":"a","valid":"ini","file":"!"}';
         Zonemaster::Backend::Config->parse( $text );


### PR DESCRIPTION
## Context

This PR is a follow-up to #749.

## Scope

Included:
* Cleaning up after #749.
* Documentation is added for the new getters from #749.
* Documentation for the database connection related properties is updated for consistency.
* Relevant pieces of cleaned up documentation is integrated into the backend config format specification.
* SQL-queries adjacent to uses of the new property getters are refactored to use the ?-syntax instead of string concatenation. To facilitate a few other refactorings are also included.

Excluded:
* Functional changes.

## Changes

Security:
* In a couple of places another layer of security is added by using SQL-injection resistant ? syntax. This also makes the code easier to review with regard to security.

Documentation:
* The backend config format specification gets a tiny improvement by adopting a wording from the getter POD.
* The POD for the uniform getters is made very light for easier maintenance and higher reliability by not duplicating information provided in the format specification. The idea is to make the format specification a single source of truth. Implementation details are still kept in the getter POD, e.g. the form in which the property values are returned.

Clean-up:
* The free-form getters that received new replacements in #749 are removed. All calls to them are replaced with calls to the new getters.

## How to test this PR

This PR contains no functional changes. It should be enough that the automatic tests pass.