### PR TITLE
Implement zmb get_test_params

### DIFF
--- a/script/zmb
+++ b/script/zmb
@@ -249,7 +249,6 @@ sub cmd_start_domain_test {
 
  Options:
    --test-id TEST_ID
-   --testid TEST_ID   # deprecated, use --test-id instead
 
 =cut
 
@@ -257,21 +256,11 @@ sub cmd_test_progress {
     my @opts = @_;
 
     my $opt_lang;
-    my $opt_testid;
     my $opt_test_id;
     GetOptionsFromArray(
         \@opts,
         'test-id|t=s' => \$opt_test_id,
-        'testid|t=s'  => \$opt_testid,
     ) or pod2usage( 2 );
-
-    if ( defined $opt_testid ) {
-        warn( "The --testid parameter deprecated. Use --test-id instead.\n" );
-    }
-    if ( defined $opt_testid && defined $opt_test_id ) {
-        pod2usage( "The --testid parameter is forbidden when --test-id is present." );
-    }
-    $opt_test_id //= $opt_testid;
 
     return to_jsonrpc(
         id     => 1,
@@ -317,7 +306,6 @@ sub cmd_get_test_params {
 
  Options:
    --test-id TEST_ID
-   --testid TEST_ID   # deprecated, use --test-id instead
    --lang LANGUAGE
 
 =cut
@@ -326,22 +314,12 @@ sub cmd_get_test_results {
     my @opts = @_;
 
     my $opt_lang;
-    my $opt_testid;
     my $opt_test_id;
     GetOptionsFromArray(
         \@opts,
-        'testid|t=s'  => \$opt_testid,
         'test-id|t=s' => \$opt_test_id,
         'lang|l=s'    => \$opt_lang,
     ) or pod2usage( 2 );
-
-    if ( defined $opt_testid ) {
-        warn( "The --testid parameter deprecated. Use --test-id instead.\n" );
-    }
-    if ( defined $opt_testid && defined $opt_test_id ) {
-        pod2usage( "The --testid parameter is forbidden when --test-id is present." );
-    }
-    $opt_test_id //= $opt_testid;
 
     return to_jsonrpc(
         id     => 1,

--- a/script/zmb
+++ b/script/zmb
@@ -270,6 +270,34 @@ sub cmd_test_progress {
 }
 
 
+=head2 get_test_params
+
+ zmb [GLOBAL OPTIONS] get_test_params [OPTIONS]
+
+ Options:
+   --test-id TEST_ID
+
+=cut
+
+sub cmd_get_test_params {
+    my @opts = @_;
+
+    my $opt_test_id;
+    GetOptionsFromArray(    #
+        \@opts,
+        'test-id|t=s' => \$opt_test_id,
+    ) or pod2usage( 2 );
+
+    return to_jsonrpc(
+        id     => 1,
+        method => 'get_test_params',
+        params => {
+            test_id => $opt_test_id,
+        },
+    );
+}
+
+
 =head2 get_test_results
 
  zmb [GLOBAL OPTIONS] get_test_results [OPTIONS]

--- a/script/zmb
+++ b/script/zmb
@@ -248,7 +248,8 @@ sub cmd_start_domain_test {
  zmb [GLOBAL OPTIONS] test_progress [OPTIONS]
 
  Options:
-   --testid TEST_ID
+   --test-id TEST_ID
+   --testid TEST_ID   # deprecated, use --test-id instead
 
 =cut
 
@@ -257,14 +258,26 @@ sub cmd_test_progress {
 
     my $opt_lang;
     my $opt_testid;
-    GetOptionsFromArray( \@opts, 'testid|t=s' => \$opt_testid, )
-      or pod2usage( 2 );
+    my $opt_test_id;
+    GetOptionsFromArray(
+        \@opts,
+        'test-id|t=s' => \$opt_test_id,
+        'testid|t=s'  => \$opt_testid,
+    ) or pod2usage( 2 );
+
+    if ( defined $opt_testid ) {
+        warn( "The --testid parameter deprecated. Use --test-id instead.\n" );
+    }
+    if ( defined $opt_testid && defined $opt_test_id ) {
+        pod2usage( "The --testid parameter is forbidden when --test-id is present." );
+    }
+    $opt_test_id //= $opt_testid;
 
     return to_jsonrpc(
         id     => 1,
         method => 'test_progress',
         params => {
-            test_id => $opt_testid,
+            test_id => $opt_test_id,
         },
     );
 }
@@ -303,7 +316,8 @@ sub cmd_get_test_params {
  zmb [GLOBAL OPTIONS] get_test_results [OPTIONS]
 
  Options:
-   --testid TEST_ID
+   --test-id TEST_ID
+   --testid TEST_ID   # deprecated, use --test-id instead
    --lang LANGUAGE
 
 =cut
@@ -313,17 +327,27 @@ sub cmd_get_test_results {
 
     my $opt_lang;
     my $opt_testid;
+    my $opt_test_id;
     GetOptionsFromArray(
         \@opts,
-        'testid|t=s' => \$opt_testid,
-        'lang|l=s'   => \$opt_lang,
+        'testid|t=s'  => \$opt_testid,
+        'test-id|t=s' => \$opt_test_id,
+        'lang|l=s'    => \$opt_lang,
     ) or pod2usage( 2 );
+
+    if ( defined $opt_testid ) {
+        warn( "The --testid parameter deprecated. Use --test-id instead.\n" );
+    }
+    if ( defined $opt_testid && defined $opt_test_id ) {
+        pod2usage( "The --testid parameter is forbidden when --test-id is present." );
+    }
+    $opt_test_id //= $opt_testid;
 
     return to_jsonrpc(
         id     => 1,
         method => 'get_test_results',
         params => {
-            id       => $opt_testid,
+            id       => $opt_test_id,
             language => $opt_lang,
         },
     );

--- a/script/zmtest
+++ b/script/zmtest
@@ -72,7 +72,7 @@ fi
 # Wait for test to finish
 while true
 do
-    output="$(zmb "${server_url}" test_progress --testid "${testid}")" || exit $?
+    output="$(zmb "${server_url}" test_progress --test-id "${testid}")" || exit $?
     progress="$(printf "%s" "${output}" | "${JQ}" -r .result)" || exit $?
     printf "\r${progress}%% done" >&2
     if [ "${progress}" -eq 100 ] ; then
@@ -83,4 +83,4 @@ do
 done
 
 # Get test results
-zmb "${server_url}" get_test_results --testid "${testid}" --lang "${lang}"
+zmb "${server_url}" get_test_results --test-id "${testid}" --lang "${lang}"


### PR DESCRIPTION
## Purpose

Add another RPC API method to zmb.

## Context

N/A

## Changes

Add `zmb get_test_params`.

Rename the `--testid` parameter to `--test-id` for the `test_progress` and `get_test_results` commands. The old parameter name still works but emits a deprecation warning.

## How to test this PR

Start a test and verify that the output from `get_test_params` looks reasonable:
```sh
testid="$(zmb start_domain_test --domain example | jq -r .result)"
zmb get_test_params --test-id "$testid" | jq .
```

Verify that zmtest still works:
```sh
zmtest example.com
```