### PR TITLE
Document keys number_of_processes_for_{frontend,batch}_testing

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -270,18 +270,24 @@ Do not use it (keep the default value "0"), or use it with care.
 ### number_of_processes_for_frontend_testing
 
 A positive integer.
-
-used -> todo
-
+Number of processes allowed to run in parallel (added with
+`number_of_processes_for_batch_testing`).
 Default value: `20`.
+
+Despite its name, this key does not limit the number of process used by the
+frontend, but is used in combination of
+`number_of_processes_for_batch_testing`.
 
 ### number_of_processes_for_batch_testing
 
 An integer.
-
-used -> todo
-
+Number of processes allowed to run in parallel (added with
+`number_of_processes_for_frontend_testing`).
 Default value: `20`.
+
+Despite its name, this key does not limit the number of process used by any
+batch pool of tests, but is used in combination of
+`number_of_processes_for_frontend_testing`.
 
 ### lock_on_queue
 


### PR DESCRIPTION
Add documentation to the last two keys. I am not completely satisfied but this is the best I came up with to explain how we use these values in the code.

There was also a discussion on deprecating these keys in #623, this will come in another PR.