### PR TITLE
Fix handling of nameserver option in zmb

### DIFF
--- a/script/zmb
+++ b/script/zmb
@@ -214,6 +214,7 @@ sub cmd_start_domain_test {
         my @nameserver_objects;
         for my $domain_ip_pair ( @opt_nameserver ) {
             my ( $domain, $ip ) = split /:/, $domain_ip_pair, 2;
+            $ip = "" if not defined $ip;
             push @nameserver_objects,
               {
                 ns => $domain,

--- a/script/zmb
+++ b/script/zmb
@@ -215,7 +215,7 @@ sub cmd_start_domain_test {
         my @nameserver_objects;
         for my $domain_ip_pair ( @opt_nameserver ) {
             my ( $domain, $ip ) = split /:/, $domain_ip_pair, 2;
-            $ip = "" if not defined $ip;
+            $ip //= "";
             push @nameserver_objects,
               {
                 ns => $domain,

--- a/script/zmb
+++ b/script/zmb
@@ -147,6 +147,7 @@ sub cmd_get_language_tags {
     --ipv4 true|false|null
     --ipv6 true|false|null
     --nameserver DOMAIN_NAME:IP_ADDRESS
+    --nameserver DOMAIN_NAME  # Trailing colon is optional when not specifing IP_ADDRESS
     --ds-info DS_INFO
     --client-id CLIENT_ID
     --client-version CLIENT_VERSION


### PR DESCRIPTION
set ip param to empty string if undefined, fix #780 

```
% ./script/zmb --verbose start_domain_test --nameserver ns.nic.se --domain iis.se
{"params":{"nameservers":[{"ip":"","ns":"ns.nic.se"}],"domain":"iis.se"},"method":"start_domain_test","jsonrpc":"2.0","id":1}
{"id":1,"result":"e3d836d48136428f","jsonrpc":"2.0"}
```

```
% ./script/zmb --verbose start_domain_test --nameserver ns.nic.se:91.226.36.45 --domain iis.se
{"id":1,"params":{"domain":"iis.se","nameservers":[{"ns":"ns.nic.se","ip":"91.226.36.45"}]},"jsonrpc":"2.0","method":"start_domain_test"}
{"id":1,"result":"dc93b829f18d2d64","jsonrpc":"2.0"}
```