### PR TITLE
Make it easier to copy from installation document on Github

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -624,7 +624,11 @@ To check the running daemons run:
 
 ```sh
 service mysql-server status      # If mysql-server is installed
+```
+```sh
 service postgresql status        # If postgresql is installed
+```
+```sh
 service zm_rpcapi status
 service zm_testagent status
 ```


### PR DESCRIPTION
Github makes it easy to copy the entire content in so called fenced code block (e.g. with backticks). This PR splits one such code block because you will never want to paste all lines to a server that you install.