### PR TITLE
Deprecate country code

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -160,9 +160,8 @@ This parameter is a string that are an IPv4 or IPv6. It's validated with the fol
 
 Basic data type: string
 
-A string of A-Z, a-z and underscores matching one of the regular expressions
-`/^[a-z]{2}$/` or `/^[a-z]{2}_[A-Z]{2}$/`. The first format is the preferred
-format, and the second format is *deprecated*.
+A string matching the regular expression `/^[a-z]{2}$/` (preferred format) or a string 
+matching the regular expressions `/^[a-z]{2}_[A-Z]{2}$/` (*deprecated* format).
 
 The set of valid *language tags* is further constrained by the
 [LANGUAGE.locale] property.

--- a/docs/API.md
+++ b/docs/API.md
@@ -160,8 +160,9 @@ This parameter is a string that are an IPv4 or IPv6. It's validated with the fol
 
 Basic data type: string
 
-A string matching the regular expression `/^[a-z]{2}$/` (preferred format) or a string 
-matching the regular expressions `/^[a-z]{2}_[A-Z]{2}$/` (*deprecated* format).
+A string matching one of the following regular expression:
+* `/^[a-z]{2}$/`, preferred format.
+* `/^[a-z]{2}_[A-Z]{2}$/`, *deprecated* format, use the preferred format instead.
 
 The set of valid *language tags* is further constrained by the
 [LANGUAGE.locale] property.

--- a/docs/API.md
+++ b/docs/API.md
@@ -160,8 +160,9 @@ This parameter is a string that are an IPv4 or IPv6. It's validated with the fol
 
 Basic data type: string
 
-A string of A-Z, a-z and underscores matching the regular expression
-`/^[a-z]{2}(_[A-Z]{2})?$/`.
+A string of A-Z, a-z and underscores matching one of the regular expressions
+`/^[a-z]{2}$/` or `/^[a-z]{2}_[A-Z]{2}$/`. The first format is the preferred
+format, and the second format is *deprecated*.
 
 The set of valid *language tags* is further constrained by the
 [LANGUAGE.locale] property.
@@ -174,6 +175,8 @@ The set of valid *language tags* is further constrained by the
 E.g. if [LANGUAGE.locale] is "en_US en_UK sv_SE", all the valid *language tags*
 are "en_US", "en_UK", "sv_SE" and "sv".
 
+The use of `language tags` that include the country code is *deprecated*.
+
 #### Design
 
 The two first characters of the *language tag* are intended to be an
@@ -183,12 +186,15 @@ are intended to be an [ISO 3166-1 alpha-2] two-character country code.
 #### Out-of-the box support
 
 A default installation will accept the following *language tags*:
-* `da` or `da_DK` for Danish language.
-* `en` or `en_US` for English language.
-* `fi` or `fi_FI` for Finnish language.
-* `fr` or `fr_FR` for French language.
-* `nb` or `nb_NO` for Norwegian language.
-* `sv` or `sv_SE` for Swedish language.
+
+Language | Preferred language tag | Deprecated language tag
+---------|------------------------|------------------
+Danish   | da                     | da_DK
+English  | en                     | en_US
+Finnish  | fi                     | fi_FI
+French   | fr                     | fr_FR
+Norwegian| nb                     | nb_NO
+Swedish  | sv                     | sv_SE
 
 
 ### Name server
@@ -391,6 +397,8 @@ Returns the set of valid [*language tags*][Language tag].
 > Note: If there are two [*locale tags*][LANGUAGE.locale] in [LANGUAGE.locale]
 > that would give the same [short language tag][Language tag] then the short tag
 > is excluded from the set of valid [*language tags*][Language tag].
+>
+> Note: Language tags that include country code are *deprecated*.
 
 Example request:
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -162,7 +162,7 @@ Basic data type: string
 
 A string matching one of the following regular expression:
 * `/^[a-z]{2}$/`, preferred format.
-* `/^[a-z]{2}_[A-Z]{2}$/`, *deprecated* format, use the preferred format instead.
+* `/^[a-z]{2}_[A-Z]{2}$/`, **deprecated** format, use the preferred format instead.
 
 The set of valid *language tags* is further constrained by the
 [LANGUAGE.locale] property.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -181,6 +181,9 @@ The LANGUAGE section has one key, `locale`.
 
 ### locale
 
+Leaving the `locale` key empty or absent is *deprecated*. Always configure it
+with supported `locale tags`.
+
 A space separated list of `locale tags` where each tag matches the regular
 expression `/^[a-z]{2}_[A-Z]{2}$/`.
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -205,7 +205,7 @@ language from being allowed. If there are more than one `locale tag`
 all those must be removed to block that language.
 
 English is the Zonemaster default language, but it can be blocked
