### PR TITLE
Make LANGUAGE section docs easier to navigate

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -393,20 +393,6 @@ If there are two `locale tags` that would give the same short
 `language tag` then that is excluded. E.g. "en_US en_UK" will
 only give "en_US" and "en_UK" as `language tags`.
 
-The following `language tags` are generated using the default configuration:
-* da
-* da_DK
-* en
-* en_US
-* fi
-* fi_FI
-* fr
-* fr_FR
-* nb
-* nb_NO
-* sv
-* sv_SE
-
 Example request:
 ```json
 {
@@ -416,16 +402,22 @@ Example request:
 }
 ```
 
-Example response:
+Example response (as generated using the default configuration):
 ```json
 {
   "jsonrpc": "2.0",
   "id": 1,
   "result": [
+    "da",
+    "da_DK",
     "en",
     "en_US",
+    "fi",
+    "fi_FI",
     "fr",
     "fr_FR",
+    "nb",
+    "nb_NO",
     "sv",
     "sv_SE"
   ]

--- a/docs/API.md
+++ b/docs/API.md
@@ -156,6 +156,41 @@ This parameter is a string that are an IPv4 or IPv6. It's validated with the fol
  - IPv6 : `/^([0-9A-Fa-f]{1,4}:[0-9A-Fa-f:]{1,}(:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?)|([0-9A-Fa-f]{1,4}::[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$/`
 
 
+### Language tag
+
+Basic data type: string
+
+A string of A-Z, a-z and underscores matching the regular expression
+`/^[a-z]{2}(_[A-Z]{2})?$/`.
+
+The set of valid *language tags* is further constrained by the
+[LANGUAGE.locale] property.
+* If the *language tag* is a five character string, it needs to match a *locale
+  tag* in LANGUAGE.locale.
+* If the *language tag* is a two-character string, it needs to match the
+  first two characters of exactly one *locale tag* in LANGUAGE.locale.
+  (So that it is unambiguous which *locale tag* is matched.)
+
+E.g. if LANGUAGE.locale is "en_US en_UK sv_SE", all the valid *language tags*
+are "en_US", "en_UK", "sv_SE" and "sv".
+
+#### Design
+
+The two first characters of the *language tag* are intended to be an
+[ISO 639-1] two-character language code and the optional two last characters
+are intended to be an [ISO 3166-1 alpha-2] two-character country code.
+
+#### Out-of-the box support
+
+A default installation will accept the following *language tags*:
+* `da` or `da_DK` for Danish language.
+* `en` or `en_US` for English language.
+* `fi` or `fi_FI` for Finnish language.
+* `fr` or `fr_FR` for French language.
+* `nb` or `nb_NO` for Norwegian language.
+* `sv` or `sv_SE` for Swedish language.
+
+
 ### Name server
 
 Basic data type: object
@@ -164,6 +199,13 @@ Properties:
 
 * `"ns"`: A *domain name*, required.
 * `"ip"`: An *IP address* (IPv4 or IPv6), optional. (default: unset)
+
+
+### Non-negative integer
+
+Basic data type: number (integer)
+ 
+A non-negative integer is either zero or strictly positive.
 
 
 ### Priority
@@ -257,48 +299,6 @@ Basic data type: string
 
 Default database timestamp format: "Y-M-D H:M:S.ms".
 Example: "2017-12-18 07:56:17.156939"
-
-
-### Language tag
-
-Basic data type: string
-
-A string of A-Z, a-z and underscores matching the regular expression
-`/^[a-z]{2}(_[A-Z]{2})?$/`.
-
-The set of valid *language tags* is further constrained by the
-[LANGUAGE.locale] property.
-* If the *language tag* is a five character string, it needs to match a *locale
-  tag* in LANGUAGE.locale.
-* If the *language tag* is a two-character string, it needs to match the
-  first two characters of exactly one *locale tag* in LANGUAGE.locale.
-  (So that it is unambiguous which *locale tag* is matched.)
-
-E.g. if LANGUAGE.locale is "en_US en_UK sv_SE", all the valid *language tags*
-are "en_US", "en_UK", "sv_SE" and "sv".
-
-#### Design
-
-The two first characters of the *language tag* are intended to be an
-[ISO 639-1] two-character language code and the optional two last characters
-are intended to be an [ISO 3166-1 alpha-2] two-character country code.
-
-#### Out-of-the box support
-
-A default installation will accept the following *language tags*:
-* `da` or `da_DK` for Danish language.
-* `en` or `en_US` for English language.
-* `fi` or `fi_FI` for Finnish language.
-* `fr` or `fr_FR` for French language.
-* `nb` or `nb_NO` for Norwegian language.
-* `sv` or `sv_SE` for Swedish language.
-
-
-### Non-negative integer
-
-Basic data type: number (integer)
- 
-A non-negative integer is either zero or strictly positive.
 
 
 ### Username

--- a/docs/API.md
+++ b/docs/API.md
@@ -277,9 +277,13 @@ The set of valid *language tags* is further constrained by the
 E.g. if LANGUAGE.locale is "en_US en_UK sv_SE", all the valid *language tags*
 are "en_US", "en_UK", "sv_SE" and "sv".
 
+#### Design
+
 The two first characters of the *language tag* are intended to be an
 [ISO 639-1] two-character language code and the optional two last characters
 are intended to be an [ISO 3166-1 alpha-2] two-character country code.
+
+#### Out-of-the box support
 
 A default installation will accept the following *language tags*:
 * `da` or `da_DK` for Danish language.

--- a/docs/API.md
+++ b/docs/API.md
@@ -266,13 +266,16 @@ Basic data type: string
 A string of A-Z, a-z and underscores matching the regular expression
 `/^[a-z]{2}(_[A-Z]{2})?$/`.
 
-The `language tag` must match a `locale tag` in the configuration file.
-If the `language tag` is a two-character string, it only needs to match the
-first two characters of the `locale tag` from the configuration file, if
-that is unique (there is only one `locale tag` starting with the same two
-characters), else it is an error.
+The set of valid `language tags` is further constrained by the
+[LANGUAGE.locale] property.
+* If the `language tag` is a five character string, it needs to match a `locale
+  tag` in LANGUAGE.locale.
+* If the `language tag` is a two-character string, it needs to match the
+  first two characters of a single `locale tag` in LANGUAGE.locale.
+  (So that it is unambiguous which *locale tag* is matched.)
 
-Any other string is an error.
+E.g. if LANGUAGE.locale is "en_US en_UK sv_SE", all the valid `language tags`
+are "en_US", "en_UK", "sv_SE" and "sv".
 
 The two first characters of the `language tag` are intended to be an
 [ISO 639-1] two-character language code and the optional two last characters
@@ -379,18 +382,8 @@ An array of *Profile names* in lower case. `"default"` is always included.
 
 ## API method: `get_language_tags`
 
-Returns all valid [language tags][language tag] generated from the
-[LANGUAGE.locale] property in the configuration file.
-
-Each `locale tag` in LANGUAGE.locale generates two `language tags`,
-a short tag equal to the first two letters (usually the same as a language
-code) and a long tag which is equal to the full `locale tag`.
-If "en_US" is the `locale tag` then "en" and "en_US" are the
-`language tags`.
-
-If there are two `locale tags` that would give the same short
-`language tag` then that is excluded. E.g. "en_US en_UK" will
-only give "en_US" and "en_UK" as `language tags`.
+Returns a list of all valid [language tags][language tag] that match `locale
+tags` according to the rules defined by the [language tag] data type.
 
 Example request:
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -401,7 +401,7 @@ Example request:
 }
 ```
 
-Example response (as generated using the default configuration):
+Example response:
 ```json
 {
   "jsonrpc": "2.0",

--- a/docs/API.md
+++ b/docs/API.md
@@ -379,10 +379,9 @@ An array of *Profile names* in lower case. `"default"` is always included.
 
 ## API method: `get_language_tags`
 
-Returns all valid [language tags][language tag] generated from the setting in
-the configuration file.
+Returns all valid [language tags][language tag] generated from the
+[LANGUAGE.locale] property in the configuration file.
 
-The `language tags` are generated from the [LANGUAGE.locale] property.
 Each `locale tag` in LANGUAGE.locale generates two `language tags`,
 a short tag equal to the first two letters (usually the same as a language
 code) and a long tag which is equal to the full `locale tag`.

--- a/docs/API.md
+++ b/docs/API.md
@@ -390,7 +390,7 @@ Returns the set of valid [*language tags*][Language tag].
 
 > Note: If there are two [*locale tags*][LANGUAGE.locale] in [LANGUAGE.locale]
 > that would give the same [short language tag][Language tag] then the short tag
-> is excluded from the set of valid [*langauge tags*][Language tag].
+> is excluded from the set of valid [*language tags*][Language tag].
 
 Example request:
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -166,12 +166,12 @@ A string of A-Z, a-z and underscores matching the regular expression
 The set of valid *language tags* is further constrained by the
 [LANGUAGE.locale] property.
 * If the *language tag* is a five character string, it needs to match a *locale
-  tag* in LANGUAGE.locale.
+  tag* in [LANGUAGE.locale].
 * If the *language tag* is a two-character string, it needs to match the
-  first two characters of exactly one *locale tag* in LANGUAGE.locale.
+  first two characters of exactly one *locale tag* in [LANGUAGE.locale].
   (So that it is unambiguous which *locale tag* is matched.)
 
-E.g. if LANGUAGE.locale is "en_US en_UK sv_SE", all the valid *language tags*
+E.g. if [LANGUAGE.locale] is "en_US en_UK sv_SE", all the valid *language tags*
 are "en_US", "en_UK", "sv_SE" and "sv".
 
 #### Design

--- a/docs/API.md
+++ b/docs/API.md
@@ -382,6 +382,31 @@ An array of *Profile names* in lower case. `"default"` is always included.
 Returns all valid [language tags][language tag] generated from the setting in
 the configuration file.
 
+The `language tags` are generated from the configured [locale tags].
+Each `locale tag` will generate two `language tags`, a short tag
+equal to the first two letters (usually the same as a language
+code) and a long tag which is equal to the full `locale tag`.
+If "en_US" is the `locale tag` then "en" and "en_US" are the
+`language tags`.
+
+If there are two `locale tags` that would give the same short
+`language tag` then that is excluded. E.g. "en_US en_UK" will
+only give "en_US" and "en_UK" as `language tags`.
+
+The following `language tags` are generated using the default configuration:
+* da
+* da_DK
+* en
+* en_US
+* fi
+* fi_FI
+* fr
+* fr_FR
+* nb
+* nb_NO
+* sv
+* sv_SE
+
 Example request:
 ```json
 {

--- a/docs/API.md
+++ b/docs/API.md
@@ -266,22 +266,22 @@ Basic data type: string
 A string of A-Z, a-z and underscores matching the regular expression
 `/^[a-z]{2}(_[A-Z]{2})?$/`.
 
-The set of valid `language tags` is further constrained by the
+The set of valid *language tags* is further constrained by the
 [LANGUAGE.locale] property.
-* If the `language tag` is a five character string, it needs to match a `locale
-  tag` in LANGUAGE.locale.
-* If the `language tag` is a two-character string, it needs to match the
-  first two characters of a single `locale tag` in LANGUAGE.locale.
+* If the *language tag* is a five character string, it needs to match a *locale
+  tag* in LANGUAGE.locale.
+* If the *language tag* is a two-character string, it needs to match the
+  first two characters of exactly one *locale tag* in LANGUAGE.locale.
   (So that it is unambiguous which *locale tag* is matched.)
 
-E.g. if LANGUAGE.locale is "en_US en_UK sv_SE", all the valid `language tags`
+E.g. if LANGUAGE.locale is "en_US en_UK sv_SE", all the valid *language tags*
 are "en_US", "en_UK", "sv_SE" and "sv".
 
-The two first characters of the `language tag` are intended to be an
+The two first characters of the *language tag* are intended to be an
 [ISO 639-1] two-character language code and the optional two last characters
 are intended to be an [ISO 3166-1 alpha-2] two-character country code.
 
-A default installation will accept the following `language tags`:
+A default installation will accept the following *language tags*:
 * `da` or `da_DK` for Danish language.
 * `en` or `en_US` for English language.
 * `fi` or `fi_FI` for Finnish language.
@@ -382,8 +382,7 @@ An array of *Profile names* in lower case. `"default"` is always included.
 
 ## API method: `get_language_tags`
 
-Returns a list of all valid [language tags][language tag] that match `locale
-tags` according to the rules defined by the [language tag] data type.
+Returns a list of all valid [*language tags*][language tag].
 
 Example request:
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -386,7 +386,11 @@ An array of *Profile names* in lower case. `"default"` is always included.
 
 ## API method: `get_language_tags`
 
-Returns a list of all valid [*language tags*][language tag].
+Returns the set of valid [*language tags*][Language tag].
+
+> Note: If there are two [*locale tags*][LANGUAGE.locale] in [LANGUAGE.locale]
+> that would give the same [short language tag][Language tag] then the short tag
+> is excluded from the set of valid [*langauge tags*][Language tag].
 
 Example request:
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -382,9 +382,9 @@ An array of *Profile names* in lower case. `"default"` is always included.
 Returns all valid [language tags][language tag] generated from the setting in
 the configuration file.
 
-The `language tags` are generated from the configured [locale tags].
-Each `locale tag` will generate two `language tags`, a short tag
-equal to the first two letters (usually the same as a language
+The `language tags` are generated from the [LANGUAGE.locale] property.
+Each `locale tag` in LANGUAGE.locale generates two `language tags`,
+a short tag equal to the first two letters (usually the same as a language
 code) and a long tag which is equal to the full `locale tag`.
 If "en_US" is the `locale tag` then "en" and "en_US" are the
 `language tags`.
@@ -1191,5 +1191,6 @@ The `"params"` object sent to `start_domain_test` or `add_batch_job` when the *t
 [Available profiles]:           Configuration.md#profiles-section
 [ISO 3166-1 alpha-2]:           https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                    https://en.wikipedia.org/wiki/ISO_639-1
-[Privilege levels]:             #privilege-levels
+[LANGUAGE.locale]:              Configuration.md#locale
 [Language tag]:                 #language-tag
+[Privilege levels]:             #privilege-levels

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -174,11 +174,15 @@ It is an error to repeat the same `locale tag`.
 If the `locale` key is empty or absent, the `locale tag` value
 "en_US" is set by default.
 
+#### Design
+
 The two first characters of a `locale tag` are intended to be an
 [ISO 639-1] two-character language code and the two last characters
 are intended to be an [ISO 3166-1 alpha-2] two-character country code.
 A `locale tag` is a locale setting for the available translation
 of messages without ".UTF-8", which is implied.
+
+#### Usage
 
 Removing a language from the configuration file just blocks that
 language from being allowed. If there are more than one `locale tag`

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -165,9 +165,10 @@ If this property is unspecified, the value of [DB.database_name] is used instead
 
 The LANGUAGE section has one key, `locale`.
 
-The value of the `locale` key is a space separated list of
-`locale tags` where each tag must match the regular expression
-`/^[a-z]{2}_[A-Z]{2}$/`.
+### locale
+
+A space separated list of `locale tags` where each tag matches the regular
+expression `/^[a-z]{2}_[A-Z]{2}$/`.
 
 It is an error to repeat the same `locale tag`.
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -178,14 +178,6 @@ are intended to be an [ISO 3166-1 alpha-2] two-character country code.
 A `locale tag` is a locale setting for the available translation
 of messages without ".UTF-8", which is implied.
 
-If a new `locale tag` is added to the configuration then the equivalent
-MO file should be added to Zonemaster-Engine at the correct place so
-that gettext can retrieve it, or else the added `locale tag` will not
-add any actual language support. See the
-[Zonemaster-Engine share directory] for the existing PO files that are
-converted to MO files. (Here we should have a link
-to documentation instead.)
-
 Removing a language from the configuration file just blocks that
 language from being allowed. If there are more than one `locale tag`
 (with different country codes) for the same language, then
@@ -240,6 +232,16 @@ Setting in the default configuration file:
 ```
 locale = da_DK en_US fi_FI fr_FR nb_NO sv_SE
 ```
+
+#### Installation considerations
+
+If a new `locale tag` is added to the configuration then the equivalent
+MO file should be added to Zonemaster-Engine at the correct place so
+that gettext can retrieve it, or else the added `locale tag` will not
+add any actual language support. See the
+[Zonemaster-Engine share directory] for the existing PO files that are
+converted to MO files. (Here we should have a link
+to documentation instead.)
 
 Each locale set in the configuration file, including the implied
 ".UTF-8", must also be installed or activate on the system

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -189,32 +189,6 @@ English is the Zonemaster default language, but it can be blocked
 from being allowed by RPC-API by not including it in the
 configuration.
 
-In the RPCAPI, `language tag` is used ([Language tag]). The
-`language tags` are generated from the `locale tags`. Each
-`locale tag` will generate two `language tags`, a short tag
-equal to the first two letters (usually the same as a language
-code) and a long tag which is equal to the full `locale tag`.
-If "en_US" is the `locale tag` then "en" and "en_US" are the
-`language tags`.
-
-If there are two `locale tags` that would give the same short
-`language tag` then that is excluded. E.g. "en_US en_UK" will
-only give "en_US" and "en_UK" as `language tags`.
-
-The following `language tags` are generated:
-* da
-* da_DK
-* en
-* en_US
-* fi
-* fi_FI
-* fr
-* fr_FR
-* nb
-* nb_NO
-* sv
-* sv_SE
-
 #### Out-of-the-box support
 
 The default installation and configuration supports the

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -201,18 +201,6 @@ If there are two `locale tags` that would give the same short
 `language tag` then that is excluded. E.g. "en_US en_UK" will
 only give "en_US" and "en_UK" as `language tags`.
 
-The default installation and configuration supports the
-following languages.
-
-Language | Locale tag value   | Locale value used
----------|--------------------|------------------
-Danish   | da_DK              | da_DK.UTF-8
-English  | en_US              | en_US.UTF-8
-Finnish  | fi_FI              | fi_FI.UTF-8
-French   | fr_FR              | fr_FR.UTF-8
-Norwegian| nb_NO              | nb_NO.UTF-8
-Swedish  | sv_SE              | sv_SE.UTF-8
-
 The following `language tags` are generated:
 * da
 * da_DK
@@ -226,6 +214,20 @@ The following `language tags` are generated:
 * nb_NO
 * sv
 * sv_SE
+
+#### Out-of-the-box support
+
+The default installation and configuration supports the
+following languages.
+
+Language | Locale tag value   | Locale value used
+---------|--------------------|------------------
+Danish   | da_DK              | da_DK.UTF-8
+English  | en_US              | en_US.UTF-8
+Finnish  | fi_FI              | fi_FI.UTF-8
+French   | fr_FR              | fr_FR.UTF-8
+Norwegian| nb_NO              | nb_NO.UTF-8
+Swedish  | sv_SE              | sv_SE.UTF-8
 
 Setting in the default configuration file:
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -169,6 +169,8 @@ The value of the `locale` key is a space separated list of
 `locale tags` where each tag must match the regular expression
 `/^[a-z]{2}_[A-Z]{2}$/`.
 
+It is an error to repeat the same `locale tag`.
+
 If the `locale` key is empty or absent, the `locale tag` value
 "en_US" is set by default.
 
@@ -224,8 +226,6 @@ The following `language tags` are generated:
 * nb_NO
 * sv
 * sv_SE
-
-It is an error to repeat the same `locale tag`.
 
 Setting in the default configuration file:
 


### PR DESCRIPTION
## Purpose

Today the `LANGUAGE section` documentation is quite long and if you're looking for something specific you may end up having to read all of it. This PR breaks it down into shorter sub-headings with clear titles.

## Context

I originally made these changes a good while ago, but I didn't get around to actually make a PR out of them until now.

## Changes

This PR moves around sections of text and inserts new headings, but it doesn't change any of the original words.

A list from the LANGUAGE.locale is integrated in to another one under `get_language_tags`.

Some text from LANGUAGE.locale and some from `get_language_tags` is integrated into the definition of the language tag data type definition.

## How to test this PR

This PR does not need testing as it only affects documentation.