### PR TITLE
Update call site after method name change

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -118,7 +118,13 @@ sub process_unfinished_tests {
             else {
                 $result = [];
             }
-            push(@$result, {"level" => "CRITICAL", "module" => "BACKEND_TEST_AGENT", "tag" => "UNABLE_TO_FINISH_TEST", "timestamp" => $self->config->MaxZonemasterExecutionTime()});
+            push @$result,
+              {
+                "level"     => "CRITICAL",
+                "module"    => "BACKEND_TEST_AGENT",
+                "tag"       => "UNABLE_TO_FINISH_TEST",
+                "timestamp" => $self->config->ZONEMASTER_max_zonemaster_execution_time
+              };
             $self->process_unfinished_tests_give_up($result, $h->{hash_id});
         }
     }


### PR DESCRIPTION
## Purpose

Fix a crash.

## Context

Introduced in #759.
Fixes #778.

## Changes

This PR updates a forgotten call site after renaming a method.

## How to test this PR

(I have not yet tried to reproduce the bug using this procedure, but from my current understanding it should work.)

1. Set ZONEMASTER.max_zonemaster_execution_time to something low.
2. Restart zm-testagent.
3. Start a new test (A).
4. Kill the test's worker process before it can finish.
5. Wait for the test to expire.
6. Verify that zm-testagent is still alive by starting a new test and seeing that it's being processed.