### PR TITLE
Make zm-rpcapi accept fake delegation again

### DIFF
--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -22,13 +22,13 @@ our %EXPORT_TAGS = (
     ],
 );
 
-Readonly my $IPV4_RE => qr/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\$/;
-Readonly my $IPV6_RE => qr/^([0-9a-f]{1,4}:[0-9a-f:]{1,}(:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?)\$|([0-9a-f]{1,4}::[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})\$/i;
+Readonly my $IPV4_RE => qr/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/;
+Readonly my $IPV6_RE => qr/^([0-9a-f]{1,4}:[0-9a-f:]{1,}(:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?)$|([0-9a-f]{1,4}::[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$/i;
 
 Readonly my $API_KEY_RE             => qr/^[a-z0-9-_]{1,512}$/i;
 Readonly my $CLIENT_ID_RE           => qr/^[a-z0-9-+~_.: ]{1,50}$/i;
 Readonly my $CLIENT_VERSION_RE      => qr/^[a-z0-9-+~_.: ]{1,50}$/i;
-Readonly my $DIGEST_RE              => qr/^[a-f0-9]{40}\$|^[a-f0-9]{64}\$/i;
+Readonly my $DIGEST_RE              => qr/^[a-f0-9]{40}$|^[a-f0-9]{64}$/i;
 Readonly my $ENGINE_TYPE_RE         => qr/^(?:mysql|postgresql|sqlite)$/i;
 Readonly my $IPADDR_RE              => qr/^$|$IPV4_RE|$IPV6_RE/;
 Readonly my $JSONRPC_METHOD_RE      => qr/^[a-z0-9_-]*$/i;

--- a/t/validator.t
+++ b/t/validator.t
@@ -5,6 +5,7 @@ use utf8;
 
 use Test::More tests => 2;
 use Test::NoWarnings;
+use Test::Differences;
 use Scalar::Util qw( tainted );
 
 # Get a tainted copy of a string
@@ -21,6 +22,20 @@ sub taint {
 subtest 'Everything but NoWarnings' => sub {
 
     use_ok( 'Zonemaster::Backend::Validator', ':untaint' );
+
+    subtest 'ds_info' => sub {
+        my $v          = Zonemaster::Backend::Validator->new->ds_info;
+        my $ds_info_40 = { digest => '0' x 40, algorithm => 0, digtype => 0, keytag => 0 };
+        my $ds_info_64 = { digest => '0' x 64, algorithm => 0, digtype => 0, keytag => 0 };
+        eq_or_diff [ $v->validate( $ds_info_40 ) ], [], 'accept ds_info with 40-digit hash';
+        eq_or_diff [ $v->validate( $ds_info_64 ) ], [], 'accept ds_info with 64-digit hash';
+    };
+
+    subtest 'ip_address' => sub {
+        my $v = Zonemaster::Backend::Validator->new->ip_address;
+        eq_or_diff [ $v->validate( '192.168.0.2' ) ], [], 'accept: 192.168.0.2';
+        eq_or_diff [ $v->validate( '2001:db8::1' ) ], [], 'accept: 2001:db8::1';
+    };
 
     subtest 'untaint_engine_type' => sub {
         is scalar untaint_engine_type( 'MySQL' ),      'MySQL',      'accept: MySQL';


### PR DESCRIPTION
## Purpose

Make zm-rpcapi accept fake delegation again.

## Context

Introduced in #759.
Fixes #779.

## Changes

This PR removes stray backslashes from regexes.
It also adds regression tests for the affected validation primitives.

## How to test this PR

Start a new test with fake delegation that includes an IP address and verify that you don't get a validation error:
```
zmb start_domain_test --domain example.com --nameserver a.example.com:192.0.2.1
zmb start_domain_test --domain example.com --ds-info keytag=0,algorithm=0,digtype=0,digest=1234567890123456789012345678901234567890
```