-from being allowed by RPC-API by including some `locale tag` it in the
+from being allowed by RPC-API by including some `locale tag` in the
 configuration, but none starting with language code for English ("en").
 
 #### Out-of-the-box support

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -205,22 +205,22 @@ language from being allowed. If there are more than one `locale tag`
 all those must be removed to block that language.
 
 English is the Zonemaster default language, but it can be blocked
-from being allowed by RPC-API by not including it in the
-configuration.
+from being allowed by RPC-API by including some `locale tag` it in the
+configuration, but none starting with language code for English ("en").
 
 #### Out-of-the-box support
 
 The default installation and configuration supports the
 following languages.
 
-Language | Locale tag value   | Locale value used
----------|--------------------|------------------
-Danish   | da_DK              | da_DK.UTF-8
-English  | en_US              | en_US.UTF-8
-Finnish  | fi_FI              | fi_FI.UTF-8
-French   | fr_FR              | fr_FR.UTF-8
-Norwegian| nb_NO              | nb_NO.UTF-8
-Swedish  | sv_SE              | sv_SE.UTF-8
+Language | Locale tag value | Language code | Locale value used
+---------|------------------|---------------|------------------
+Danish   | da_DK            | da            | da_DK.UTF-8
+English  | en_US            | en            | en_US.UTF-8
+Finnish  | fi_FI            | fi            | fi_FI.UTF-8
+French   | fr_FR            | fr            | fr_FR.UTF-8
+Norwegian| nb_NO            | nb            | nb_NO.UTF-8
+Swedish  | sv_SE            | sv            | sv_SE.UTF-8
 
 Setting in the default configuration file:
 
@@ -233,9 +233,15 @@ locale = da_DK en_US fi_FI fr_FR nb_NO sv_SE
 If a new `locale tag` is added to the configuration then the equivalent
 MO file should be added to Zonemaster-Engine at the correct place so
 that gettext can retrieve it, or else the added `locale tag` will not
-add any actual language support. See the
-[Zonemaster-Engine share directory] for the existing PO files that are
-converted to MO files. (Here we should have a link
+add any actual language support. The MO file should be created for the
+`language code` of the `locale tag` (see the table above), not the entire
+`locale tag`. E.g. if the `locale` configuration key includes "sv_SE" then
+a MO file for "sv" should be included in the installation.
+
+Use of MO files based on the entire `locale tag` is *deprecated*.
+
+See the [Zonemaster-Engine share directory] for the existing PO files that are
+converted to MO files during installation. (Here we should have a link
 to documentation instead.)
 
 Each locale set in the configuration file, including the implied

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -254,15 +254,20 @@ sub parse {
         $obj->_set_ZONEMASTER_age_reuse_previous_test( $value );
     }
 
-    $obj->{_LANGUAGE_locale} = {};
-    for my $locale_tag ( split /\s+/, $get_and_clear->( 'LANGUAGE', 'locale' ) || 'en_US' ) {
-        $locale_tag =~ /^[a-z]{2}_[A-Z]{2}$/
-          or die "Illegal locale tag in LANGUAGE.locale: $locale_tag\n";
-
-        !exists $obj->{_LANGUAGE_locale}{$locale_tag}
-          or die "Repeated locale tag in LANGUAGE.locale: $locale_tag\n";
-
-        $obj->{_LANGUAGE_locale}{$locale_tag} = 1;
+    {
+        $obj->{_LANGUAGE_locale} = {};
+        my $values = $get_and_clear->( 'LANGUAGE', 'locale' );
+        unless ($values) {
+            push @warnings, "Use of empty LANGUAGE.locale propery is deprecated.";
+            $values = 'en_US';
+        }
+        for my $locale_tag ( split /\s+/, $values ) {
+            $locale_tag =~ /^[a-z]{2}_[A-Z]{2}$/
+                or die "Illegal locale tag in LANGUAGE.locale: $locale_tag\n";
+            !exists $obj->{_LANGUAGE_locale}{$locale_tag}
+            or die "Repeated locale tag in LANGUAGE.locale: $locale_tag\n";
+            $obj->{_LANGUAGE_locale}{$locale_tag} = 1;
+        }
     }
 
     $obj->{_public_profiles} = {


### PR DESCRIPTION
## Purpose

Language tags have been defined to possibly include country code, but there is no real use case for that, and it only adds to the complexity of documentation and code.

The possibility to have an empty LANGUAGE.locale unnecessarily adds to complexity.

## Context

Resolves issue #794 and deprecates the use of empty LANGUAGE.locale.

## Changes

* Deprecates language tags with country code in API.pm
* Deprecates empty LANGUAGE.locale and clarifies in Configuration.pm
* Adds warning in Config.pm if LANGUAGE.locale is empty.

## How to test this PR

If LANGUAGE.locale is empty, a log messages will be outputted to the log file. If non-empty, there should be no change in behavior. There should be no change besides the log message.
