### PR TITLE
Fix broken installation

### DIFF
--- a/t/config.t
+++ b/t/config.t
@@ -6,6 +6,10 @@ use Test::More tests => 2;
 use Test::NoWarnings;
 use Test::Exception;
 use Log::Any::Test;    # Must come before use Log::Any
+
+use File::Basename qw( dirname );
+use File::Slurp qw( read_file );
+use File::Spec::Functions qw( catfile );
 use Log::Any qw( $log );
 
 subtest 'Everything but NoWarnings' => sub {
@@ -338,4 +342,13 @@ subtest 'Everything but NoWarnings' => sub {
         Zonemaster::Backend::Config->parse( $text );
     }
     qr/LANGUAGE\.locale.*en_US/, 'die: Repeated locale_tag in LANGUAGE.locale';
+
+    {
+        my $path = catfile( dirname( $0 ), '..', 'share', 'backend_config.ini' );
+        my $text = read_file( $path );
+        lives_ok {
+            Zonemaster::Backend::Config->parse( $text );
+        } 'default config is valid';
+    }
+
 };


### PR DESCRIPTION
## Purpose

This PR fixes a problem when installing the dist tarball where test01.t would require that /var/lib/zonemaster/ exists.

## Context

Fixes #762.

## Changes

Basically this PR does two things.
1. It makes test01.t independent of the default config file, and
2. It adds a test to config.t to make sure the default config file is valid.

Instead of creating its SQLite database file under /var/lib/zonemaster it creates a temporary directory for the database file. (The temporary directory is automatically cleaned up.)

## How to test this PR

Make sure test suite passes when executed by cpanm:
```sh
make dist
sudo rm -rf /var/lib/zonemaster
cpanm --test-only Zonemaster-Backend-*.tar.gz
```