### PR TITLE
Refactor locale validation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -181,11 +181,11 @@ The LANGUAGE section has one key, `locale`.
 
 ### locale
 
-Leaving the `locale` key empty or absent is *deprecated*. Always configure it
-with supported `locale tags`.
-
-A space separated list of `locale tags` where each tag matches the regular
-expression `/^[a-z]{2}_[A-Z]{2}$/`.
+A string matching one of the following descriptions:
+* A space separated list of one or more `locale tags` where each tag matches the
+  regular expression `/^[a-z]{2}_[A-Z]{2}$/`.
+* The empty string. **Deprecated**, remove the LANGUAGE.locale entry or specify
+  LANGUAGE.locale = en_US instead.
 
 It is an error to repeat the same `locale tag`.
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -187,7 +187,7 @@ sub parse {
     }
     if ( defined( my $value = $ini->val( 'LANGUAGE', 'locale' ) ) ) {
         if ( $value eq "" ) {
-            push @warnings, "Use of empty LANGUAGE.locale propery is deprecated. Remove the LANGUAGE.locale entry or specify LANGUAGE.locale = en_US instead.";
+            push @warnings, "Use of empty LANGUAGE.locale property is deprecated. Remove the LANGUAGE.locale entry or specify LANGUAGE.locale = en_US instead.";
         }
     }
     if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_professes_for_frontend_testing' ) ) ) {

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -187,7 +187,7 @@ sub parse {
     }
     if ( defined( my $value = $ini->val( 'LANGUAGE', 'locale' ) ) ) {
         if ( $value eq "" ) {
-            push @warnings, "Use of empty LANGUAGE.locale propery is deprecated. Remove LANGUAGE.locale entry or specify LANUGAGE.locale = en_US instead.";
+            push @warnings, "Use of empty LANGUAGE.locale propery is deprecated. Remove the LANGUAGE.locale entry or specify LANGUAGE.locale = en_US instead.";
         }
     }
     if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_professes_for_frontend_testing' ) ) ) {

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -595,31 +595,6 @@ sub Language_Locale_hash {
     return %locale;
 }
 
