### PR TITLE
Tell OS about failed daemon startup (Linux)

### DIFF
--- a/share/zm-rpcapi.lsb
+++ b/share/zm-rpcapi.lsb
@@ -27,7 +27,7 @@ STARMAN=`PATH="$PATH:/usr/local/bin" /usr/bin/which starman`
 . /lib/lsb/init-functions
 
 start () {
-    $STARMAN --user=$USER --group=$GROUP --error-log=$LOGFILE --pid=$PIDFILE --listen=$LISTENIP:$LISTENPORT --preload-app --daemonize $BINDIR/zonemaster_backend_rpcapi.psgi
+    $STARMAN --user=$USER --group=$GROUP --error-log=$LOGFILE --pid=$PIDFILE --listen=$LISTENIP:$LISTENPORT --preload-app --daemonize $BINDIR/zonemaster_backend_rpcapi.psgi || exit 1
 }
 
 stop () {

--- a/share/zm-testagent.lsb
+++ b/share/zm-testagent.lsb
@@ -28,7 +28,7 @@ if [ -n "$ZM_BACKEND_TESTAGENT_LOGLEVEL" ] ; then
 fi
 
 start () {
-    $BINDIR/zonemaster_backend_testagent $testagent_args start
+    $BINDIR/zonemaster_backend_testagent $testagent_args start || exit 1
 }
 
 stop () {


### PR DESCRIPTION
## Purpose

This PR makes systemd aware of failures during daemon startup. In particular it makes `systemctl {start,status} {zm-rpcapi,zm-testagent}` actually report failures.

## Context

Without this the config validation feature is pretty lame.

## Changes

The LSB service scripts are updated to exit with an error status if any of their commands fail.

I have NOT tested how FreeBSD behaves in this respect. I suggest that is handled separately from this PR.

## How to test this PR

Make sure the daemons are stopped and that the config is invalid:
```
sudo systemctl stop zm-rpcapi
sudo systemctl stop zm-testagent
sudo sed -i '/\bengine\b/ s/=.*/= Excel/' /etc/zonemaster/backend_config.ini
```

Verify that you get an error message when you starting `zm-rpcapi` and that systemctl knows that it failed:
```
sudo systemctl start zm-rpcapi
sudo systemctl status zm-rpcapi
```

Verify that you get an error message when you starting `zm-testagent` and that systemctl knows that it failed:
```
sudo systemctl start zm-testagent
sudo systemctl status zm-testagent
```