### PR TITLE
Stop rounding test shelflife to whole minutes

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -305,9 +305,6 @@ If a new test is requested for the same zone name and parameters within the
 shelf life of a previous test result, that test result is reused.
 Otherwise a new test request is enqueued.
 
-Internally the value is converted to whole minutes.
-If the conversion results in zero minutes, then the default value is used.
-
 
 
 [DB.database_host]:                   #database_host

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -114,7 +114,7 @@ sub create_new_batch_job {
 }
 
 sub create_new_test {
-    my ( $self, $domain, $test_params, $minutes_between_tests_with_same_params, $batch_id ) = @_;
+    my ( $self, $domain, $test_params, $seconds_between_tests_with_same_params, $batch_id ) = @_;
 
     my $dbh = $self->dbh;
 
@@ -133,7 +133,7 @@ sub create_new_test {
             q[
             SELECT hash_id FROM test_results WHERE params_deterministic_hash = ? AND (TO_SECONDS(NOW()) - TO_SECONDS(creation_time)) < ?
             ],
-            undef, $test_params_deterministic_hash, 60 * $minutes_between_tests_with_same_params,
+            undef, $test_params_deterministic_hash, $seconds_between_tests_with_same_params,
         );
 
         if ( $recent_hash_id ) {

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -130,7 +130,7 @@ sub create_new_batch_job {
 }
 
 sub create_new_test {
-    my ( $self, $domain, $test_params, $minutes_between_tests_with_same_params, $batch_id ) = @_;
+    my ( $self, $domain, $test_params, $seconds_between_tests_with_same_params, $batch_id ) = @_;
     my $dbh = $self->dbh;
 
     $test_params->{domain} = $domain;
@@ -157,7 +157,7 @@ sub create_new_test {
         $test_params_deterministic_hash,
         $encoded_params,
         $test_params_deterministic_hash,
-        sprintf( "%d minutes", $minutes_between_tests_with_same_params ),
+        sprintf( "%d seconds", $seconds_between_tests_with_same_params ),
     );
 
     my ( undef, $hash_id ) = $dbh->selectrow_array(

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -172,7 +172,7 @@ sub create_new_batch_job {
 }
 
 sub create_new_test {
-    my ( $self, $domain, $test_params, $minutes, $batch_id ) = @_;
+    my ( $self, $domain, $test_params, $seconds, $batch_id ) = @_;
 
     my $dbh = $self->dbh;
 
@@ -185,13 +185,13 @@ sub create_new_test {
     my $priority = $test_params->{priority};
     my $queue = $test_params->{queue};
 
-    # Search for recent test result with the test same parameters, where "$minutes"
+    # Search for recent test result with the test same parameters, where "$seconds"
     # gives the time limit for how old test result that is accepted.
     my ( $recent_hash_id ) = $dbh->selectrow_array(
         "SELECT hash_id FROM test_results WHERE params_deterministic_hash = ? AND test_start_time > DATETIME('now', ?)",
         undef,
         $test_params_deterministic_hash,
-        "-$minutes minutes"
+        "-$seconds seconds"
     );
 
     if ( $recent_hash_id ) {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -385,10 +385,8 @@ sub start_domain_test {
 
         $params->{priority}  //= 10;
         $params->{queue}     //= 0;
-        my $shelf_life_seconds = $self->{config}->ZONEMASTER_age_reuse_previous_test;
-        my $shelf_life_minutes = int ( ($shelf_life_seconds / 60) + 0.5);
 
-        $result = $self->{db}->create_new_test( $params->{domain}, $params, $shelf_life_minutes );
+        $result = $self->{db}->create_new_test( $params->{domain}, $params, $self->{config}->ZONEMASTER_age_reuse_previous_test );
     };
     if ($@) {
         handle_exception('start_domain_test', $@, '009');


### PR DESCRIPTION
## Context

This PR is a follow-up to https://github.com/zonemaster/zonemaster-backend/pull/692#discussion_r551941117.

## Changes

The ZONEMASTER.age_reuse_previous_test property is specified in seconds, but it was rounded to whole minutes.

This PR removes rounding logic and relieves us from having to describe this normalization in the configuration documentation.

## How to test this PR

1. Set `ZONEMASTER.age_reuse_previous_test` to 30 in your backend config file.
2. (Re)start your RPCAPI daemon to make sure the configuration is in effect.
3. Run:
   ```sh
   zmtest null.example >/dev/null
   sleep 15
   zmtest null.example >/dev/null
   sleep 30
   zmtest null.example >/dev/null
   ```
4. Before the fix: All three runs result int the same testid.
   After the fix: The first two runs result in the same testid, but the third one results in a different one.