-=head2 ListLanguageTags
-
-Read indirectly LANGUAGE.locale from the configuration (.ini) file
-and returns a list of valid language tags for RPCAPI. The list can
-be retrieved via an RPCAPI method.
-
-=head3 INPUT
-
-None
-
-=head3 RETURNS
-
-An array of valid language tags. The array is never empty.
-
-=cut
-
-sub ListLanguageTags {
-    my ($self) = @_;
-    my %locale = &Language_Locale_hash($self);
-    my @langtags;
-    foreach my $key (keys %locale) {
-        push @langtags, $key unless $locale{$key} eq 'NOT-UNIQUE';
-    }
-    return @langtags;
-}
 
 sub ReadProfilesInfo {
     my ($self) = @_;

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -576,47 +576,6 @@ UNITCHECK {
     _create_setter( '_set_ZONEMASTER_age_reuse_previous_test',                  '_ZONEMASTER_age_reuse_previous_test',                  \&untaint_strictly_positive_int );
 }
 
-=head2 Language_Locale_hash
-
-Read LANGUAGE.locale from the configuration (.ini) file and returns
-the valid language tags for RPCAPI. The incoming language tag
-from RPCAPI is compared to those. The language tags are mapped to
-locale setting value.
-
-=head3 INPUT
-
-None
-
-=head3 RETURNS
-
-A hash of valid language tags as keys with set locale value as value.
-The hash is never empty.
-
-=cut
-
-sub Language_Locale_hash {
-    # There is one special value to capture ambiguous (and therefore
-    # not permitted) translation language tags.
-    my ($self) = @_;
-    my @localetags = map { keys %{$_} } values %{ { $self->LANGUAGE_locale } };
-    my %locale;
-    foreach my $la (@localetags) {
-        (my $a) = split (/_/,$la); # $a is the language code only
-        my $lo = "$la.UTF-8";
-        # Set special value if the same language code is used more than once
-        # with different country codes.
-        if ( $locale{$a} and $locale{$a} ne $lo ) {
-            $locale{$a} = 'NOT-UNIQUE';
-        }
-        else {
-            $locale{$a} = $lo;
-        }
-        $locale{$la} = $lo;
-    }
-    return %locale;
-}
-
-
 sub ReadProfilesInfo {
     my ($self) = @_;
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -120,12 +120,18 @@ $json_schemas{get_language_tags} = joi->object->strict;
 sub get_language_tags {
     my ( $self ) = @_;
 
-    my %locale_tags = $self->{config}->Language_Locale_hash();
-    my @langtags;
-    foreach my $key (keys %locale_tags) {
-        push @langtags, $key unless $locale_tags{$key} eq 'NOT-UNIQUE';
+    my %locales = $self->{config}->LANGUAGE_locale;
+
+    my @lang_tags;
+    for my $lang ( sort keys %locales ) {
+        my @locale_tags = sort keys %{ $locales{$lang} };
+        if ( scalar @locale_tags == 1 ) {
+            push @lang_tags, $lang;
+        }
+        push @lang_tags, @locale_tags;
     }
-    return \@langtags;
+
+    return \@lang_tags;
 }
 
 $json_schemas{get_host_by_name} = joi->object->strict->props(
@@ -443,22 +449,33 @@ $json_schemas{get_test_results} = joi->object->strict->props(
 sub get_test_results {
     my ( $self, $params ) = @_;
 
+    my $language = $params->{language};
+
+    my %locales = $self->{config}->LANGUAGE_locale;
+
+    my $locale_tag;
+    if ( length $language == 2 ) {
+        if ( !exists $locales{$language} ) {
+            die "Undefined language string: '$language'\n";
+        }
+        elsif ( scalar keys %{ $locales{$language} } > 1 ) {
+            die "Language string not unique: '$language'\n";
+        }
+        ( $locale_tag ) = keys %{ $locales{$language} };
+    }
+    else {
+        if ( !exists $locales{substr $language, 0, 2}{$language} ) {
+            die "Undefined language string: '$language'\n";
+        }
+        $locale_tag = $language;
+    }
+
     my $result;
     my $translator;
     $translator = Zonemaster::Backend::Translator->new;
 
-    my %locale = $self->{config}->Language_Locale_hash();
-    if ( $locale{$params->{language}} ) {
-        if ( $locale{$params->{language}} eq 'NOT-UNIQUE') {
-            die "Language string not unique: '$params->{language}'\n";
-        }
-    }
-    else {
-        die "Undefined language string: '$params->{language}'\n";
-    }
-
     my $previous_locale = $translator->locale;
-    $translator->locale( $locale{$params->{language}} );
+    $translator->locale( $locale_tag );
 
     eval { $translator->data } if $translator;    # Provoke lazy loading of translation data
 
@@ -479,7 +496,7 @@ sub get_test_results {
             }
 
             $res->{module} = $test_res->{module};
-            $res->{message} = $translator->translate_tag( $test_res, $params->{language} ) . "\n";
+            $res->{message} = $translator->translate_tag( $test_res, $locale_tag ) . "\n";
             $res->{message} =~ s/,/, /isg;
             $res->{message} =~ s/;/; /isg;
             $res->{level} = $test_res->{level};

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -120,9 +120,12 @@ $json_schemas{get_language_tags} = joi->object->strict;
 sub get_language_tags {
     my ( $self ) = @_;
 
-    my @lang = $self->{config}->ListLanguageTags();
-
-    return \@lang;
+    my %locale_tags = $self->{config}->Language_Locale_hash();
+    my @langtags;
+    foreach my $key (keys %locale_tags) {
+        push @langtags, $key unless $locale_tags{$key} eq 'NOT-UNIQUE';
+    }
+    return \@langtags;
 }
 
 $json_schemas{get_host_by_name} = joi->object->strict->props(

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -20,6 +20,7 @@ our @EXPORT_OK = qw(
   untaint_ipv6_address
   untaint_host
   untaint_ldh_domain
+  untaint_locale_tag
   untaint_mariadb_database
   untaint_mariadb_user
   untaint_non_negative_int
@@ -39,6 +40,7 @@ our %EXPORT_TAGS = (
           untaint_ipv6_address
           untaint_host
           untaint_ldh_domain
+          untaint_locale_tag
           untaint_mariadb_database
           untaint_mariadb_user
           untaint_non_negative_int
@@ -66,6 +68,7 @@ Readonly my $JSONRPC_METHOD_RE          => qr/^[a-z0-9_-]*$/i;
 Readonly my $LANGUAGE_RE                => qr/^[a-z]{2}(_[A-Z]{2})?$/;
 Readonly my $LDH_DOMAIN_RE1             => qr{^[a-z0-9-.]{1,253}[.]?$}i;
 Readonly my $LDH_DOMAIN_RE2             => qr{^(?:[.]|[^.]{1,63}(?:[.][^.]{1,63})*[.]?)$};
+Readonly my $LOCALE_TAG_RE              => qr/^[a-z]{2}_[A-Z]{2}$/;
 Readonly my $MARIADB_DATABASE_LENGTH_RE => qr/^.{1,64}$/;
 
 # See: https://mariadb.com/kb/en/identifier-names/#unquoted
@@ -259,6 +262,17 @@ Accepts an LDH domain name.
 sub untaint_ldh_domain {
     my ( $value ) = @_;
     return _untaint_pat( $value, $LDH_DOMAIN_RE1, $LDH_DOMAIN_RE2 );
+}
+
+=head2 untaint_locale_tag
+
+Accepts a locale tag.
+
+=cut
+
+sub untaint_locale_tag {
+    my ( $value ) = @_;
+    return _untaint_pat( $value, $LOCALE_TAG_RE );
 }
 
 sub untaint_mariadb_database {

--- a/t/config.t
+++ b/t/config.t
@@ -97,6 +97,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest 'Deprecated values and fallbacks when DB.engine = MySQL' => sub {
+        $log->clear();
         my $text = q{
             [DB]
             engine        = MySQL
@@ -117,6 +118,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest 'Deprecated values and fallbacks when DB.engine = PostgreSQL' => sub {
+        $log->clear();
         my $text = q{
             [DB]
             engine        = PostgreSQL
@@ -137,6 +139,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest 'Deprecated values and fallbacks when DB.engine = SQLite' => sub {
+        $log->clear();
         my $text = q{
             [DB]
             engine        = SQLite
@@ -154,6 +157,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest 'Deprecated values and fallbacks that are unconditional' => sub {
+        $log->clear();
         my $text = q{
             [DB]
             engine = SQLite
@@ -174,6 +178,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest 'Warnings' => sub {
+        $log->clear();
         my $text = q{
             [DB]
             engine = MySQL

--- a/t/config.t
+++ b/t/config.t
@@ -17,7 +17,7 @@ subtest 'Everything but NoWarnings' => sub {
 
     use_ok( 'Zonemaster::Backend::Config' );
 
-    lives_and {
+    subtest 'Set values' => sub {
         my $text = q{
             [DB]
             engine           = sqlite
@@ -75,7 +75,7 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->ZONEMASTER_age_reuse_previous_test,                  800,  'set: ZONEMASTER.age_reuse_previous_test';
     };
 
-    lives_and {
+    subtest 'Default values' => sub {
         my $text = q{
             [DB]
             engine = SQLite
@@ -96,7 +96,7 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->ZONEMASTER_age_reuse_previous_test,                  600, 'default: ZONEMASTER.age_reuse_previous_test';
     };
 
-    lives_and {
+    subtest 'Deprecated values and fallbacks when DB.engine = MySQL' => sub {
         my $text = q{
             [DB]
             engine        = MySQL
@@ -116,7 +116,7 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->MYSQL_database, 'db_database', 'fallback: MYSQL.database';
     };
 
-    lives_and {
+    subtest 'Deprecated values and fallbacks when DB.engine = PostgreSQL' => sub {
         my $text = q{
             [DB]
             engine        = PostgreSQL
@@ -136,7 +136,7 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->POSTGRESQL_database, 'db_database', 'fallback: POSTGRESQL.database';
     };
 
-    lives_and {
+    subtest 'Deprecated values and fallbacks when DB.engine = SQLite' => sub {
         my $text = q{
             [DB]
             engine        = SQLite
@@ -153,7 +153,7 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->SQLITE_database_file, '/var/db/zonemaster.sqlite', 'fallback: SQLITE.database_file';
     };
 
-    lives_and {
+    subtest 'Deprecated values and fallbacks that are unconditional' => sub {
         my $text = q{
             [DB]
             engine = SQLite
@@ -173,7 +173,7 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->ZONEMASTER_number_of_processes_for_batch_testing,    '22', 'fallback: ZONEMASTER.number_of_processes_for_batch_testing';
     };
 
-    lives_and {
+    subtest 'Warnings' => sub {
         my $text = q{
             [DB]
             engine = MySQL

--- a/t/config.t
+++ b/t/config.t
@@ -4,6 +4,7 @@ use utf8;
 
 use Test::More tests => 2;
 use Test::NoWarnings;
+use Test::Differences;
 use Test::Exception;
 use Log::Any::Test;    # Must come before use Log::Any
 
@@ -39,6 +40,9 @@ subtest 'Everything but NoWarnings' => sub {
             [SQLITE]
             database_file = /var/db/zonemaster.sqlite
 
+            [LANGUAGE]
+            locale = sv_FI
+
             [ZONEMASTER]
             max_zonemaster_execution_time            = 1200
             number_of_processes_for_frontend_testing = 30
@@ -49,25 +53,26 @@ subtest 'Everything but NoWarnings' => sub {
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
         isa_ok $config, 'Zonemaster::Backend::Config', 'parse() return value';
-        is $config->DB_engine,                                           'SQLite',                    'set: DB.engine';
-        is $config->DB_polling_interval,                                 1.5,                         'set: DB.polling_interval';
-        is $config->MYSQL_host,                                          'mysql-host',                'set: MYSQL.host';
-        is $config->MYSQL_port,                                          3456,                        'set: MYSQL.port';
-        is $config->MYSQL_user,                                          'mysql_user',                'set: MYSQL.user';
-        is $config->MYSQL_password,                                      'mysql_password',            'set: MYSQL.password';
-        is $config->MYSQL_database,                                      'mysql_database',            'set: MYSQL.database';
-        is $config->POSTGRESQL_host,                                     'postgresql-host',           'set: POSTGRESQL.host';
-        is $config->POSTGRESQL_port,                                     6543,                        'set: POSTGRESQL.port';
-        is $config->POSTGRESQL_user,                                     'postgresql_user',           'set: POSTGRESQL.user';
-        is $config->POSTGRESQL_password,                                 'postgresql_password',       'set: POSTGRESQL.password';
-        is $config->POSTGRESQL_database,                                 'postgresql_database',       'set: POSTGRESQL.database';
-        is $config->SQLITE_database_file,                                '/var/db/zonemaster.sqlite', 'set: SQLITE.database_file';
-        is $config->ZONEMASTER_max_zonemaster_execution_time,            1200,                        'set: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->ZONEMASTER_maximal_number_of_retries,                2,                           'set: ZONEMASTER.maximal_number_of_retries';
-        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 30,                          'set: ZONEMASTER.number_of_processes_for_frontend_testing';
-        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    40,                          'set: ZONEMASTER.number_of_processes_for_batch_testing';
-        is $config->ZONEMASTER_lock_on_queue,                            1,                           'set: ZONEMASTER.lock_on_queue';
-        is $config->ZONEMASTER_age_reuse_previous_test,                  800,                         'set: ZONEMASTER.age_reuse_previous_test';
+        is $config->DB_engine,            'SQLite',                    'set: DB.engine';
+        is $config->DB_polling_interval,  1.5,                         'set: DB.polling_interval';
+        is $config->MYSQL_host,           'mysql-host',                'set: MYSQL.host';
+        is $config->MYSQL_port,           3456,                        'set: MYSQL.port';
+        is $config->MYSQL_user,           'mysql_user',                'set: MYSQL.user';
+        is $config->MYSQL_password,       'mysql_password',            'set: MYSQL.password';
+        is $config->MYSQL_database,       'mysql_database',            'set: MYSQL.database';
+        is $config->POSTGRESQL_host,      'postgresql-host',           'set: POSTGRESQL.host';
+        is $config->POSTGRESQL_port,      6543,                        'set: POSTGRESQL.port';
+        is $config->POSTGRESQL_user,      'postgresql_user',           'set: POSTGRESQL.user';
+        is $config->POSTGRESQL_password,  'postgresql_password',       'set: POSTGRESQL.password';
+        is $config->POSTGRESQL_database,  'postgresql_database',       'set: POSTGRESQL.database';
+        is $config->SQLITE_database_file, '/var/db/zonemaster.sqlite', 'set: SQLITE.database_file';
+        eq_or_diff { $config->LANGUAGE_locale }, { sv => { sv_FI => 1 } }, 'set: LANGUAGE.locale';
+        is $config->ZONEMASTER_max_zonemaster_execution_time,            1200, 'set: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->ZONEMASTER_maximal_number_of_retries,                2,    'set: ZONEMASTER.maximal_number_of_retries';
+        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 30,   'set: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    40,   'set: ZONEMASTER.number_of_processes_for_batch_testing';
+        is $config->ZONEMASTER_lock_on_queue,                            1,    'set: ZONEMASTER.lock_on_queue';
+        is $config->ZONEMASTER_age_reuse_previous_test,                  800,  'set: ZONEMASTER.age_reuse_previous_test';
     };
 
     lives_and {
@@ -80,14 +85,15 @@ subtest 'Everything but NoWarnings' => sub {
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
         cmp_ok abs( $config->DB_polling_interval - 0.5 ), '<', 0.000001, 'default: DB.polling_interval';
-        is $config->ZONEMASTER_max_zonemaster_execution_time,            600,  'default: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->ZONEMASTER_maximal_number_of_retries,                0,    'default: ZONEMASTER.maximal_number_of_retries';
-        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 20,   'default: ZONEMASTER.number_of_processes_for_frontend_testing';
-        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    20,   'default: ZONEMASTER.number_of_processes_for_batch_testing';
-        is $config->ZONEMASTER_lock_on_queue,                            0,    'default: ZONEMASTER.lock_on_queue';
-        is $config->ZONEMASTER_age_reuse_previous_test,                  600,  'default: ZONEMASTER.age_reuse_previous_test';
-        is $config->MYSQL_port,                                          3306, 'default: MYSQL.port';
-        is $config->POSTGRESQL_port,                                     5432, 'default: POSTGRESQL.port';
+        is $config->MYSQL_port,      3306, 'default: MYSQL.port';
+        is $config->POSTGRESQL_port, 5432, 'default: POSTGRESQL.port';
+        eq_or_diff { $config->LANGUAGE_locale }, { en => { en_US => 1 } }, 'default: LANGUAGE.locale';
+        is $config->ZONEMASTER_max_zonemaster_execution_time,            600, 'default: ZONEMASTER.max_zonemaster_execution_time';
+        is $config->ZONEMASTER_maximal_number_of_retries,                0,   'default: ZONEMASTER.maximal_number_of_retries';
+        is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
+        is $config->ZONEMASTER_number_of_processes_for_batch_testing,    20,  'default: ZONEMASTER.number_of_processes_for_batch_testing';
+        is $config->ZONEMASTER_lock_on_queue,                            0,   'default: ZONEMASTER.lock_on_queue';
+        is $config->ZONEMASTER_age_reuse_previous_test,                  600, 'default: ZONEMASTER.age_reuse_previous_test';
     };
 
     lives_and {
@@ -153,6 +159,8 @@ subtest 'Everything but NoWarnings' => sub {
             engine = SQLite
             [SQLITE]
             database_file = /var/db/zonemaster.sqlite
+            [LANGUAGE]
+            locale =
             [ZONEMASTER]
             number_of_professes_for_frontend_testing = 21
             number_of_professes_for_batch_testing    = 22
@@ -160,6 +168,7 @@ subtest 'Everything but NoWarnings' => sub {
         my $config = Zonemaster::Backend::Config->parse( $text );
         $log->contains_ok( qr/deprecated.*ZONEMASTER\.number_of_professes_for_frontend_testing/, 'deprecated: ZONEMASTER.number_of_professes_for_frontend_testing' );
         $log->contains_ok( qr/deprecated.*ZONEMASTER\.number_of_professes_for_batch_testing/,    'deprecated: ZONEMASTER.number_of_professes_for_batch_testing' );
+        $log->contains_ok( qr/deprecated.*LANGUAGE\.locale/,                                     'deprecated empty LANGUAGE.locale' );
         is $config->ZONEMASTER_number_of_processes_for_frontend_testing, '21', 'fallback: ZONEMASTER.number_of_processes_for_frontend_testing';
         is $config->ZONEMASTER_number_of_processes_for_batch_testing,    '22', 'fallback: ZONEMASTER.number_of_processes_for_batch_testing';
     };

--- a/t/validator.t
+++ b/t/validator.t
@@ -81,6 +81,13 @@ subtest 'Everything but NoWarnings' => sub {
         ok !tainted( untaint_ldh_domain( taint( 'localhost' ) ) ), 'launder taint';
     };
 
+    subtest 'untaint_locale_tag' => sub {
+        is scalar untaint_locale_tag( 'en_US' ),   'en_US', 'accept: en_US';
+        is scalar untaint_locale_tag( 'en' ),      undef,   'reject: en';
+        is scalar untaint_locale_tag( 'English' ), undef,   'reject: English';
+        ok !tainted( untaint_locale_tag( taint( 'en_US' ) ) ), 'launder taint';
+    };
+
     subtest 'untaint_mariadb_database' => sub {
         is scalar untaint_mariadb_database( 'zonemaster' ),    'zonemaster',  'accept: zonemaster';
         is scalar untaint_mariadb_database( 'ZONEMASTER' ),    'ZONEMASTER',  'accept: ZONEMASTER';


### PR DESCRIPTION
## Purpose

This PR refactors the implementation of LANGUAGE.locale.

## Context

This PR extends the use of patterns for API and validation introduced in #759 and #757 to also cover the LANGUAGE.locale property.

These changes were developed in parallel with #759 and #757 as part of resolving #685. These changes are not part for solving in a technical sense, because the validations were already there. But they are in an architectural sense because they make the Config module interface more cohesive. These changes also played an important role when designing the new Config module interface, its internal structure and the new validation framework.

## Changes

The methods Language_Locale_hash() and ListLanguageTags() are replaced by the LANGUAGE_locale() getter.
Call sites are updated to use the new getter instead.

The internal representation of the LANGUAGE.locale property within the Config is updated to reflect a little more of its structure as described in the configuration documentation.

The assignment of the default value for LANGUAGE.locale is placed together with the other properties.

## How to test this PR

This PR is a pure refactoring so it should not affect any functionality, and it does add a few new tests at the unit level. That said it modifies code used by the `get_language_tags` and `get_test_results` RPC-API methods and we don't have any automatic tests for those.