### PR TITLE
Adds documentation of camel case database engine name

### DIFF
--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -765,6 +765,7 @@ sub _create_setter {
 sub _normalize_engine_type {
     my ( $value ) = @_;
 
+    # Normalized to camel case to match the database engine Perl module name, e.g. "SQLite.pm".
     state $db_module_names = {
         mysql      => 'MySQL',
         postgresql => 'PostgreSQL',


### PR DESCRIPTION
## Purpose

Document why the normalized database engine name is in a specific camel case form in Config.pm

## Changes

One line (comment) in the Perl module.

## How to test this PR

It does not change the code.
