### PR TITLE
Properly define properties to use for database fingerprint (deterministic hash)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -66,6 +66,7 @@ share/zm-testagent.lsb
 share/zm_rpcapi-bsd
 share/zm_testagent-bsd
 t/config.t
+t/db.t
 t/test01.data
 t/test01.t
 t/test_validate_syntax.t

--- a/docs/API.md
+++ b/docs/API.md
@@ -575,8 +575,8 @@ An object with the property:
 
 An object with the following properties:
 
-* `"ns_list"`: A list of *name server* objects representing the nameservers of the given *domain name*.
-* `"ds_list"`: A list of *DS info* objects representing delegated signer of the given *domain name*.
+* `"ns_list"`: A list of [*name server*][Name server] objects representing the nameservers of the given *domain name*.
+* `"ds_list"`: A list of [*DS info*][DS info] objects representing delegation signer (DS record data) of the given *domain name*.
 
 
 #### `"error"`
@@ -639,11 +639,11 @@ Example response:
 An object with the following properties:
 
 * `"domain"`: A *domain name*, required. The zone to test.
-* `"ipv6"`: A boolean, optional. (default `true`). Used to configure the test and enable IPv4 tests.
-* `"ipv4"`: A boolean, optional. (default `true`). Used to configure the test and enable IPv6 tests.
-* `"nameservers"`: A list of *name server* objects, optional. (default: `[]`). Used to perform un-delegated test.
-* `"ds_info"`: A list of *DS info* objects, optional. (default: `[]`). Used to perform un-delegated test.
-* `"profile"`: A *profile name*, optional. (default `"default"`). Run the tests using the given profile.
+* `"ipv6"`: A boolean, optional. (default: [`net.ipv4`][net.ipv4] profile value). Used to enable or disable testing over IPv4 transport protocol.
+* `"ipv4"`: A boolean, optional. (default: [`net.ipv6`][net.ipv6] profile value). Used to enable or disable testing over IPv6 transport protocol.
+* `"nameservers"`: A list of [*name server*][Name server] objects, optional. (default: `[]`). Used to perform un-delegated test.
+* `"ds_info"`: A list of [*DS info*][DS info] objects, optional. (default: `[]`). Used to perform un-delegated test.
+* `"profile"`: A *profile name*, optional. (default: `"default"`). Run the tests using the given profile.
 * `"config"`: **No longer supported**. Use `"profile"` instead.
 * `"client_id"`: A *client id*, optional. (default: unset). Used to monitor which client uses the API.
 * `"client_version"`: A *client version*, optional. (default: unset). Used to monitor which client use the API
@@ -1045,13 +1045,13 @@ An object with the following properties:
 The value of `"test_params"` is an object with the following properties:
 
 * `"client_id"`: A *client id*, optional. (default: unset)
-* `"profile"`: A *profile name*, optional (default `"default"`). Run the tests using the given profile.
+* `"profile"`: A *profile name*, optional (default: `"default"`). Run the tests using the given profile.
 * `"config"`: **No longer supported**. Use `"profile"` instead.
 * `"client_version"`: A *client version*, optional. (default: unset)
-* `"nameservers"`: A list of *name server* objects, optional. (default: `[]`)
-* `"ds_info"`: A list of *DS info* objects, optional. (default: `[]`)
-* `"ipv4"`: A boolean, optional. (default: `true`)
-* `"ipv6"`: A boolean, optional. (default: `true`)
+* `"nameservers"`: A list of [*name server*][Name server] objects, optional. (default: `[]`)
+* `"ds_info"`: A list of [*DS info*][DS info] objects, optional. (default: `[]`)
+* `"ipv6"`: A boolean, optional. (default: [`net.ipv4`][net.ipv4] profile value).
+* `"ipv4"`: A boolean, optional. (default: [`net.ipv6`][net.ipv6] profile value).
 * `"priority"`: A *priority*, optional. (default: `5`)
 * `"queue"`: A *queue*, optional. (default: `0`)
 
@@ -1196,8 +1196,12 @@ The `"params"` object sent to `start_domain_test` or `add_batch_job` when the *t
 >
 
 [Available profiles]:           Configuration.md#profiles-section
+[DS info]:                      #ds-info
 [ISO 3166-1 alpha-2]:           https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                    https://en.wikipedia.org/wiki/ISO_639-1
 [LANGUAGE.locale]:              Configuration.md#locale
 [Language tag]:                 #language-tag
+[Name server]:                  #name-server
+[net.ipv4]:                     https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv4
+[net.ipv6]:                     https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv6
 [Privilege levels]:             #privilege-levels

--- a/docs/API.md
+++ b/docs/API.md
@@ -807,8 +807,8 @@ In the case of a test created with `start_domain_test`:
 * `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued.
 * `"id"`: An integer.
 * `"hash_id"`: A *test id*. The *test* in question. 
-* `"params"`: The `"params"` object sent to `start_domain_test` when the *test*
-  was started.
+* `"params"`: A normalized version `"params"` object sent to
+  `start_domain_test` when the *test* was started.
 * `"results"`: A list of *test result* objects.
 
 
@@ -816,9 +816,10 @@ In the case of a test created with `add_batch_job`:
 * `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued.
 * `"id"`: An integer.
 * `"hash_id"`: A *test id*. The *test* in question. 
-* `"params"`: The `"params"` object sent to `start_domain_test` when the *test*
-  was started.
-* `"results"`: the result is a list of *test id* corresponding to each tested domain.
+* `"params"`: A normalized version `"params"` object sent to `add_batch_job`
+  when the *test* was started.
+* `"results"`: the result is a list of *test id* corresponding to each tested
+  domain.
 
 >
 > TODO: Change name in the API of `"hash_id"` to `"test_id"`
@@ -1129,7 +1130,7 @@ An object with the following properties:
 
 ## API method: `get_test_params`
 
-Return all *params* objects of a *test*.
+Return a normalized *params* objects of a *test*.
 
 Example request:
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -644,7 +644,7 @@ An object with the following properties:
 * `"nameservers"`: A list of *name server* objects, optional. (default: `[]`). Used to perform un-delegated test.
 * `"ds_info"`: A list of *DS info* objects, optional. (default: `[]`). Used to perform un-delegated test.
 * `"profile"`: A *profile name*, optional. (default `"default"`). Run the tests using the given profile.
-* `"config"`: **Deprecated**. A string, optional. Ignored. Specify `"profile"` instead.
+* `"config"`: **No longer supported**. Use `"profile"` instead.
 * `"client_id"`: A *client id*, optional. (default: unset). Used to monitor which client uses the API.
 * `"client_version"`: A *client version*, optional. (default: unset). Used to monitor which client use the API
 * `"priority"`: A *priority*, optional. (default: `10`)
@@ -1046,7 +1046,7 @@ The value of `"test_params"` is an object with the following properties:
 
 * `"client_id"`: A *client id*, optional. (default: unset)
 * `"profile"`: A *profile name*, optional (default `"default"`). Run the tests using the given profile.
