### PR TITLE
Configuration of the database port

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -70,7 +70,7 @@ Default value: `0.5`.
 
 ## MYSQL section
 
-Available keys : `host`, `user`, `password`, `database`.
+Available keys : `host`, `port`, `user`, `password`, `database`.
 
 ### host
 
@@ -79,6 +79,13 @@ An [LDH domain name] or IP address.
 The host name of the machine on which the MySQL server is running.
 
 If this property is unspecified, the value of [DB.database_host] is used instead.
+
+### port
+
+The port the MySQL server is listening on. If the server is on the local
+machine, then the [MYSQL.host] value must contain the loopback IP
+address (127.0.0.1).
+Default value: `3306`.
 
 ### user
 
@@ -111,7 +118,7 @@ If this property is unspecified, the value of [DB.database_name] is used instead
 
 ## POSTGRESQL section
 
-Available keys : `host`, `user`, `password`, `database`.
+Available keys : `host`, `port`, `user`, `password`, `database`.
 
 ### host
 
@@ -120,6 +127,11 @@ An [LDH domain name] or IP address.
 The host name of the machine on which the PostgreSQL server is running.
 
 If this property is unspecified, the value of [DB.database_host] is used instead.
+
+### port
+
+The port the PostgreSQL server is listening on.
+Default value: `5432`.
 
 ### user
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -85,7 +85,7 @@ If this property is unspecified, the value of [DB.database_host] is used instead
 The port the MySQL server is listening on.
 Default value: `3306`.
 
-If [MYSQL.host] is set to `localhost` (but not `127.0.0.1` nor `::1`),
+If [MYSQL.host] is set to `localhost` (but neither `127.0.0.1` nor `::1`),
 then the value of the [MYSQL.port] property is discarded as the driver
 connects using a UNIX socket (see the [DBD::mysql documentation]).
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -80,12 +80,18 @@ The host name of the machine on which the MySQL server is running.
 
 If this property is unspecified, the value of [DB.database_host] is used instead.
 
+If this property is set to `localhost`, then the [MYSQL.port] property
+is discarded as the driver connects using a UNIX socket (see the
+[DBD::mysql documentation]).
+
 ### port
 
-The port the MySQL server is listening on. If the server is on the local
-machine, then the [MYSQL.host] value must contain the loopback IP
-address (127.0.0.1).
+The port the MySQL server is listening on.
 Default value: `3306`.
+
+If [MYSQL.host] is set to `localhost`, then this property is discarded as
+the driver connects using a UNIX socket (see the [DBD::mysql
+documentation]).
 
 ### user
 
@@ -359,6 +365,7 @@ Otherwise a new test request is enqueued.
 [DB.database_name]:                   #database_name
 [DB.password]:                        #password
 [DB.user]:                            #user
+[DBD::mysql documentation]:           https://metacpan.org/pod/DBD::mysql#host
 [Default JSON profile file]:          https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
 [File format]:                        https://metacpan.org/pod/Config::IniFiles#FILE-FORMAT
 [ISO 3166-1 alpha-2]:                 https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -80,18 +80,14 @@ The host name of the machine on which the MySQL server is running.
 
 If this property is unspecified, the value of [DB.database_host] is used instead.
 
-If this property is set to `localhost`, then the [MYSQL.port] property
-is discarded as the driver connects using a UNIX socket (see the
-[DBD::mysql documentation]).
-
 ### port
 
 The port the MySQL server is listening on.
 Default value: `3306`.
 
-If [MYSQL.host] is set to `localhost`, then this property is discarded as
-the driver connects using a UNIX socket (see the [DBD::mysql
-documentation]).
+If [MYSQL.host] is set to `localhost` (but not `127.0.0.1` nor `::1`),
+then the value of the [MYSQL.port] property is discarded as the driver
+connects using a UNIX socket (see the [DBD::mysql documentation]).
 
 ### user
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -136,7 +136,7 @@ sub parse {
         $obj->_set_DB_engine( $value );
     }
 
-    # Check required propertys (part 1/2)
+    # Check required properties (part 1/2)
     if ( !defined $obj->DB_engine ) {
         die "config: missing required property DB.engine\n";
     }
