### PR TITLE
Updates license statements (zonemaster-backend)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,10 @@
 ### Code license
 
-Copyright (c) 2013-2017, IIS (The Internet Foundation in Sweden)
-Copyright (c) 2013-2017, AFNIC
+Copyright (c) The Swedish Internet Foundation (<https://internetstiftelsen.se/en/>)
+Copyright (c) AFNIC (<https://www.afnic.fr/en/>)
 All rights reserved.
+
+Copyright belongs to external contributor where applicable.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
@@ -28,8 +30,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### Documentation license
 
-Copyright (c) 2013-2017, IIS (The Internet Foundation in Sweden)
-Copyright (c) 2013-2017, AFNIC
+Copyright (c) The Swedish Internet Foundation (<https://internetstiftelsen.se/en/>)
+Copyright (c) AFNIC (<https://www.afnic.fr/en/>)
+All rights reserved.
+
+Copyright belongs to external contributor where applicable.
+
 Creative Commons Attribution 4.0 International License
 
 You should have received a copy of the license along with this


### PR DESCRIPTION
## Purpose

In the copyright statement a range of years is given. That requires updates, but year is not needed.

Nothing is said about copyright for contributors.

## Changes

Removes year from copyright and give the correct "translation" of Internetstiftelsen. Adds statement about contributor's copyright.

## How to test this PR

No need to test.