-* `"config"`: **Deprecated.** A string, optional. Ignored. Specify profile instead.
+* `"config"`: **No longer supported**. Use `"profile"` instead.
 * `"client_version"`: A *client version*, optional. (default: unset)
 * `"nameservers"`: A list of *name server* objects, optional. (default: `[]`)
 * `"ds_info"`: A list of *DS info* objects, optional. (default: `[]`)

--- a/docs/API.md
+++ b/docs/API.md
@@ -644,7 +644,6 @@ An object with the following properties:
 * `"nameservers"`: A list of [*name server*][Name server] objects, optional. (default: `[]`). Used to perform un-delegated test.
 * `"ds_info"`: A list of [*DS info*][DS info] objects, optional. (default: `[]`). Used to perform un-delegated test.
 * `"profile"`: A *profile name*, optional. (default: `"default"`). Run the tests using the given profile.
-* `"config"`: **No longer supported**. Use `"profile"` instead.
 * `"client_id"`: A *client id*, optional. (default: unset). Used to monitor which client uses the API.
 * `"client_version"`: A *client version*, optional. (default: unset). Used to monitor which client use the API
 * `"priority"`: A *priority*, optional. (default: `10`)
@@ -754,7 +753,6 @@ Example response:
       "domain": "zonemaster.net",
       "profile": "default",
       "ipv6": true,
-      "advanced": true,
       "nameservers": [
         {
           "ns": "ns3.nic.se",
@@ -865,13 +863,11 @@ Example response:
       "id": "c45a3f8256c4a155",
       "creation_time": "2016-11-15 11:53:13.965982",
       "overall_result": "error",
-      "advanced_options": null
     },
     {
       "id": "32dd4bc0582b6bf9",
       "creation_time": "2016-11-14 08:46:41.532047",
       "overall_result": "error",
-      "advanced_options": null
     },
     ...
   ]
@@ -1046,7 +1042,6 @@ The value of `"test_params"` is an object with the following properties:
 
 * `"client_id"`: A *client id*, optional. (default: unset)
 * `"profile"`: A *profile name*, optional (default: `"default"`). Run the tests using the given profile.
-* `"config"`: **No longer supported**. Use `"profile"` instead.
 * `"client_version"`: A *client version*, optional. (default: unset)
 * `"nameservers"`: A list of [*name server*][Name server] objects, optional. (default: `[]`)
 * `"ds_info"`: A list of [*DS info*][DS info] objects, optional. (default: `[]`)
@@ -1157,7 +1152,6 @@ Example response:
          "domain": "zonemaster.net",
          "profile": "default",
          "client_id": "Zonemaster Dancer Frontend",