@@ -203,6 +203,9 @@ sub parse {
         $obj->_set_MYSQL_host( $value );
     }
     if ( defined( my $value = $get_and_clear->( 'MYSQL', 'port' ) ) ) {
+        if ( $obj->MYSQL_host eq 'localhost' ) {
+            push @warnings, "MYSQL.port is disregarded if MYSQL.host is set to 'localhost'";
+        }
         $obj->{_MYSQL_port} = $value;
     }
     if ( defined( my $value = $get_and_clear->( 'MYSQL', 'user' ) ) ) {

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -122,6 +122,7 @@ sub parse {
 
     # Assign default values
     $obj->_set_DB_polling_interval( '0.5' );
+    $obj->_set_MYSQL_port( '3306' );
     $obj->_set_ZONEMASTER_max_zonemaster_execution_time( '600' );
     $obj->_set_ZONEMASTER_maximal_number_of_retries( '0' );
     $obj->_set_ZONEMASTER_number_of_processes_for_frontend_testing( '20' );
@@ -199,6 +200,9 @@ sub parse {
     }
     if ( defined( my $value = $get_and_clear->( 'MYSQL', 'host' ) ) ) {
         $obj->_set_MYSQL_host( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'MYSQL', 'port' ) ) ) {
+        $obj->{_MYSQL_port} = $value;
     }
     if ( defined( my $value = $get_and_clear->( 'MYSQL', 'user' ) ) ) {
         $obj->_set_MYSQL_user( $value );
@@ -384,6 +388,14 @@ Get the value of L<MYSQL.host|https://github.com/zonemaster/zonemaster-backend/b
 Returns a string.
 
 
+=head2 MYSQL_port
+
+Returns the L<MYSQL.port|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#port>
+property from the loaded config.
+
+Returns a number.
+
+
 =head2 MYSQL_password
 
 Get the value of L<MYSQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password-1>.
@@ -484,6 +496,7 @@ Returns a number.
 # Getters for the properties documented above
 sub DB_polling_interval                                 { return $_[0]->{_DB_polling_interval}; }
 sub MYSQL_host                                          { return $_[0]->{_MYSQL_host}; }
+sub MYSQL_port                                          { return $_[0]->{_MYSQL_port}; }
 sub MYSQL_user                                          { return $_[0]->{_MYSQL_user}; }
 sub MYSQL_password                                      { return $_[0]->{_MYSQL_password}; }
 sub MYSQL_database                                      { return $_[0]->{_MYSQL_database}; }
@@ -503,6 +516,7 @@ sub ZONEMASTER_age_reuse_previous_test                  { return $_[0]->{_ZONEMA
 UNITCHECK {
     _create_setter( '_set_DB_polling_interval',                                 '_DB_polling_interval',                                 \&untaint_strictly_positive_millis );
     _create_setter( '_set_MYSQL_host',                                          '_MYSQL_host',                                          \&untaint_host );
+    _create_setter( '_set_MYSQL_port',                                          '_MYSQL_port',                                          \&untaint_strictly_positive_int );
     _create_setter( '_set_MYSQL_user',                                          '_MYSQL_user',                                          \&untaint_mariadb_user );
     _create_setter( '_set_MYSQL_password',                                      '_MYSQL_password',                                      \&untaint_password );
     _create_setter( '_set_MYSQL_database',                                      '_MYSQL_database',                                      \&untaint_mariadb_database );

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -123,6 +123,7 @@ sub parse {
     # Assign default values
     $obj->_set_DB_polling_interval( '0.5' );
     $obj->_set_MYSQL_port( '3306' );
+    $obj->_set_POSTGRESQL_port( '5432' );
     $obj->_set_ZONEMASTER_max_zonemaster_execution_time( '600' );
     $obj->_set_ZONEMASTER_maximal_number_of_retries( '0' );
     $obj->_set_ZONEMASTER_number_of_processes_for_frontend_testing( '20' );
@@ -215,6 +216,9 @@ sub parse {
     }
     if ( defined( my $value = $get_and_clear->( 'POSTGRESQL', 'host' ) ) ) {
         $obj->_set_POSTGRESQL_host( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'POSTGRESQL', 'port' ) ) ) {
+        $obj->{_POSTGRESQL_port} = $value;
     }
     if ( defined( my $value = $get_and_clear->( 'POSTGRESQL', 'user' ) ) ) {
         $obj->_set_POSTGRESQL_user( $value );
@@ -424,6 +428,14 @@ Get the value of L<POSTGRESQL.host|https://github.com/zonemaster/zonemaster-back
 Returns a string.
 
 
+=head2 POSTGRESQL_port
+
+Returns the L<POSTGRESQL.port|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#port-1>
+property from the loaded config.
+
+Returns a number.
+
+
 =head2 POSTGRESQL_password
 
 Get the value of L<POSTGRESQL.password|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#password-2>.
@@ -501,6 +513,7 @@ sub MYSQL_user                                          { return $_[0]->{_MYSQL_
 sub MYSQL_password                                      { return $_[0]->{_MYSQL_password}; }
 sub MYSQL_database                                      { return $_[0]->{_MYSQL_database}; }
 sub POSTGRESQL_host                                     { return $_[0]->{_POSTGRESQL_host}; }
+sub POSTGRESQL_port                                     { return $_[0]->{_POSTGRESQL_port}; }
 sub POSTGRESQL_user                                     { return $_[0]->{_POSTGRESQL_user}; }
 sub POSTGRESQL_password                                 { return $_[0]->{_POSTGRESQL_password}; }
 sub POSTGRESQL_database                                 { return $_[0]->{_POSTGRESQL_database}; }
@@ -521,6 +534,7 @@ UNITCHECK {
     _create_setter( '_set_MYSQL_password',                                      '_MYSQL_password',                                      \&untaint_password );
     _create_setter( '_set_MYSQL_database',                                      '_MYSQL_database',                                      \&untaint_mariadb_database );
     _create_setter( '_set_POSTGRESQL_host',                                     '_POSTGRESQL_host',                                     \&untaint_host );
+    _create_setter( '_set_POSTGRESQL_port',                                     '_POSTGRESQL_port',                                     \&untaint_strictly_positive_int );
     _create_setter( '_set_POSTGRESQL_user',                                     '_POSTGRESQL_user',                                     \&untaint_postgresql_ident );
     _create_setter( '_set_POSTGRESQL_password',                                 '_POSTGRESQL_password',                                 \&untaint_password );
     _create_setter( '_set_POSTGRESQL_database',                                 '_POSTGRESQL_database',                                 \&untaint_postgresql_ident );

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -377,7 +377,7 @@ Get the value of L<MYSQL.database|https://github.com/zonemaster/zonemaster-backe
 Returns a string.
 
 
-=head2 MySQL_host
+=head2 MYSQL_host
 
 Get the value of L<MYSQL.host|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#host>.
 

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -38,8 +38,8 @@ sub dbh {
     else {
         my $database = $self->config->MYSQL_database;
         my $host     = $self->config->MYSQL_host;
-        my $user     = $self->config->MYSQL_user();
-        my $password = $self->config->MYSQL_password();
+        my $user     = $self->config->MYSQL_user;
+        my $password = $self->config->MYSQL_password;
 
         $log->notice( "Connecting to MySQL: database=$database host=$host user=$user" ) if $log->is_notice;
 

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -38,8 +38,11 @@ sub dbh {
     else {
         my $database = $self->config->MYSQL_database;
         my $host     = $self->config->MYSQL_host;
+        my $port     = $self->config->MYSQL_port;
         my $user     = $self->config->MYSQL_user;
         my $password = $self->config->MYSQL_password;
+
+        my $data_source_name = "DBI:mysql:database=$database;host=$host;port=$port";
 
         $log->notice( "Connecting to MySQL: database=$database host=$host user=$user" ) if $log->is_notice;
 
@@ -48,7 +51,7 @@ sub dbh {
         }
 
         $dbh = DBI->connect(
-            "DBI:mysql:database=$database;host=$host",
+            $data_source_name,
             $user,
             $password,
             {

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -37,12 +37,15 @@ sub dbh {
     else {
         my $database = $self->config->POSTGRESQL_database;
         my $host     = $self->config->POSTGRESQL_host;
+        my $port     = $self->config->POSTGRESQL_port;
         my $user     = $self->config->POSTGRESQL_user;
         my $password = $self->config->POSTGRESQL_password;
 
+        my $data_source_name = "DBI:Pg:database=$database;host=$host;port=$port";
+
         $log->notice( "Connecting to PostgreSQL: database=$database host=$host user=$user" ) if $log->is_notice;
         $dbh = DBI->connect(
-            "DBI:Pg:database=$database;host=$host",
+            $data_source_name,
             $user,
             $password,
             {

--- a/t/config.t
+++ b/t/config.t
@@ -80,12 +80,14 @@ subtest 'Everything but NoWarnings' => sub {
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
         cmp_ok abs( $config->DB_polling_interval - 0.5 ), '<', 0.000001, 'default: DB.polling_interval';
-        is $config->ZONEMASTER_max_zonemaster_execution_time,            600, 'default: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->ZONEMASTER_maximal_number_of_retries,                0,   'default: ZONEMASTER.maximal_number_of_retries';
-        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
-        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    20,  'default: ZONEMASTER.number_of_processes_for_batch_testing';
-        is $config->ZONEMASTER_lock_on_queue,                            0,   'default: ZONEMASTER.lock_on_queue';
-        is $config->ZONEMASTER_age_reuse_previous_test,                  600, 'default: ZONEMASTER.age_reuse_previous_test';
+        is $config->ZONEMASTER_max_zonemaster_execution_time,            600,  'default: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->ZONEMASTER_maximal_number_of_retries,                0,    'default: ZONEMASTER.maximal_number_of_retries';
+        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 20,   'default: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    20,   'default: ZONEMASTER.number_of_processes_for_batch_testing';
+        is $config->ZONEMASTER_lock_on_queue,                            0,    'default: ZONEMASTER.lock_on_queue';
+        is $config->ZONEMASTER_age_reuse_previous_test,                  600,  'default: ZONEMASTER.age_reuse_previous_test';
+        is $config->MYSQL_port,                                          3306, 'default: MYSQL.port';
+        is $config->POSTGRESQL_port,                                     5432, 'default: POSTGRESQL.port';
     };
 
     lives_and {

--- a/t/config.t
+++ b/t/config.t
@@ -164,6 +164,24 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->ZONEMASTER_number_of_processes_for_batch_testing,    '22', 'fallback: ZONEMASTER.number_of_processes_for_batch_testing';
     };
 
+    lives_and {
+        my $text = q{
+            [DB]
+            engine = MySQL
+
+            [MYSQL]
+            host     = localhost
+            port     = 3333
+            user     = mysql_user
+            password = mysql_password
+            database = mysql_database
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        $log->contains_ok( qr/MYSQL\.port.*MYSQL\.host/, 'warning: MYSQL.host is "localhost" and MYSQL.port defined' );
+        is $config->MYSQL_host, 'localhost', 'set: MYSQL.host';
+        is $config->MYSQL_port, 3333,        'set: MYSQL.port';
+    };
+
     throws_ok {
         my $text = '{"this":"is","not":"a","valid":"ini","file":"!"}';
         Zonemaster::Backend::Config->parse( $text );

--- a/t/config.t
+++ b/t/config.t
@@ -24,12 +24,14 @@ subtest 'Everything but NoWarnings' => sub {
 
             [MYSQL]
             host     = mysql-host
+            port     = 3456
             user     = mysql_user
             password = mysql_password
             database = mysql_database
 
             [POSTGRESQL]
             host     = postgresql-host
+            port     = 6543
             user     = postgresql_user
             password = postgresql_password
             database = postgresql_database
@@ -50,10 +52,12 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->DB_engine,                                           'SQLite',                    'set: DB.engine';
         is $config->DB_polling_interval,                                 1.5,                         'set: DB.polling_interval';
         is $config->MYSQL_host,                                          'mysql-host',                'set: MYSQL.host';
+        is $config->MYSQL_port,                                          3456,                        'set: MYSQL.port';
         is $config->MYSQL_user,                                          'mysql_user',                'set: MYSQL.user';
         is $config->MYSQL_password,                                      'mysql_password',            'set: MYSQL.password';
         is $config->MYSQL_database,                                      'mysql_database',            'set: MYSQL.database';
         is $config->POSTGRESQL_host,                                     'postgresql-host',           'set: POSTGRESQL.host';
+        is $config->POSTGRESQL_port,                                     6543,                        'set: POSTGRESQL.port';
         is $config->POSTGRESQL_user,                                     'postgresql_user',           'set: POSTGRESQL.user';
         is $config->POSTGRESQL_password,                                 'postgresql_password',       'set: POSTGRESQL.password';
         is $config->POSTGRESQL_database,                                 'postgresql_database',       'set: POSTGRESQL.database';


### PR DESCRIPTION
## Context

Adds a new configuration key to specify the database port for MySQL and PostgreSQL as suggested in #496.
~This PR needs #753 to be merged first, and then rebased on top of develop.~

## Changes

This adds 2 new configuration entries, one in the MYSQL section and the other in the POSTGRESQL section. Each entry makes it possible to specify the port number on which the database server is listening. If the `host` key is not present, then the behavior is the same as before, each DBI uses its default port value.

With MySQL, if you want to talk with the database server on the local machine with another port number, you need to define the loopback IP address in the MYSQL.host (otherwise using `localhost` will result in using a UNIX socket as explained in the [DBD::mysql documentation](https://metacpan.org/pod/DBD::mysql#connect))


## How to test this PR

1. modify the configuration of your database to listen on a specific port, and restart your database server
2. if you are testing against MySQL with a local database server, update the `MYSQL.host` value to `127.0.0.1`
3. if you are testing with a remote database server, make sure you have allowed remote access to the database
4. add or update the `MYSQL.port` or `POSTGRESQL.port` config key/value accordingly to your setup
5. run a test with `zmb`