### PR TITLE
Control the flow of time from unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ inc
 # Ignore Emacs and other backup files
 *.bak
 *~
+.*.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,4 +118,4 @@ before_script:
     - if [[ "$TARGET" == "MySQL" ]]; then cpanm DBD::mysql; fi
 
 script:
-    - perl Makefile.PL && make test
+    - perl Makefile.PL && make test TEST_VERBOSE=1

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -18,6 +18,7 @@ use Zonemaster::Backend::Errors;
 requires qw(
   add_batch_job
   create_schema
+  drop_tables
   from_config
   get_test_history
   process_unfinished_tests_give_up
@@ -83,22 +84,6 @@ sub dbh {
     }
 
     return $self->dbhandle;
-}
-
-=head2 drop_tables
-
-Drop all the tables if they exist.
-
-=cut
-
-sub drop_tables {
-    my ( $self ) = @_;
-
-    $self->dbh->do( "DROP TABLE IF EXISTS test_results" );
-    $self->dbh->do( "DROP TABLE IF EXISTS users" );
-    $self->dbh->do( "DROP TABLE IF EXISTS batch_jobs" );
-
-    return;
 }
 
 sub user_exists {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -85,6 +85,22 @@ sub dbh {
     return $self->dbhandle;
 }
 
+=head2 drop_tables
+
+Drop all the tables if they exist.
+
+=cut
+
+sub drop_tables {
+    my ( $self ) = @_;
+
+    $self->dbh->do( "DROP TABLE IF EXISTS test_results" );
+    $self->dbh->do( "DROP TABLE IF EXISTS users" );
+    $self->dbh->do( "DROP TABLE IF EXISTS batch_jobs" );
+
+    return;
+}
+
 sub user_exists {
     my ( $self, $user ) = @_;
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -17,7 +17,7 @@ use Zonemaster::Backend::Errors;
 
 requires qw(
   add_batch_job
-  create_db
+  create_schema
   from_config
   get_test_history
   process_unfinished_tests_give_up

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -166,7 +166,8 @@ sub recent_test_hash_id {
             SELECT hash_id
             FROM test_results
             WHERE fingerprint = ?
-              AND test_start_time > ?
+              AND ( test_start_time IS NULL
+                 OR test_start_time >= ? )
         ],
         undef,
         $fingerprint,

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -475,7 +475,6 @@ sub undelegated {
     return 0;
 }
 
-
 no Moose::Role;
 
 1;

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -56,7 +56,7 @@ sub from_config {
 }
 
 
-sub create_db {
+sub create_schema {
     my ( $self ) = @_;
 
     my $dbh = $self->dbh;
@@ -141,6 +141,8 @@ sub create_db {
         ) ENGINE=InnoDB;
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'users' table", data => $dbh->errstr() );
+
+    return;
 }
 
 sub test_progress {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -148,8 +148,15 @@ sub recent_test_hash_id {
 
     my $dbh = $self->dbh;
     my ( $recent_hash_id ) = $dbh->selectrow_array(
-        "SELECT hash_id FROM test_results WHERE fingerprint = ? AND (TO_SECONDS(NOW()) - TO_SECONDS(creation_time)) < ?",
-        undef, $fingerprint, $age_reuse_previous_test
+        q[
+            SELECT hash_id
+            FROM test_results
+            WHERE fingerprint = ?
+              AND (TO_SECONDS(NOW()) - TO_SECONDS(creation_time)) < ?
+        ],
+        undef,
+        $fingerprint,
+        $age_reuse_previous_test,
     );
 
     return $recent_hash_id;
@@ -160,11 +167,32 @@ sub test_progress {
 
     my $dbh = $self->dbh;
     if ( $progress ) {
-        if ($progress == 1) {
-            $dbh->do( "UPDATE test_results SET progress=?, test_start_time=NOW() WHERE hash_id=? AND progress <> 100", undef, $progress, $test_id );
+        if ( $progress == 1 ) {
+            $dbh->do(
+                q[
+                    UPDATE test_results
+                    SET progress = ?,
+                        test_start_time = NOW()
+                    WHERE hash_id = ?
+                      AND progress <> 100
+                ],
+                undef,
+                $progress,
+                $test_id,
+            );
         }
         else {
-            $dbh->do( "UPDATE test_results SET progress=? WHERE hash_id=? AND progress <> 100", undef, $progress, $test_id );
+            $dbh->do(
+                q[
+                    UPDATE test_results
+                    SET progress = ?
+                    WHERE hash_id = ?
+                      AND progress <> 100
+                ],
+                undef,
+                $progress,
+                $test_id,
+            );
         }
     }
 
@@ -177,8 +205,19 @@ sub test_results {
     my ( $self, $test_id, $new_results ) = @_;
 
     if ( $new_results ) {
-        $self->dbh->do( qq[UPDATE test_results SET progress=100, test_end_time=NOW(), results = ? WHERE hash_id=? AND progress < 100],
-            undef, $new_results, $test_id );
+        $self->dbh->do(
+            q[
+                UPDATE test_results
+                SET progress = 100,
+                    test_end_time = NOW(),
+                    results = ?
+                WHERE hash_id = ?
+                  AND progress < 100
+            ],
+            undef,
+            $new_results,
+            $test_id,
+        );
     }
 
     my $result;
@@ -286,7 +325,20 @@ sub add_batch_job {
         eval {$dbh->do( "DROP INDEX test_results__progress ON test_results" );};
         eval {$dbh->do( "DROP INDEX test_results__domain_undelegated ON test_results" );};
 
-        my $sth = $dbh->prepare( 'INSERT INTO test_results (hash_id, domain, batch_id, priority, queue, fingerprint, params, undelegated) VALUES (?,?,?,?,?,?,?,?)' );
+        my $sth = $dbh->prepare(
+            q[
+                INSERT INTO test_results (
+                    hash_id,
+                    domain,
+                    batch_id,
+                    priority,
+                    queue,
+                    fingerprint,
+                    params,
+                    undelegated
+                ) VALUES (?,?,?,?,?,?,?,?)
+            ]
+        );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
 
@@ -295,7 +347,16 @@ sub add_batch_job {
             my $undelegated = $self->undelegated ( $test_params );
 
             my $hash_id = substr(md5_hex(time().rand()), 0, 16);
-            $sth->execute( $hash_id, $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params, $undelegated );
+            $sth->execute(
+                $hash_id,
+                $test_params->{domain},
+                $batch_id,
+                $priority,
+                $queue_label,
+                $fingerprint,
+                $encoded_params,
+                $undelegated,
+            );
         }
         $dbh->do( "CREATE INDEX test_results__hash_id ON test_results (hash_id, creation_time)" );
         $dbh->do( "CREATE INDEX test_results__fingerprint ON test_results (fingerprint)" );
@@ -347,13 +408,32 @@ sub select_unfinished_tests {
 sub process_unfinished_tests_give_up {
     my ( $self, $result, $hash_id ) = @_;
 
-    $self->dbh->do("UPDATE test_results SET progress = 100, test_end_time = NOW(), results = ? WHERE hash_id=?", undef, encode_json($result), $hash_id);
+    $self->dbh->do(
+        q[
+            UPDATE test_results
+            SET progress = 100,
+                test_end_time = NOW(),
+                results = ?
+            WHERE hash_id = ?
+        ],
+        undef,
+        encode_json( $result ),
+        $hash_id,
+    );
 }
 
 sub get_relative_start_time {
     my ( $self, $hash_id ) = @_;
 
-    return $self->dbh->selectrow_array("SELECT now() - test_start_time FROM test_results WHERE hash_id=?", undef, $hash_id);
+    return $self->dbh->selectrow_array(
+        q[
+            SELECT now() - test_start_time
+            FROM test_results
+            WHERE hash_id = ?
+        ],
+        undef,
+        $hash_id,
+    );
 }
 
 

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -145,6 +145,22 @@ sub create_schema {
     return;
 }
 
+=head2 drop_tables
+
+Drop all the tables if they exist.
+
+=cut
+
+sub drop_tables {
+    my ( $self ) = @_;
+
+    $self->dbh->do( "DROP TABLE IF EXISTS test_results" );
+    $self->dbh->do( "DROP TABLE IF EXISTS users" );
+    $self->dbh->do( "DROP TABLE IF EXISTS batch_jobs" );
+
+    return;
+}
+
 sub test_progress {
     my ( $self, $test_id, $progress ) = @_;
 

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -52,7 +52,7 @@ sub from_config {
     );
 }
 
-sub create_db {
+sub create_schema {
     my ( $self ) = @_;
 
     my $dbh = $self->dbh;
@@ -127,6 +127,7 @@ sub create_db {
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'users' table", data => $dbh->errstr() );
 
+    return;
 }
 
 sub test_progress {

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -129,25 +129,6 @@ sub create_db {
 
 }
 
-sub recent_test_hash_id {
-    my ( $self, $fingerprint, $threshold ) = @_;
-
-    my $dbh = $self->dbh;
-    my ( $recent_hash_id ) = $dbh->selectrow_array(
-        q[
-            SELECT hash_id
-            FROM test_results
-            WHERE fingerprint = ?
-              AND test_start_time > ?
-        ],
-        undef,
-        $fingerprint,
-        $self->format_time( $threshold ),
-    );
-
-    return $recent_hash_id;
-}
-
 sub test_progress {
     my ( $self, $test_id, $progress ) = @_;
 
@@ -346,37 +327,6 @@ sub add_batch_job {
     }
 
     return $batch_id;
-}
-
-sub select_unfinished_tests {
-    my ( $self, $queue_label, $test_run_timeout ) = @_;
-
-    if ( $queue_label ) {
-        my $sth = $self->dbh->prepare( "
-            SELECT hash_id, results
-            FROM test_results
-            WHERE test_start_time < ?
-            AND progress > 0
-            AND progress < 100
-            AND queue = ?" );
-        $sth->execute(    #
-            $self->format_time( time() - $test_run_timeout ),
-            $queue_label,
-        );
-        return $sth;
-    }
-    else {
-        my $sth = $self->dbh->prepare( "
-            SELECT hash_id, results
-            FROM test_results
-            WHERE test_start_time < ?
-            AND progress > 0
-            AND progress < 100" );
-        $sth->execute(    #
-            $self->format_time( time() - $test_run_timeout ),
-        );
-        return $sth;
-    }
 }
 
 sub process_unfinished_tests_give_up {

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -120,6 +120,22 @@ sub create_schema {
     return;
 }
 
+=head2 drop_tables
+
+Drop all the tables if they exist.
+
+=cut
+
+sub drop_tables {
+    my ( $self ) = @_;
+
+    $self->dbh->do( "DROP TABLE IF EXISTS test_results" );
+    $self->dbh->do( "DROP TABLE IF EXISTS users" );
+    $self->dbh->do( "DROP TABLE IF EXISTS batch_jobs" );
+
+    return;
+}
+
 sub test_progress {
     my ( $self, $test_id, $progress ) = @_;
 

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -120,27 +120,6 @@ sub create_db {
     return 1;
 }
 
-# Search for recent test result with the test same parameters, where
-# "threshold" gives the oldest start time.
-sub recent_test_hash_id {
-    my ( $self, $fingerprint, $threshold ) = @_;
-
-    my $dbh = $self->dbh;
-    my ( $recent_hash_id ) = $dbh->selectrow_array(
-        q[
-            SELECT hash_id
-            FROM test_results
-            WHERE fingerprint = ?
-              AND test_start_time > ?
-        ],
-        undef,
-        $fingerprint,
-        $self->format_time( $threshold ),
-    );
-
-    return $recent_hash_id;
-}
-
 sub test_progress {
     my ( $self, $test_id, $progress ) = @_;
 
@@ -353,37 +332,6 @@ sub add_batch_job {
     }
 
     return $batch_id;
-}
-
-sub select_unfinished_tests {
-    my ( $self, $queue_label, $test_run_timeout ) = @_;
-
-    if ( $queue_label ) {
-        my $sth = $self->dbh->prepare( "
-            SELECT hash_id, results
-            FROM test_results
-            WHERE test_start_time < ?
-            AND progress > 0
-            AND progress < 100
-            AND queue = ?" );
-        $sth->execute(    #
-            $self->format_time( time() - $test_run_timeout ),
-            $queue_label,
-        );
-        return $sth;
-    }
-    else {
-        my $sth = $self->dbh->prepare( "
-            SELECT hash_id, results
-            FROM test_results
-            WHERE test_start_time < ?
-            AND progress > 0
-            AND progress < 100" );
-        $sth->execute(    #
-            $self->format_time( time() - $test_run_timeout ),
-        );
-        return $sth;
-    }
 }
 
 sub process_unfinished_tests_give_up {

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -47,7 +47,7 @@ sub DEMOLISH {
     $self->dbh->disconnect() if defined $self->dbhandle && $self->dbhandle->ping;
 }
 
-sub create_db {
+sub create_schema {
     my ( $self ) = @_;
 
     my $dbh = $self->dbh;
@@ -117,7 +117,7 @@ sub create_db {
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'users' table", data => $dbh->errstr() );
 
-    return 1;
+    return;
 }
 
 sub test_progress {

--- a/share/create_db.pl
+++ b/share/create_db.pl
@@ -12,4 +12,4 @@ my $db_engine = $config->DB_engine;
 my $db_class = Zonemaster::Backend::DB->get_db_class( $db_engine );
 
 my $db = $db_class->from_config( $config );
-$db->create_db();
+$db->create_schema();

--- a/share/patch/patch_sqlite_db_zonemaster_backend_ver_8.0.0.pl
+++ b/share/patch/patch_sqlite_db_zonemaster_backend_ver_8.0.0.pl
@@ -28,7 +28,7 @@ sub patch_db {
         $dbh->do('ALTER TABLE test_results RENAME TO test_results_old');
 
         # create the table
-        $db->create_db();
+        $db->create_schema();
 
         # populate it
         # - nb_retries is omitted as we remove this column
@@ -55,7 +55,7 @@ sub patch_db {
         $dbh->do('DROP TABLE test_results_old');
 
         # recreate indexes
-        $db->create_db();
+        $db->create_schema();
     };
     print( "Error while updating the 'test_results' table schema:  " . $@ ) if ($@);
 
@@ -82,7 +82,7 @@ sub patch_db {
         $dbh->do('ALTER TABLE users RENAME TO users_old');
 
         # create the table
-        $db->create_db();
+        $db->create_schema();
 
         # populate it
         $dbh->do('INSERT INTO users SELECT id, username, api_key FROM users_old');

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -27,7 +27,7 @@ sub advance_time {
 }
 
 my $db_backend = Zonemaster::Backend::Config->check_db( $ENV{TARGET} || 'SQLite' );
-diag "database: $db_backend";
+note "database: $db_backend";
 
 my $tempdir = tempdir( CLEANUP => 1 );
 my $config = Zonemaster::Backend::Config->parse( <<EOF );

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -57,10 +57,8 @@ subtest 'Everything but Test::NoWarnings' => sub {
     lives_ok {    # Make sure we get to print log messages in case of errors.
         my $dbclass = Zonemaster::Backend::DB->get_db_class( $db_backend );
         my $db      = $dbclass->from_config( $config );
-
-        if ( $db_backend eq 'SQLite' ) {
-            $db->create_schema();
-        }
+        $db->drop_tables();
+        $db->create_schema();
 
         subtest 'Testid reuse' => sub {
             my $testid1 = $db->create_new_test( "zone1.rpcapi.example", {}, 10 );

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -1,0 +1,119 @@
+use strict;
+use warnings;
+use 5.14.2;
+
+use Test::More tests => 2;
+use Test::Exception;
+use Test::NoWarnings;
+use Log::Any::Test;
+use Log::Any qw( $log );
+
+my $TIME = CORE::time();
+BEGIN {
+    *CORE::GLOBAL::time = sub { $TIME };
+}
+
+use JSON::PP;
+use File::ShareDir qw[dist_file];
+use File::Temp qw[tempdir];
+
+use Zonemaster::Engine;
+use Zonemaster::Backend::Config;
+use Zonemaster::Backend::RPCAPI;
+
+sub advance_time {
+    my ( $delta ) = @_;
+    $TIME += $delta;
+}
+
+my $db_backend = Zonemaster::Backend::Config->check_db( $ENV{TARGET} || 'SQLite' );
+diag "database: $db_backend";
+
+my $tempdir = tempdir( CLEANUP => 1 );
+my $config = Zonemaster::Backend::Config->parse( <<EOF );
+[DB]
+engine = $db_backend
+
+[MYSQL]
+host     = localhost
+user     = travis_zm
+password = travis_zonemaster
+database = travis_zonemaster
+
+[POSTGRESQL]
+host     = localhost
+user     = travis_zonemaster
+password = travis_zonemaster
+database = travis_zonemaster
+
+[SQLITE]
+database_file = $tempdir/zonemaster.sqlite
+
+[ZONEMASTER]
+age_reuse_previous_test = 10
+EOF
+
+subtest 'Everything but Test::NoWarnings' => sub {
+    lives_ok {    # Make sure we get to print log messages in case of errors.
+        my $dbclass = Zonemaster::Backend::DB->get_db_class( $db_backend );
+        my $db      = $dbclass->from_config( $config );
+
+        if ( $db_backend eq 'SQLite' ) {
+            $db->create_db()
+              or BAIL_OUT( "$db_backend database could not be created" );
+        }
+
+        subtest 'Testid reuse' => sub {
+            my $testid1 = $db->create_new_test( "zone1.rpcapi.example", {}, 10 );
+            advance_time( 11 );
+            my $testid2 = $db->create_new_test( "zone1.rpcapi.example", {}, 10 );
+
+            $db->test_progress( $testid1, 1 );    # mark test as started
+            advance_time( 10 );
+
+            my $testid3 = $db->create_new_test( "zone1.rpcapi.example", {}, 10 );
+            advance_time( 1 );
+            my $testid4 = $db->create_new_test( "zone1.rpcapi.example", {}, 10 );
+
+            is ref $testid1, '', 'start_domain_test returns "testid" scalar';
+            is $testid2,   $testid1, 'reuse is determined from start time (as opposed to creation time)';
+            is $testid3,   $testid1, 'old testid is reused before it expires';
+            isnt $testid4, $testid1, 'a new testid is generated after the old one expires';
+        };
+
+        subtest 'Termination of timed out tests' => sub {
+            my $testid2 = $db->create_new_test( "zone2.rpcapi.example", {}, 10 );
+            my $testid3 = $db->create_new_test( "zone3.rpcapi.example", {}, 10 );
+
+            # testid2 started 11 seconds ago, testid3 started 10 seconds ago
+            $db->test_progress( $testid2, 1 );
+            advance_time( 1 );
+            $db->test_progress( $testid3, 1 );
+            advance_time( 10 );
+
+            $db->process_unfinished_tests( undef, 10 );
+
+            is $db->test_progress( $testid3 ), 1,   'leave test alone AT its timeout';
+            is $db->test_progress( $testid2 ), 100, 'terminate test AFTER its timeout';
+        };
+
+        subtest 'Termination of crashed tests' => sub {
+            my $testid4 = $db->create_new_test( "zone4.rpcapi.example", {}, 10 );
+            $db->test_progress( $testid4, 1 );    # mark test as started
+
+            $db->process_dead_test( $testid4 );
+
+            is $db->test_progress( $testid4 ), 100, 'terminates test';
+        };
+    };
+};
+
+for my $msg ( @{ $log->msgs } ) {
+    my $text = sprintf( "%s: %s", $msg->{level}, $msg->{message} );
+    if ( $msg->{level} =~ /trace|debug|info|notice/ ) {
+        note $text;
+    }
+    else {
+        diag $text;
+    }
+}

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -59,8 +59,7 @@ subtest 'Everything but Test::NoWarnings' => sub {
         my $db      = $dbclass->from_config( $config );
 
         if ( $db_backend eq 'SQLite' ) {
-            $db->create_db()
-              or BAIL_OUT( "$db_backend database could not be created" );
+            $db->create_schema();
         }
 
         subtest 'Testid reuse' => sub {

--- a/t/test01.t
+++ b/t/test01.t
@@ -102,9 +102,7 @@ isa_ok( $backend, 'Zonemaster::Backend::RPCAPI' );
 my $dbh = $backend->{db}->dbh;
 
 # prepare the database
-$dbh->do( "DROP TABLE IF EXISTS test_results" );
-$dbh->do( "DROP TABLE IF EXISTS users" );
-$dbh->do( "DROP TABLE IF EXISTS batch_jobs" );
+$backend->{db}->drop_tables();
 $backend->{db}->create_schema();
 
 # Create the agent

--- a/t/test01.t
+++ b/t/test01.t
@@ -3,6 +3,7 @@ use warnings;
 use 5.14.2;
 
 use Cwd;
+use Data::Dumper;
 use File::Temp qw[tempdir];
 use JSON::PP;
 use Test::Exception;
@@ -183,7 +184,12 @@ subtest 'API calls' => sub {
         ok( defined $res->{params}, 'Value "params" properly defined' );
         ok( defined $res->{creation_time}, 'Value "creation_time" properly defined' );
         ok( defined $res->{results}, 'Value "results" properly defined' );
-        cmp_ok( scalar( @{ $res->{results} } ), '>', 1, 'The test has some results' );
+        if ( @{ $res->{results} } > 1 ) {
+            pass 'The test has some results';
+        }
+        else {
+            fail 'The test has some results: ' . Dumper( $res->{results} );
+        }
     };
 
     subtest 'get_test_params' => sub {

--- a/t/test01.t
+++ b/t/test01.t
@@ -105,13 +105,7 @@ my $dbh = $backend->{db}->dbh;
 $dbh->do( "DROP TABLE IF EXISTS test_results" );
 $dbh->do( "DROP TABLE IF EXISTS users" );
 $dbh->do( "DROP TABLE IF EXISTS batch_jobs" );
-eval {
-    ok( $backend->{db}->create_db(), "$db_backend database prepared");
-};
-if ( $@ ) {
-    diag explain( $@ );
-    BAIL_OUT( 'Could not prepare the database' );
-}
+$backend->{db}->create_schema();
 
 # Create the agent
 use_ok( 'Zonemaster::Backend::TestAgent' );


### PR DESCRIPTION
## Purpose

This PR introduces rpcapi.t which is intended to host unit tests for the entire RPC-API. It also adds a feature to control the flow of time from unit tests. Finally it makes use of this feature to add a unit test for the behavior of ZONEMASTER.age_reuse_previous_test.

## Context

Fixes #758 and #761.

## Changes

* The formatting commit is just there to reduce the diffs of the remaining commits.
* All questions to SQL about the current time (and some adjacent time calculations) are removed and replaced questions to Perl. It's much easier to control Perl's perception of time, and we'll be able to leverage this to be able to procedurally control time from unit tests. Fixes #758.
* Thanks to the removal of some database specific syntax we're able to deduplicate some (now identical) code in the database specific classes and move it to the common base class.
* Lastly a fix is included for #761. It takes a slightly lighter approach than what's suggested in the issue by not involving any RPC-JSON but rather hitting the RPCAPI::start_domain_test() method directly. It also deviates from the issue by letting time() stand perfectly still except for when advance_time() is called.

N.B. The database schemas still use references to NOW() in default value definitions for certain fields, but all insert queries are updated to make sure that those default values are never used. Clean up of those default value definitions is deferred to a later PR - it's more complicated because it requires an update to the database schema.

## How to test this PR

### Manual testing
Until #827 is fixed we don't have a good way to automate testing of batch jobs.
I'm opting to not expand this PR to cover #827.
Instead the changes in `DB::add_batch_job` (called from RPCAPI::add_batch_job and add-batch-job.pl) need to be tested manually.

```sh
$ zmb add_api_user --username testuser --api-key secret
$ zmb add_batch_job --username testuser --api-key secret --domain zonemaster.net
$ zmb get_batch_job_result --batch-id 1234
```

### New automatic tests
The changes in these parts are covered by the new rpcapi.t:
* DB::create_new_test
* DB::test_progress
* DB::process_unfinished_tests
* DB::process_dead_test

### Existing automatic tests
The changes in these parts are covered by test01.t:
* DB::test_progress
* DB::test_results