-         "advanced": true,
          "nameservers": [
             {
                 "ns": "ns3.nic.se",

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -209,6 +209,7 @@ sub _normalize_parameter_hash {
     my $array_nameservers = $$params{nameservers} // [];
     for my $nameserver (@$array_nameservers) {
         $$nameserver{ip} = "" if ( not defined $$nameserver{ip} );
+        $$nameserver{ns} = lc $$nameserver{ns};
     }
     my @array_nameservers_sort = sort {
         $a->{ip} cmp $b->{ip} or

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -189,7 +189,7 @@ sub generate_fingerprint {
     my $profile = Zonemaster::Engine::Profile->effective;
 
     my %to_encode = ();
-    $to_encode{domain}      = $$params{domain}      // "";
+    $to_encode{domain}      = lc $$params{domain}   // "";
     $to_encode{ds_info}     = $$params{ds_info}     // [];
     $to_encode{ipv4}        = $$params{ipv4}        // $profile->get( 'net.ipv4' );
     $to_encode{ipv6}        = $$params{ipv6}        // $profile->get( 'net.ipv6' );

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -190,13 +190,34 @@ sub generate_fingerprint {
 
     my %to_encode = ();
     $to_encode{domain}      = lc $$params{domain}   // "";
-    $to_encode{ds_info}     = $$params{ds_info}     // [];
     $to_encode{ipv4}        = $$params{ipv4}        // $profile->get( 'net.ipv4' );
     $to_encode{ipv6}        = $$params{ipv6}        // $profile->get( 'net.ipv6' );
-    $to_encode{nameservers} = $$params{nameservers} // [];
     $to_encode{priority}    = $$params{priority}    // 10;
     $to_encode{profile}     = $$params{profile}     // "default";
     $to_encode{queue}       = $$params{queue}       // 0;
+
+    my $array_ds_info = $$params{ds_info} // [];
+    my @array_ds_info_sort = sort {
+        $a->{algorithm} cmp $b->{algorithm} or
+        $a->{digest}    cmp $b->{digest}    or
+        $a->{digtype}   <=> $b->{digtype}   or
+        $a->{keytag}    <=> $b->{keytag}
+    } @$array_ds_info;
+
+    $to_encode{ds_info} = \@array_ds_info_sort;
+
+    my $array_nameservers = $$params{nameservers} // [];
+    my @array_nameservers_sort = sort {
+        (
+            defined $a->{ip} and
+            defined $b->{ip} and
+            $a->{ip} cmp $b->{ip}
+        ) or
+        $a->{ns} cmp $b->{ns}
+    } @$array_nameservers;
+
+    $to_encode{nameservers} = \@array_nameservers_sort;
+
 
     my $js = JSON::PP->new;
     $js->canonical( 1 );

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -7,6 +7,8 @@ use Moose::Role;
 use 5.14.2;
 
 use JSON::PP;
+use Digest::MD5 qw(md5_hex);
+use Encode;
 use Log::Any qw( $log );
 
 requires qw(
@@ -177,6 +179,18 @@ sub _new_dbh {
     $dbh->{AutoInactiveDestroy} = 1;
 
     return $dbh;
+}
+
+sub generate_fingerprint {
+    my ( $self, $params ) = @_;
+
+    my $js = JSON::PP->new;
+    $js->canonical( 1 );
+
+    my $encoded_params = $js->encode( $params );
+    my $fingerprint = md5_hex( encode_utf8( $encoded_params ) );
+
+    return ( $fingerprint, $encoded_params );
 }
 
 no Moose::Role;

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -207,12 +207,11 @@ sub _normalize_parameter_hash {
     $normalized{ds_info} = \@array_ds_info_sort;
 
     my $array_nameservers = $$params{nameservers} // [];
+    for my $nameserver (@$array_nameservers) {
+        $$nameserver{ip} = "" if ( not defined $$nameserver{ip} );
+    }
     my @array_nameservers_sort = sort {
-        (
-            defined $a->{ip} and
-            defined $b->{ip} and
-            $a->{ip} cmp $b->{ip}
-        ) or
+        $a->{ip} cmp $b->{ip} or
         $a->{ns} cmp $b->{ns}
     } @$array_nameservers;
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -221,6 +221,14 @@ sub _normalize_parameter_hash {
     return \%normalized;
 }
 
+=head2 encode_normalized_params
+
+Returns a normalized JSON string based on the provided parameters.
+Each entry is set to a default value, see
+L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/API.md#params-2>
+
+=cut
+
 sub encode_normalized_params {
     my ( $self, $params ) = @_;
 
@@ -233,6 +241,13 @@ sub encode_normalized_params {
 
     return $encoded_params;
 }
+
+=head2 generate_fingerprint
+
+Returns a fingerprint of the normalized parameters passed in argument.
+Such fingerprint are usefull to find similar tests in the database.
+
+=cut
 
 sub generate_fingerprint {
     my ( $self, $encoded_params ) = @_;

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -189,6 +189,9 @@ sub _normalize_params {
     my $profile = Zonemaster::Engine::Profile->effective;
 
     my %normalized = ();
+
+    # some of these values are already set in RPCAPI
+    # however setting them here again is required for testing purpose
     $normalized{domain}   = lc $$params{domain} // "";
     $normalized{ipv4}     = $$params{ipv4}      // $profile->get( 'net.ipv4' );
     $normalized{ipv6}     = $$params{ipv6}      // $profile->get( 'net.ipv6' );

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -208,12 +208,14 @@ sub _normalize_parameter_hash {
 
     my $array_nameservers = $$params{nameservers} // [];
     for my $nameserver (@$array_nameservers) {
-        $$nameserver{ip} = "" if ( not defined $$nameserver{ip} );
+        if ( defined $$nameserver{ip} and $$nameserver{ip} eq "" ) {
+            delete $$nameserver{ip};
+        }
         $$nameserver{ns} = lc $$nameserver{ns};
     }
     my @array_nameservers_sort = sort {
-        $a->{ip} cmp $b->{ip} or
-        $a->{ns} cmp $b->{ns}
+        $a->{ns} cmp $b->{ns} or
+        ( defined $a->{ip} and defined $b->{ip} and $a->{ip} cmp $b->{ip} )
     } @$array_nameservers;
 
     $normalized{nameservers} = \@array_nameservers_sort;

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -7,8 +7,6 @@ use 5.14.2;
 
 use Data::Dumper;
 use DBI qw(:utils);
-use Digest::MD5 qw(md5_hex);
-use Encode;
 use JSON::PP;
 
 use Zonemaster::Backend::Validator qw( untaint_ipv6_address );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -332,8 +332,6 @@ sub add_batch_job {
     my $batch_id;
 
     my $dbh = $self->dbh;
-    my $js = JSON::PP->new;
-    $js->canonical( 1 );
 
     if ( $self->user_authorized( $params->{username}, $params->{api_key} ) ) {
         $batch_id = $self->create_new_batch_job( $params->{username} );
@@ -352,8 +350,7 @@ sub add_batch_job {
         my $sth = $dbh->prepare( 'INSERT INTO test_results (domain, batch_id, priority, queue, params_deterministic_hash, params) VALUES (?, ?, ?, ?, ?, ?) ' );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
-            my $encoded_params = $js->encode( $test_params );
-            my $fingerprint    = md5_hex( encode_utf8( $encoded_params ) );
+            my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
 
             $sth->execute( $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params );
             $sth->execute( $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -131,15 +131,15 @@ sub create_new_batch_job {
     my ( $self, $username ) = @_;
 
     my ( $batch_id, $creaton_time ) = $self->dbh->selectrow_array( "
-            SELECT 
-                batch_id, 
-                batch_jobs.creation_time AS batch_creation_time 
-            FROM 
-                test_results 
-            JOIN batch_jobs 
-                ON batch_id=batch_jobs.id 
+            SELECT
+                batch_id,
+                batch_jobs.creation_time AS batch_creation_time
+            FROM
+                test_results
+            JOIN batch_jobs
+                ON batch_id=batch_jobs.id
                 AND username=?
-            WHERE 
+            WHERE
                 test_results.progress<>100
             LIMIT 1
             ", undef, $username );
@@ -193,10 +193,10 @@ sub create_new_test {
                 $test_params->{domain},
                 ($test_params->{nameservers})?(1):(0),
             );
-            
+
             my ( undef, $hash_id ) = $dbh->selectrow_array(
                 "SELECT id, hash_id FROM test_results WHERE params_deterministic_hash=? ORDER BY id DESC LIMIT 1", undef, $test_params_deterministic_hash);
-                
+
             $result_id = $hash_id;
         }
     };
@@ -232,9 +232,9 @@ sub get_test_params {
     eval {
         $result = decode_json( $params_json );
     };
-    
+
     warn "decoding of params_json failed (testi_id: [$test_id]):".Dumper($params_json) if $@;
-    
+
     return decode_json( $params_json );
 }
 
@@ -350,7 +350,7 @@ sub add_batch_job {
         eval {$dbh->do( "DROP INDEX test_results__batch_id_progress ON test_results" );};
         eval {$dbh->do( "DROP INDEX test_results__progress ON test_results" );};
         eval {$dbh->do( "DROP INDEX test_results__domain_undelegated ON test_results" );};
-        
+
         my $sth = $dbh->prepare( 'INSERT INTO test_results (domain, batch_id, priority, queue, params_deterministic_hash, params) VALUES (?, ?, ?, ?, ?, ?) ' );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
@@ -364,7 +364,7 @@ sub add_batch_job {
         $dbh->do( "CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)" );
         $dbh->do( "CREATE INDEX test_results__progress ON test_results (progress)" );
         $dbh->do( "CREATE INDEX test_results__domain_undelegated ON test_results (domain, undelegated)" );
-       
+
         $dbh->commit();
         $dbh->{AutoCommit} = 1;
     }

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -157,8 +157,8 @@ sub create_new_test {
 
     $test_params->{domain} = $domain;
 
-    my $encoded_params = $self->encode_normalized_params( $test_params );
-    my $fingerprint = $self->generate_fingerprint( $encoded_params );
+    my $fingerprint = $self->generate_fingerprint( $test_params );
+    my $encoded_params = $self->encode_params( $test_params );
 
     my $result_id;
 
@@ -352,8 +352,8 @@ sub add_batch_job {
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
 
-            my $encoded_params = $self->encode_normalized_params( $test_params );
-            my $fingerprint = $self->generate_fingerprint( $encoded_params );
+            my $fingerprint = $self->generate_fingerprint( $test_params );
+            my $encoded_params = $self->encode_params( $test_params );
 
             $sth->execute( $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params );
             $sth->execute( $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -156,7 +156,10 @@ sub create_new_test {
     my $dbh = $self->dbh;
 
     $test_params->{domain} = $domain;
-    my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
+
+    my $encoded_params = $self->encode_normalized_params( $test_params );
+    my $fingerprint = $self->generate_fingerprint( $encoded_params );
+
     my $result_id;
 
     my $priority    = $test_params->{priority};
@@ -348,7 +351,9 @@ sub add_batch_job {
         my $sth = $dbh->prepare( 'INSERT INTO test_results (domain, batch_id, priority, queue, params_deterministic_hash, params) VALUES (?, ?, ?, ?, ?, ?) ' );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
-            my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
+
+            my $encoded_params = $self->encode_normalized_params( $test_params );
+            my $fingerprint = $self->generate_fingerprint( $encoded_params );
 
             $sth->execute( $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params );
             $sth->execute( $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -158,9 +158,7 @@ sub create_new_test {
     my $dbh = $self->dbh;
 
     $test_params->{domain} = $domain;
-    my $js             = JSON::PP->new->canonical;
-    my $encoded_params = $js->encode( $test_params );
-    my $fingerprint    = md5_hex( $encoded_params );
+    my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
     my $result_id;
 
     my $priority    = $test_params->{priority};

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -132,7 +132,7 @@ sub test_progress {
             $dbh->do( "UPDATE test_results SET progress=? WHERE hash_id=? AND progress <> 100", undef, $progress, $test_id );
         }
     }
-    
+
     my ( $result ) = $dbh->selectrow_array( "SELECT progress FROM test_results WHERE hash_id=?", undef, $test_id );
 
     return $result;
@@ -143,14 +143,14 @@ sub create_new_batch_job {
 
     my $dbh = $self->dbh;
     my ( $batch_id, $creation_time ) = $dbh->selectrow_array( "
-            SELECT 
-                batch_id, 
-                batch_jobs.creation_time AS batch_creation_time 
-            FROM 
-                test_results 
-            JOIN batch_jobs 
-                ON batch_id=batch_jobs.id 
-                AND username=? WHERE 
+            SELECT
+                batch_id,
+                batch_jobs.creation_time AS batch_creation_time
+            FROM
+                test_results
+            JOIN batch_jobs
+                ON batch_id=batch_jobs.id
+                AND username=? WHERE
                 test_results.progress<>100
             LIMIT 1
             ", undef, $username );
@@ -225,8 +225,8 @@ sub test_results {
     eval {
         my ( $hrefs ) = $dbh->selectall_hashref( "SELECT id, hash_id, creation_time at time zone current_setting('TIMEZONE') at time zone 'UTC' as creation_time, params, results FROM test_results WHERE hash_id=?", 'hash_id', undef, $test_id );
         $result            = $hrefs->{$test_id};
-        
-        # This workaround is needed to properly handle all versions of perl and the DBD::Pg module 
+
+        # This workaround is needed to properly handle all versions of perl and the DBD::Pg module
         # More details in the zonemaster backend issue #570
         if (utf8::is_utf8($result->{params}) ) {
                 $result->{params}  = decode_json( encode_utf8($result->{params}) );
@@ -234,7 +234,7 @@ sub test_results {
         else {
                 $result->{params}  = decode_json( $result->{params} );
         }
-        
+
         if (utf8::is_utf8($result->{results} ) ) {
                 $result->{results}  = decode_json( encode_utf8($result->{results}) );
         }
@@ -261,7 +261,7 @@ sub get_test_history {
 
     my @results;
     my $query = "
-        SELECT 
+        SELECT
             (SELECT count(*) FROM (SELECT json_array_elements(results) AS result) AS t1 WHERE result->>'level'='CRITICAL') AS nb_critical,
             (SELECT count(*) FROM (SELECT json_array_elements(results) AS result) AS t1 WHERE result->>'level'='ERROR') AS nb_error,
             (SELECT count(*) FROM (SELECT json_array_elements(results) AS result) AS t1 WHERE result->>'level'='WARNING') AS nb_warning,
@@ -269,8 +269,8 @@ sub get_test_history {
             hash_id,
             creation_time at time zone current_setting('TIMEZONE') at time zone 'UTC' as creation_time
         FROM test_results
-        WHERE params->>'domain'=" . $dbh->quote( $p->{frontend_params}->{domain} ) . " $undelegated 
-        ORDER BY id DESC 
+        WHERE params->>'domain'=" . $dbh->quote( $p->{frontend_params}->{domain} ) . " $undelegated
+        ORDER BY id DESC
         OFFSET $p->{offset} LIMIT $p->{limit}";
     my $sth1 = $dbh->prepare( $query );
     $sth1->execute;
@@ -322,7 +322,7 @@ sub add_batch_job {
         $dbh->do( "DROP INDEX IF EXISTS test_results__batch_id_progress" );
         $dbh->do( "DROP INDEX IF EXISTS test_results__progress" );
         $dbh->do( "DROP INDEX IF EXISTS test_results__domain_undelegated" );
-        
+
         $dbh->do( "COPY test_results(batch_id, priority, queue, params_deterministic_hash, params) FROM STDIN" );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
@@ -338,7 +338,7 @@ sub add_batch_job {
         $dbh->do( "CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)" );
         $dbh->do( "CREATE INDEX test_results__progress ON test_results (progress)" );
         $dbh->do( "CREATE INDEX test_results__domain_undelegated ON test_results ((params->>'domain'), (params->>'undelegated'))" );
-        
+
         $dbh->commit();
     }
     else {

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -302,8 +302,6 @@ sub add_batch_job {
     my $batch_id;
 
     my $dbh = $self->dbh;
-    my $js = JSON::PP->new;
-    $js->canonical( 1 );
 
     if ( $self->user_authorized( $params->{username}, $params->{api_key} ) ) {
         $batch_id = $self->create_new_batch_job( $params->{username} );
@@ -324,8 +322,7 @@ sub add_batch_job {
         $dbh->do( "COPY test_results(batch_id, priority, queue, params_deterministic_hash, params) FROM STDIN" );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
-            my $encoded_params = $js->encode( $test_params );
-            my $fingerprint    = md5_hex( encode_utf8( $encoded_params ) );
+            my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
 
             $dbh->pg_putcopydata("$batch_id\t$priority\t$queue_label\t$fingerprint\t$encoded_params\n");
         }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -168,10 +168,8 @@ sub create_new_test {
     my $dbh = $self->dbh;
 
     $test_params->{domain} = $domain;
-    my $js = JSON::PP->new;
-    $js->canonical( 1 );
-    my $encoded_params = $js->encode( $test_params );
-    my $fingerprint    = md5_hex( encode_utf8( $encoded_params ) );
+
+    my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
 
     my $priority    = $test_params->{priority};
     my $queue_label = $test_params->{queue};

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -6,7 +6,6 @@ use Moose;
 use 5.14.2;
 
 use DBI qw(:utils);
-use Digest::MD5 qw(md5_hex);
 use Encode;
 use JSON::PP;
 

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -168,7 +168,8 @@ sub create_new_test {
 
     $test_params->{domain} = $domain;
 
-    my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
+    my $encoded_params = $self->encode_normalized_params( $test_params );
+    my $fingerprint = $self->generate_fingerprint( $encoded_params );
 
     my $priority    = $test_params->{priority};
     my $queue_label = $test_params->{queue};
@@ -321,7 +322,9 @@ sub add_batch_job {
         $dbh->do( "COPY test_results(batch_id, priority, queue, params_deterministic_hash, params) FROM STDIN" );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
-            my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
+
+            my $encoded_params = $self->encode_normalized_params( $test_params );
+            my $fingerprint = $self->generate_fingerprint( $encoded_params );
 
             $dbh->pg_putcopydata("$batch_id\t$priority\t$queue_label\t$fingerprint\t$encoded_params\n");
         }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -168,8 +168,8 @@ sub create_new_test {
 
     $test_params->{domain} = $domain;
 
-    my $encoded_params = $self->encode_normalized_params( $test_params );
-    my $fingerprint = $self->generate_fingerprint( $encoded_params );
+    my $fingerprint = $self->generate_fingerprint( $test_params );
+    my $encoded_params = $self->encode_params( $test_params );
 
     my $priority    = $test_params->{priority};
     my $queue_label = $test_params->{queue};
@@ -323,8 +323,8 @@ sub add_batch_job {
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
 
-            my $encoded_params = $self->encode_normalized_params( $test_params );
-            my $fingerprint = $self->generate_fingerprint( $encoded_params );
+            my $fingerprint = $self->generate_fingerprint( $test_params );
+            my $encoded_params = $self->encode_params( $test_params );
 
             $dbh->pg_putcopydata("$batch_id\t$priority\t$queue_label\t$fingerprint\t$encoded_params\n");
         }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -173,8 +173,8 @@ sub create_new_test {
 
     $test_params->{domain} = $domain;
 
-    my $encoded_params = $self->encode_normalized_params( $test_params );
-    my $fingerprint = $self->generate_fingerprint( $encoded_params );
+    my $fingerprint = $self->generate_fingerprint( $test_params );
+    my $encoded_params = $self->encode_params( $test_params );
 
     my $result_id;
 
@@ -346,8 +346,8 @@ sub add_batch_job {
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
 
-            my $encoded_params = $self->encode_normalized_params( $test_params );
-            my $fingerprint = $self->generate_fingerprint( $encoded_params );
+            my $fingerprint = $self->generate_fingerprint( $test_params );
+            my $encoded_params = $self->encode_params( $test_params );
 
             $sth->execute( substr(md5_hex(time().rand()), 0, 16), $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params );
         }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -139,7 +139,7 @@ sub user_authorized {
 
     my ( $id ) =
       $self->dbh->selectrow_array( q[SELECT id FROM users WHERE username = ? AND api_key = ?], undef, $user, $api_key );
-      
+
     return $id;
 }
 
@@ -147,14 +147,14 @@ sub create_new_batch_job {
     my ( $self, $username ) = @_;
 
     my ( $batch_id, $creaton_time ) = $self->dbh->selectrow_array( "
-               SELECT 
-                    batch_id, 
-                    batch_jobs.creation_time AS batch_creation_time 
-               FROM 
-                    test_results 
-               JOIN batch_jobs 
-                    ON batch_id=batch_jobs.id 
-                    AND username=" . $self->dbh->quote( $username ) . " WHERE 
+               SELECT
+                    batch_id,
+                    batch_jobs.creation_time AS batch_creation_time
+               FROM
+                    test_results
+               JOIN batch_jobs
+                    ON batch_id=batch_jobs.id
+                    AND username=" . $self->dbh->quote( $username ) . " WHERE
                     test_results.progress<>100
                LIMIT 1
                " );
@@ -247,7 +247,7 @@ sub get_test_params {
     eval {
         $result = decode_json( $params_json );
     };
-    
+
     $log->warn( "decoding of params_json failed (test_id: [$test_id]):".Dumper($params_json) ) if $@;
 
     return $result;
@@ -289,7 +289,7 @@ sub get_test_history {
                     hash_id,
                     creation_time,
                     params,
-                    results   
+                    results
                  FROM
                     test_results
                  WHERE
@@ -343,7 +343,7 @@ sub add_batch_job {
         eval {$dbh->do( "DROP INDEX IF EXISTS test_results__batch_id_progress " );};
         eval {$dbh->do( "DROP INDEX IF EXISTS test_results__progress " );};
         eval {$dbh->do( "DROP INDEX IF EXISTS test_results__domain_undelegated " );};
-        
+
         my $sth = $dbh->prepare( 'INSERT INTO test_results (hash_id, domain, batch_id, priority, queue, params_deterministic_hash, params) VALUES (?, ?, ?, ?, ?, ?, ?) ' );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
@@ -357,7 +357,7 @@ sub add_batch_job {
         $dbh->do( "CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)" );
         $dbh->do( "CREATE INDEX test_results__progress ON test_results (progress)" );
         $dbh->do( "CREATE INDEX test_results__domain_undelegated ON test_results (domain, undelegated)" );
-       
+
         $dbh->commit();
         $dbh->{AutoCommit} = 1;
     }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -173,9 +173,9 @@ sub create_new_test {
     my $dbh = $self->dbh;
 
     $test_params->{domain} = $domain;
-    my $js             = JSON::PP->new->canonical;
-    my $encoded_params = $js->encode( $test_params );
-    my $fingerprint     = md5_hex( $encoded_params );
+
+    my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
+
     my $result_id;
 
     my $priority    = $test_params->{priority};

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -173,9 +173,9 @@ sub create_new_test {
     my $dbh = $self->dbh;
 
     $test_params->{domain} = $domain;
-    my $js                             = JSON::PP->new->canonical;
-    my $encoded_params                 = $js->encode( $test_params );
-    my $test_params_deterministic_hash = md5_hex( $encoded_params );
+    my $js             = JSON::PP->new->canonical;
+    my $encoded_params = $js->encode( $test_params );
+    my $fingerprint     = md5_hex( $encoded_params );
     my $result_id;
 
     my $priority    = $test_params->{priority};
@@ -186,7 +186,7 @@ sub create_new_test {
     my ( $recent_hash_id ) = $dbh->selectrow_array(
         "SELECT hash_id FROM test_results WHERE params_deterministic_hash = ? AND test_start_time > DATETIME('now', ?)",
         undef,
-        $test_params_deterministic_hash,
+        $fingerprint,
         "-$seconds seconds"
     );
 
@@ -209,7 +209,7 @@ sub create_new_test {
             $batch_id,
             $priority,
             $queue_label,
-            $test_params_deterministic_hash,
+            $fingerprint,
             $encoded_params,
             $test_params->{domain},
             ($test_params->{nameservers})?(1):(0),
@@ -347,10 +347,10 @@ sub add_batch_job {
         my $sth = $dbh->prepare( 'INSERT INTO test_results (hash_id, domain, batch_id, priority, queue, params_deterministic_hash, params) VALUES (?, ?, ?, ?, ?, ?, ?) ' );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
-            my $encoded_params                 = $js->encode( $test_params );
-            my $test_params_deterministic_hash = md5_hex( encode_utf8( $encoded_params ) );
+            my $encoded_params = $js->encode( $test_params );
+            my $fingerprint    = md5_hex( encode_utf8( $encoded_params ) );
 
-            $sth->execute( substr(md5_hex(time().rand()), 0, 16), $test_params->{domain}, $batch_id, $priority, $queue_label, $test_params_deterministic_hash, $encoded_params );
+            $sth->execute( substr(md5_hex(time().rand()), 0, 16), $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params );
         }
         $dbh->do( "CREATE INDEX test_results__hash_id ON test_results (hash_id, creation_time)" );
         $dbh->do( "CREATE INDEX test_results__params_deterministic_hash ON test_results (params_deterministic_hash)" );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -8,7 +8,6 @@ use 5.14.2;
 use Data::Dumper;
 use DBI qw(:utils);
 use Digest::MD5 qw(md5_hex);
-use Encode;
 use JSON::PP;
 use Log::Any qw( $log );
 

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -327,8 +327,6 @@ sub add_batch_job {
     my $batch_id;
 
     my $dbh = $self->dbh;
-    my $js = JSON::PP->new;
-    $js->canonical( 1 );
 
     if ( $self->user_authorized( $params->{username}, $params->{api_key} ) ) {
         $batch_id = $self->create_new_batch_job( $params->{username} );
@@ -347,8 +345,7 @@ sub add_batch_job {
         my $sth = $dbh->prepare( 'INSERT INTO test_results (hash_id, domain, batch_id, priority, queue, params_deterministic_hash, params) VALUES (?, ?, ?, ?, ?, ?, ?) ' );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
-            my $encoded_params = $js->encode( $test_params );
-            my $fingerprint    = md5_hex( encode_utf8( $encoded_params ) );
+            my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
 
             $sth->execute( substr(md5_hex(time().rand()), 0, 16), $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params );
         }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -173,7 +173,8 @@ sub create_new_test {
 
     $test_params->{domain} = $domain;
 
-    my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
+    my $encoded_params = $self->encode_normalized_params( $test_params );
+    my $fingerprint = $self->generate_fingerprint( $encoded_params );
 
     my $result_id;
 
@@ -344,7 +345,9 @@ sub add_batch_job {
         my $sth = $dbh->prepare( 'INSERT INTO test_results (hash_id, domain, batch_id, priority, queue, params_deterministic_hash, params) VALUES (?, ?, ?, ?, ?, ?, ?) ' );
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
-            my ( $fingerprint, $encoded_params ) = $self->generate_fingerprint( $test_params );
+
+            my $encoded_params = $self->encode_normalized_params( $test_params );
+            my $fingerprint = $self->generate_fingerprint( $encoded_params );
 
             $sth->execute( substr(md5_hex(time().rand()), 0, 16), $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params );
         }

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -382,11 +382,6 @@ sub start_domain_test {
 
         die "No domain in parameters\n" unless ( $params->{domain} );
 
-        if ($params->{config}) {
-            $params->{config} =~ s/[^\w_]//isg;
-            die "Unknown test configuration: [$params->{config}]\n" unless ( $self->{config}->GetCustomConfigParameter('ZONEMASTER', $params->{config}) );
-        }
-
         $params->{priority}  //= 10;
         $params->{queue}     //= 0;
 

--- a/t/db.t
+++ b/t/db.t
@@ -74,10 +74,23 @@ subtest 'encoding and fingerprint' => sub {
                 ],
                 domain => "example.com"
             );
+            my %params3 = (
+                domain => "example.com",
+                nameservers => [
+                    { ip => "", ns => "ns1.nic.fr" },
+                    { ns => "ns2.nic.fr", ip => "192.134.4.1" }
+                ]
+            );
+
             my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
             my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
+            my ( $encoded_params3, $fingerprint3 ) = encode_and_fingerprint( \%params3 );
+
             is $fingerprint1, $fingerprint2, 'nameservers: same fingerprint';
             is $encoded_params1, $encoded_params2, 'nameservers: same encoded string';
+
+            is $fingerprint1, $fingerprint3, 'nameservers: same fingerprint (empty ip)';
+            is $encoded_params1, $encoded_params3, 'nameservers: same encoded string (empty ip)';
         };
     };
 

--- a/t/db.t
+++ b/t/db.t
@@ -27,6 +27,54 @@ subtest 'encoding and fingerprint' => sub {
         is $fingerprint_ipv4, $fingerprint, 'fingerprints should match';
     };
 
+    subtest 'array properties' => sub {
+        subtest 'ds_info' => sub {
+            my %params1 = (
+                domain => "example.com",
+                ds_info => [{
+                    algorithm => 8,
+                    keytag => 11627,
+                    digtype => 2,
+                    digest => "a6cca9e6027ecc80ba0f6d747923127f1d69005fe4f0ec0461bd633482595448"
+                }]
+            );
+            my %params2 = (
+                ds_info => [{
+                    digtype => 2,
+                    algorithm => 8,
+                    keytag => 11627,
+                    digest => "a6cca9e6027ecc80ba0f6d747923127f1d69005fe4f0ec0461bd633482595448"
+                }],
+                domain => "example.com"
+            );
+            my ( $encoded_params1, $fingerprint1 ) = generate_fingerprint( \%params1 );
+            my ( $encoded_params2, $fingerprint2 ) = generate_fingerprint( \%params2 );
+            is $fingerprint1, $fingerprint2, 'ds_info same fingerprint';
+            is $encoded_params1, $encoded_params2, 'ds_info same encoded string';
+        };
+
+        subtest 'nameservers order' => sub {
+            my %params1 = (
+                domain => "example.com",
+                nameservers => [
+                    { ns => "ns2.nic.fr", ip => "192.134.4.1" },
+                    { ns => "ns1.nic.fr" }
+                ]
+            );
+            my %params2 = (
+                nameservers => [
+                    { ns => "ns1.nic.fr" },
+                    { ip => "192.134.4.1", ns => "ns2.nic.fr"}
+                ],
+                domain => "example.com"
+            );
+            my ( $encoded_params1, $fingerprint1 ) = generate_fingerprint( \%params1 );
+            my ( $encoded_params2, $fingerprint2 ) = generate_fingerprint( \%params2 );
+            is $fingerprint1, $fingerprint2, 'nameservers: same fingerprint';
+            is $encoded_params1, $encoded_params2, 'nameservers: same encoded string';
+        };
+    };
+
     subtest 'should be case insensitive' => sub {
         my %params1 = ( domain => "example.com" );
         my %params2 = ( domain => "eXamPLe.COm" );

--- a/t/db.t
+++ b/t/db.t
@@ -10,8 +10,8 @@ sub encode_and_fingerprint {
     my $params = shift;
 
     my $self = "Zonemaster::Backend::DB";
-    my $encoded_params = $self->encode_normalized_params( $params );
-    my $fingerprint = $self->generate_fingerprint( $encoded_params );
+    my $encoded_params = $self->encode_params( $params );
+    my $fingerprint = $self->generate_fingerprint( $params );
 
     return ( $encoded_params, $fingerprint );
 }
@@ -120,13 +120,19 @@ subtest 'encoding and fingerprint' => sub {
     };
 
     subtest 'garbage properties set' => sub {
-        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"priority":10,"profile":"default","queue":0}';
-        my %params = (
+        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"priority":10,"profile":"default","queue":0}';
+        my %params1 = (
+            domain => "example.com",
+        );
+        my %params2 = (
             domain => "example.com",
             client => "GUI v3.3.0"
         );
-        my ( $encoded_params, $fingerprint ) = encode_and_fingerprint( \%params );
-        is $encoded_params, $expected_encoded_params, 'leave out garbage property';
+        my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
+        my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
+
+        is $fingerprint1, $fingerprint2, 'leave out garbage property in fingerprint computation...';
+        is $encoded_params2, $expected_encoded_params, '...but keep it in the encoded string';
     };
 };
 

--- a/t/db.t
+++ b/t/db.t
@@ -81,16 +81,27 @@ subtest 'encoding and fingerprint' => sub {
                     { ns => "ns2.nic.fr", ip => "192.134.4.1" }
                 ]
             );
+            my %params4 = (
+                domain => "example.com",
+                nameservers => [
+                    { ip => "192.134.4.1", ns => "nS2.Nic.FR"},
+                    { ns => "Ns1.nIC.fR", ip => "" }
+                ]
+            );
 
             my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
             my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
             my ( $encoded_params3, $fingerprint3 ) = encode_and_fingerprint( \%params3 );
+            my ( $encoded_params4, $fingerprint4 ) = encode_and_fingerprint( \%params4 );
 
             is $fingerprint1, $fingerprint2, 'nameservers: same fingerprint';
             is $encoded_params1, $encoded_params2, 'nameservers: same encoded string';
 
             is $fingerprint1, $fingerprint3, 'nameservers: same fingerprint (empty ip)';
             is $encoded_params1, $encoded_params3, 'nameservers: same encoded string (empty ip)';
+
+            is $fingerprint1, $fingerprint4, 'nameservers: same fingerprint (ignore nameservers\' ns case)';
+            is $encoded_params1, $encoded_params4, 'nameservers: same encoded string (ignore nameservers\' ns case)';
         };
     };
 

--- a/t/db.t
+++ b/t/db.t
@@ -1,0 +1,51 @@
+use strict;
+use warnings;
+
+use Test::More;    # see done_testing()
+
+use_ok( 'Zonemaster::Backend::DB' );
+use_ok( 'JSON::PP' );
+
+sub generate_fingerprint {
+    return Zonemaster::Backend::DB::generate_fingerprint( undef, shift );
+}
+
+subtest 'encoding and fingerprint' => sub {
+
+    subtest 'missing properties' => sub {
+        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"priority":10,"profile":"default","queue":0}';
+
+        my %params = ( domain => "example.com" );
+
+        my ( $fingerprint, $encoded_params ) = generate_fingerprint( \%params );
+        is $encoded_params, $expected_encoded_params, 'domain only: the encoded strings should match';
+        #diag ($fingerprint);
+
+        $params{ipv4} = JSON::PP->true;
+        my ( $fingerprint_ipv4, $encoded_params_ipv4 ) = generate_fingerprint( \%params );
+        is $encoded_params_ipv4, $expected_encoded_params, 'add ipv4: the encoded strings should match';
+        is $fingerprint_ipv4, $fingerprint, 'fingerprints should match';
+    };
+
+    subtest 'should be case insensitive' => sub {
+        my %params1 = ( domain => "example.com" );
+        my %params2 = ( domain => "eXamPLe.COm" );
+
+        my ( $fingerprint1, $encoded_params1 ) = generate_fingerprint( \%params1 );
+        my ( $fingerprint2, $encoded_params2 ) = generate_fingerprint( \%params2 );
+        is $fingerprint1, $fingerprint2, 'same fingerprint';
+        is $encoded_params1, $encoded_params2, 'same encoded string';
+    };
+
+    subtest 'garbage properties set' => sub {
+        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"priority":10,"profile":"default","queue":0}';
+        my %params = (
+            domain => "example.com",
+            client => "GUI v3.3.0"
+        );
+        my ( $fingerprint, $encoded_params ) = generate_fingerprint( \%params );
+        is $encoded_params, $expected_encoded_params, 'leave out garbage property';
+    };
+};
+
+done_testing();

--- a/t/db.t
+++ b/t/db.t
@@ -64,11 +64,13 @@ subtest 'encoding and fingerprint' => sub {
                 domain => "example.com",
                 nameservers => [
                     { ns => "ns2.nic.fr", ip => "192.134.4.1" },
-                    { ns => "ns1.nic.fr" }
+                    { ns => "ns1.nic.fr" },
+                    { ip => "192.0.2.1", ns => "ns3.nic.fr"}
                 ]
             );
             my %params2 = (
                 nameservers => [
+                    { ns => "ns3.nic.fr", ip => "192.0.2.1" },
                     { ns => "ns1.nic.fr" },
                     { ip => "192.134.4.1", ns => "ns2.nic.fr"}
                 ],
@@ -78,6 +80,7 @@ subtest 'encoding and fingerprint' => sub {
                 domain => "example.com",
                 nameservers => [
                     { ip => "", ns => "ns1.nic.fr" },
+                    { ns => "ns3.nic.FR", ip => "192.0.2.1" },
                     { ns => "ns2.nic.fr", ip => "192.134.4.1" }
                 ]
             );
@@ -85,7 +88,8 @@ subtest 'encoding and fingerprint' => sub {
                 domain => "example.com",
                 nameservers => [
                     { ip => "192.134.4.1", ns => "nS2.Nic.FR"},
-                    { ns => "Ns1.nIC.fR", ip => "" }
+                    { ns => "Ns1.nIC.fR", ip => "" },
+                    { ns => "ns3.nic.fr", ip => "192.0.2.1" }
                 ]
             );
 

--- a/t/db.t
+++ b/t/db.t
@@ -6,8 +6,14 @@ use Test::More;    # see done_testing()
 use_ok( 'Zonemaster::Backend::DB' );
 use_ok( 'JSON::PP' );
 
-sub generate_fingerprint {
-    return Zonemaster::Backend::DB::generate_fingerprint( undef, shift );
+sub encode_and_fingerprint {
+    my $params = shift;
+
+    my $self = "Zonemaster::Backend::DB";
+    my $encoded_params = $self->encode_normalized_params( $params );
+    my $fingerprint = $self->generate_fingerprint( $encoded_params );
+
+    return ( $encoded_params, $fingerprint );
 }
 
 subtest 'encoding and fingerprint' => sub {
@@ -17,12 +23,12 @@ subtest 'encoding and fingerprint' => sub {
 
         my %params = ( domain => "example.com" );
 
-        my ( $fingerprint, $encoded_params ) = generate_fingerprint( \%params );
+        my ( $encoded_params, $fingerprint ) = encode_and_fingerprint( \%params );
         is $encoded_params, $expected_encoded_params, 'domain only: the encoded strings should match';
         #diag ($fingerprint);
 
         $params{ipv4} = JSON::PP->true;
-        my ( $fingerprint_ipv4, $encoded_params_ipv4 ) = generate_fingerprint( \%params );
+        my ( $encoded_params_ipv4, $fingerprint_ipv4 ) = encode_and_fingerprint( \%params );
         is $encoded_params_ipv4, $expected_encoded_params, 'add ipv4: the encoded strings should match';
         is $fingerprint_ipv4, $fingerprint, 'fingerprints should match';
     };
@@ -47,8 +53,8 @@ subtest 'encoding and fingerprint' => sub {
                 }],
                 domain => "example.com"
             );
-            my ( $encoded_params1, $fingerprint1 ) = generate_fingerprint( \%params1 );
-            my ( $encoded_params2, $fingerprint2 ) = generate_fingerprint( \%params2 );
+            my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
+            my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
             is $fingerprint1, $fingerprint2, 'ds_info same fingerprint';
             is $encoded_params1, $encoded_params2, 'ds_info same encoded string';
         };
@@ -68,8 +74,8 @@ subtest 'encoding and fingerprint' => sub {
                 ],
                 domain => "example.com"
             );
-            my ( $encoded_params1, $fingerprint1 ) = generate_fingerprint( \%params1 );
-            my ( $encoded_params2, $fingerprint2 ) = generate_fingerprint( \%params2 );
+            my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
+            my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
             is $fingerprint1, $fingerprint2, 'nameservers: same fingerprint';
             is $encoded_params1, $encoded_params2, 'nameservers: same encoded string';
         };
@@ -79,8 +85,8 @@ subtest 'encoding and fingerprint' => sub {
         my %params1 = ( domain => "example.com" );
         my %params2 = ( domain => "eXamPLe.COm" );
 
-        my ( $fingerprint1, $encoded_params1 ) = generate_fingerprint( \%params1 );
-        my ( $fingerprint2, $encoded_params2 ) = generate_fingerprint( \%params2 );
+        my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
+        my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
         is $fingerprint1, $fingerprint2, 'same fingerprint';
         is $encoded_params1, $encoded_params2, 'same encoded string';
     };
@@ -91,7 +97,7 @@ subtest 'encoding and fingerprint' => sub {
             domain => "example.com",
             client => "GUI v3.3.0"
         );
-        my ( $fingerprint, $encoded_params ) = generate_fingerprint( \%params );
+        my ( $encoded_params, $fingerprint ) = encode_and_fingerprint( \%params );
         is $encoded_params, $expected_encoded_params, 'leave out garbage property';
     };
 };

--- a/t/test01.t
+++ b/t/test01.t
@@ -157,6 +157,40 @@ is( scalar( @$test_history ), 2, 'Two tests created' );
 is( length($test_history->[0]->{id}), 16, 'Test 0 has 16 characters length hash ID' );
 is( length($test_history->[1]->{id}), 16, 'Test 1 has 16 characters length hash ID' );
 
+subtest 'mock another client' => sub {
+    $frontend_params_1->{client_id} = 'Another Client';
+    $frontend_params_1->{client_version} = '0.1';
+
+    my $hash_id = $engine->start_domain_test( $frontend_params_1 );
+    ok( $hash_id, "API start_domain_test OK" );
+    is( length($hash_id), 16, "Test has a 16 characters length hash ID (hash_id=$hash_id)" );
+
+    # check that we reuse one of the previous test
+    subtest 'check that previous test was reused' => sub {
+        my %ids = map { $_->{id} => 1 } @$test_history;
+        ok ( exists( $ids{$hash_id} ), "Has the same hash than previous test" );
+    };
+
+    subtest 'check test_params values' => sub {
+        my $res = $engine->get_test_params( { test_id => "$hash_id" } );
+        my @keys_res = sort( keys %$res );
+        my @keys_params = sort( keys %$frontend_params_1 );
+
+        is_deeply( \@keys_res, \@keys_params, "All keys are in database" );
+
+        foreach my $key (@keys_res) {
+            if ( $key eq "client_id" or $key eq "client_version" ) {
+                isnt( $frontend_params_1->{$key}, $res->{$key}, "but value for key '$key' is different (which is fine)" );
+            }
+            else {
+                is_deeply( $frontend_params_1->{$key}, $res->{$key}, "same value for key '$key'" );
+            }
+        }
+    };
+    #diag "...but values for client_id and client_version are different (which is fine)";
+
+};
+
 if ( $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->save_cache( $datafile );
 }


### PR DESCRIPTION
## Purpose

When we store a test in the database, we also store a fingerprint based on some criteria, that can be used to avoid running the same time in a short period of time.
This PR harmonizes the way we compute the fingerprint so that we can reuse tests that are similar, even if some properties are left out by the client.
This also normalize the value stored in the `params` database field.

## Context

As explained in #775, depending on the client used, some properties are used in the computation of the fingerprint or not. This PR solves this by always using the same properties (falling back to a default value if the property is not set).
Fixes #775

## Changes

* a first commit is only about removing trailing spaces and changing tabs into spaces (839f435)
* update variable name "deterministic hash" into "fingerprint"
* create new methods to normalize the parameters and to compute the fingerprint
* always include the same properties to compute the fingerprint, only the value will differ
* use default value if the property is not already set (`profile: default` and look into the profile to get the value for `ipv4 ` and `ipv6`)
* normalize the `params` object to a minimal set enlarged with extra values given by the client (such as `client_id` and `client_version`)

## Breaking change

Removal of the `config` property from the config file.
(TBH, this breaking change has not been introduced with this PR, however this PR removes the documentation associated with this property)

## How to test this PR

Unit tests are added with this PR. It is also possible to test using the scenario explained in #775 or by using the `get_test_params` API call.

Testing with the following test case allows to make sure the database is properly populated and that the behavior has not been altered (you may need to increase the `age_reuse_previous_test` value in the config while running the following tests).

1. Starting twice the same test should give the same test-id (the diff output should be empty):
    ```
    TESTID1=$(zmb start_domain_test --domain example.com | jq -r '.result')
    TESTID2=$(zmb start_domain_test --domain example.com | jq -r '.result')
    diff <(echo $TESTID1) <(echo $TESTID2)
    ```

2. Adding garbage option should give the same test-id:
    ```
    TESTID3=$(zmb start_domain_test --domain example.com --client-id "zmb" | jq -r '.result')
    diff <(echo $TESTID1) <(echo $TESTID3)
    ```

3. Adding nameservers without ip should give another test-id (the diff should give an error):
    ```
    TESTID4=$(zmb start_domain_test --domain example.com --nameserver a.example.com | jq -r '.result')
    diff <(echo $TESTID1) <(echo $TESTID4)
    ```

4. Adding ip to the nameserver should give another test-id (both diff should fail):
    ```
    TESTID5=$(zmb start_domain_test --domain example.com --nameserver a.example.com:192.0.2.1 | jq -r '.result')
    diff <(echo $TESTID1) <(echo $TESTID5)
    diff <(echo $TESTID4) <(echo $TESTID5)
    ```

5. Wait `age_reuse_previous_test` and run:
    ```
    TESTID6=$(zmb start_domain_test --domain example.com --client-id "my personal client" | jq -r '.result')
    TESTID7=$(zmb start_domain_test --domain example.com --client-id "another client" | jq -r '.result')
    diff <(echo $TESTID6) <(echo $TESTID7)
    ```

6. Finally output each test parameters and check that the values are correct
    ```
    zmb get_test_params --test-id $TESTID1
    zmb get_test_params --test-id $TESTID2
    zmb get_test_params --test-id $TESTID3  # should not contain any "client_id" property
    zmb get_test_params --test-id $TESTID4
    zmb get_test_params --test-id $TESTID5
    zmb get_test_params --test-id $TESTID6  # should have a "client_id" property set to "my personal client"
    zmb get_test_params --test-id $TESTID7  # should have a "client_id" property which is NOT "another client" but "my personal client"
    ```