### PR TITLE
Validate profiles

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -10,6 +10,7 @@ made to the `backend_config.ini` file.
 
 The `backend_config.ini` file uses a file format in the INI family that is
 described in detail [here][File format].
+Repeating a key name in one section is forbidden.
 
 Each section in `backend_config.ini` is documented below.
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -767,7 +767,19 @@ sub _reset_LANGUAGE_locale {
 sub _add_public_profile {
     my ( $self, $name, $path ) = @_;
 
+    $name = untaint_profile_name( $name )    #
+      // die "Invalid profile name in PUBLIC PROFILES section: $name\n";
+
     $name = lc $name;
+
+    if ( defined $self->{_public_profiles}{$name} || exists $self->{_private_profiles}{$name} ) {
+        die "Profile name not unique: $name\n";
+    }
+
+    if ( defined $path ) {
+        $path = untaint_abs_path( $path )    #
+          // die "Path must be absolute for profile: $name\n";
+    }
 
     $self->{_public_profiles}{$name} = $path;
     return;
@@ -776,7 +788,21 @@ sub _add_public_profile {
 sub _add_private_profile {
     my ( $self, $name, $path ) = @_;
 
+    $name = untaint_profile_name( $name )    #
+      // die "Invalid profile name in PRIVATE PROFILES section: $name\n";
+
     $name = lc $name;
+
+    if ( $name eq 'default' ) {
+        die "Profile name must not be present in PRIVATE PROFILES section: $name\n";
+    }
+
+    if ( exists $self->{_public_profiles}{$name} || exists $self->{_private_profiles}{$name} ) {
+        die "Profile name not unique: $name\n";
+    }
+
+    $path = untaint_abs_path( $path )    #
+      // die "Path must be absolute for profile: $name\n";
 
     $self->{_private_profiles}{$name} = $path;
     return;

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -108,7 +108,10 @@ sub parse {
 
     my $get_and_clear = sub {    # Read and clear a property from a Config::IniFiles object.
         my ( $section, $param ) = @_;
-        my $value = $ini->val( $section, $param );
+        my ( $value, @extra ) = $ini->val( $section, $param );
+        if ( @extra ) {
+            die "Property not unique: $section.$param\n";
+        }
         $ini->delval( $section, $param );
         return $value;
     };

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -600,29 +600,6 @@ UNITCHECK {
     _create_setter( '_set_ZONEMASTER_age_reuse_previous_test',                  '_ZONEMASTER_age_reuse_previous_test',                  \&untaint_strictly_positive_int );
 }
 
-sub ReadProfilesInfo {
-    my ($self) = @_;
-
-    my $profiles;
-    foreach my $public_profile ( keys %{ $self->{_public_profiles} } ) {
-        $profiles->{$public_profile}->{type} = 'public';
-        $profiles->{$public_profile}->{profile_file_name} = $self->{_public_profiles}{$public_profile} // "";
-    }
-
-    foreach my $private_profile ( keys %{ $self->{_private_profiles} } ) {
-        $profiles->{$private_profile}->{type} = 'private';
-        $profiles->{$private_profile}->{profile_file_name} = $self->{_private_profiles}{$private_profile};
-    }
-
-    return $profiles;
-}
-
-sub ListPublicProfiles {
-    my ($self) = @_;
-
-    return keys %{ $self->{_public_profiles} };
-}
-
 =head2 new_DB
 
 Create a new database adapter object according to configuration.

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -295,6 +295,7 @@ sub validate_syntax {
         }
 
         if ( defined $syntax_input->{profile} ) {
+            $syntax_input->{profile} = lc $syntax_input->{profile};
             my %profiles = ( $self->{config}->PUBLIC_PROFILES, $self->{config}->PRIVATE_PROFILES );
             if ( !exists $profiles{ $syntax_input->{profile} } ) {
                 return { status => 'nok', message => encode_entities( "Unrecognized profile name" ) };

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -100,13 +100,13 @@ $json_schemas{profile_names} = joi->object->strict;
 sub profile_names {
     my ( $self ) = @_;
 
-    my @profiles;
-    eval { @profiles = $self->{config}->ListPublicProfiles() };
+    my %profiles;
+    eval { %profiles = $self->{config}->PUBLIC_PROFILES };
     if ( $@ ) {
         handle_exception( 'profile_names', $@, '004' );
     }
 
-    return \@profiles;
+    return [ keys %profiles ];
 }
 
 # Return the list of language tags supported by get_test_results(). The tags are
@@ -295,9 +295,10 @@ sub validate_syntax {
         }
 
         if ( defined $syntax_input->{profile} ) {
-            my @profiles = map lc, $self->{config}->ListPublicProfiles();
-            return { status => 'nok', message => encode_entities( "Invalid profile option format" ) }
-            unless ( grep { $_ eq lc $syntax_input->{profile} } @profiles );
+            my %profiles = $self->{config}->PUBLIC_PROFILES;
+            if ( !exists $profiles{ $syntax_input->{profile} } ) {
+                return { status => 'nok', message => encode_entities( "Unrecognized profile name" ) };
+            }
         }
 
         my ( undef, $dn_syntax ) = $self->_check_domain( $syntax_input->{domain}, 'Domain name' );

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -295,7 +295,7 @@ sub validate_syntax {
         }
 
         if ( defined $syntax_input->{profile} ) {
-            my %profiles = $self->{config}->PUBLIC_PROFILES;
+            my %profiles = ( $self->{config}->PUBLIC_PROFILES, $self->{config}->PRIVATE_PROFILES );
             if ( !exists $profiles{ $syntax_input->{profile} } ) {
                 return { status => 'nok', message => encode_entities( "Unrecognized profile name" ) };
             }

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -42,7 +42,6 @@ sub new {
     foreach my $name ( keys %all_profiles ) {
         my $path = $all_profiles{$name}{profile_file_name};
 
-        die "default profile cannot be private" if ( $name eq 'default' && $all_profiles{$name}{type} eq 'private' );
         my $full_profile = Zonemaster::Engine::Profile->default;
         if ( $path ne "" ) {
             my $json = eval { read_file( $path, err_mode => 'croak' ) }    #

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -38,12 +38,12 @@ sub new {
     my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
     $self->{_db} = $dbclass->from_config( $config );
 
-    my %all_profiles = %{ $config->ReadProfilesInfo() };
+    my %all_profiles = ( $config->PUBLIC_PROFILES, $config->PRIVATE_PROFILES );
     foreach my $name ( keys %all_profiles ) {
-        my $path = $all_profiles{$name}{profile_file_name};
+        my $path = $all_profiles{$name};
 
         my $full_profile = Zonemaster::Engine::Profile->default;
-        if ( $path ne "" ) {
+        if ( defined $path ) {
             my $json = eval { read_file( $path, err_mode => 'croak' ) }    #
               // die "Error loading profile '$name': $@";
             my $named_profile = eval { Zonemaster::Engine::Profile->from_json( $json ) }    #

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -26,6 +26,7 @@ our @EXPORT_OK = qw(
   untaint_non_negative_int
   untaint_password
   untaint_postgresql_ident
+  untaint_profile_name
   untaint_strictly_positive_int
   untaint_strictly_positive_millis
 );
@@ -46,6 +47,7 @@ our %EXPORT_TAGS = (
           untaint_non_negative_int
           untaint_password
           untaint_postgresql_ident
+          untaint_profile_name
           untaint_strictly_positive_int
           untaint_strictly_positive_millis
           )
@@ -308,6 +310,11 @@ sub untaint_postgresql_ident {
 sub untaint_non_negative_int {
     my ( $value ) = @_;
     return _untaint_pat( $value, $NON_NEGATIVE_INT_RE );
+}
+
+sub untaint_profile_name {
+    my ( $value ) = @_;
+    return _untaint_pat( $value, $PROFILE_NAME_RE );
 }
 
 sub _untaint_pat {

--- a/t/config.t
+++ b/t/config.t
@@ -43,6 +43,14 @@ subtest 'Everything but NoWarnings' => sub {
             [LANGUAGE]
             locale = sv_FI
 
+            [PUBLIC PROFILES]
+            default = /path/to/default.profile
+            two     = /path/to/two.profile
+
+            [PRIVATE PROFILES]
+            three = /path/to/three.profile
+            four  = /path/to/four.profile
+
             [ZONEMASTER]
             max_zonemaster_execution_time            = 1200
             number_of_processes_for_frontend_testing = 30
@@ -67,6 +75,16 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->POSTGRESQL_database,  'postgresql_database',       'set: POSTGRESQL.database';
         is $config->SQLITE_database_file, '/var/db/zonemaster.sqlite', 'set: SQLITE.database_file';
         eq_or_diff { $config->LANGUAGE_locale }, { sv => { sv_FI => 1 } }, 'set: LANGUAGE.locale';
+        eq_or_diff { $config->PUBLIC_PROFILES }, {    #
+            default => '/path/to/default.profile',
+            two     => '/path/to/two.profile'
+          },
+          'set: PUBLIC PROFILES';
+        eq_or_diff { $config->PRIVATE_PROFILES }, {    #
+            three => '/path/to/three.profile',
+            four  => '/path/to/four.profile'
+          },
+          'set: PRIVATE PROFILES';
         is $config->ZONEMASTER_max_zonemaster_execution_time,            1200, 'set: ZONEMASTER.max_zonemaster_execution_time';
         is $config->ZONEMASTER_maximal_number_of_retries,                2,    'set: ZONEMASTER.maximal_number_of_retries';
         is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 30,   'set: ZONEMASTER.number_of_processes_for_frontend_testing';
@@ -88,6 +106,8 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->MYSQL_port,      3306, 'default: MYSQL.port';
         is $config->POSTGRESQL_port, 5432, 'default: POSTGRESQL.port';
         eq_or_diff { $config->LANGUAGE_locale }, { en => { en_US => 1 } }, 'default: LANGUAGE.locale';
+        eq_or_diff { $config->PUBLIC_PROFILES }, { default => undef }, 'default: PUBLIC_PROFILES';
+        eq_or_diff { $config->PRIVATE_PROFILES }, {}, 'default: PRIVATE_PROFILES';
         is $config->ZONEMASTER_max_zonemaster_execution_time,            600, 'default: ZONEMASTER.max_zonemaster_execution_time';
         is $config->ZONEMASTER_maximal_number_of_retries,                0,   'default: ZONEMASTER.maximal_number_of_retries';
         is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
@@ -709,6 +729,118 @@ subtest 'Everything but NoWarnings' => sub {
         Zonemaster::Backend::Config->parse( $text );
     }
     qr/LANGUAGE\.locale.*en_US/, 'die: Repeated locale_tag in LANGUAGE.locale';
+
+    lives_and {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [PUBLIC PROFILES]
+            DEFAULT = /path/to/my.profile
+
+            [PRIVATE PROFILES]
+            SECRET = /path/to/my.profile
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+        eq_or_diff { $config->PUBLIC_PROFILES },  { default => '/path/to/my.profile' }, 'normalize profile names under PUBLIC PROFILES';
+        eq_or_diff { $config->PRIVATE_PROFILES }, { secret  => '/path/to/my.profile' }, 'normalize profile names under PRIVATE PROFILES';
+    };
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [PUBLIC PROFILES]
+            -invalid-name- = /path/to/my.profile
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/PUBLIC PROFILES.*-invalid-name-/, 'die: Invalid profile name in PUBLIC PROFILES';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [PRIVATE PROFILES]
+            -invalid-name- = /path/to/my.profile
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/PRIVATE PROFILES.*-invalid-name-/, 'die: Invalid profile name in PRIVATE PROFILES';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [PUBLIC PROFILES]
+            valid-name = relative/path/to/my.profile
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/absolute.*valid-name/, 'die: Invalid absolute path in PUBLIC PROFILES';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [PRIVATE PROFILES]
+            valid-name = relative/path/to/my.profile
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/absolute.*valid-name/, 'die: Invalid absolute path in PRIVATE PROFILES';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [PUBLIC PROFILES]
+            pub-and-priv = /path/to/my.profile
+
+            [PRIVATE PROFILES]
+            pub-and-priv = /path/to/my.profile
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/unique.*pub-and-priv/, 'die: Repeated profile name across sections';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [PRIVATE PROFILES]
+            default = /path/to/my.profile
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/PRIVATE PROFILES.*default/, 'die: Default profile in PRIVATE PROFILES';
 
     {
         my $path = catfile( dirname( $0 ), '..', 'share', 'backend_config.ini' );

--- a/t/config.t
+++ b/t/config.t
@@ -818,6 +818,38 @@ subtest 'Everything but NoWarnings' => sub {
             database_file = /var/db/zonemaster.sqlite
 
             [PUBLIC PROFILES]
+            valid-name = /path/to/my.profile
+            valid-name = /path/to/my.profile
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/unique.*valid-name/, 'die: Repeated profile name in PUBLIC PROFILES section';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [PRIVATE PROFILES]
+            valid-name = /path/to/my.profile
+            valid-name = /path/to/my.profile
+        };
+        Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/unique.*valid-name/, 'die: Repeated profile name in PRIVATE PROFILES section';
+
+    throws_ok {
+        my $text = q{
+            [DB]
+            engine = SQLite
+
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+
+            [PUBLIC PROFILES]
             pub-and-priv = /path/to/my.profile
 
             [PRIVATE PROFILES]

--- a/t/validator.t
+++ b/t/validator.t
@@ -152,6 +152,23 @@ subtest 'Everything but NoWarnings' => sub {
         ok !tainted( untaint_postgresql_ident( taint( 'zonemaster' ) ) ), 'launder taint';
     };
 
+    subtest 'untaint_profile_name' => sub {
+        is scalar untaint_profile_name( 'default' ),              'default',           'accept: default';
+        is scalar untaint_profile_name( '-leading-dash' ),        undef,               'reject: -leading-dash';
+        is scalar untaint_profile_name( 'trailing-dash-' ),       undef,               'reject: trailing-dash-';
+        is scalar untaint_profile_name( 'middle-dash' ),          'middle-dash',       'accept: middle-dash';
+        is scalar untaint_profile_name( '_leading_underscore' ),  undef,               'reject: _leading_underscore';
+        is scalar untaint_profile_name( 'trailing_underscore_' ), undef,               'reject: trailing_underscore_';
+        is scalar untaint_profile_name( 'middle_underscore' ),    'middle_underscore', 'accept: middle_underscore';
+        is scalar untaint_profile_name( '0-leading-digit' ),      '0-leading-digit',   'accept: 0-leading-digit';
+        is scalar untaint_profile_name( 'a' ),                    'a',                 'accept: a';
+        is scalar untaint_profile_name( '-' ),                    undef,               'reject dash';
+        is scalar untaint_profile_name( '_' ),                    undef,               'reject underscore';
+        is scalar untaint_profile_name( 'a' x 32 ), 'a' x 32, 'accept 32 characters';
+        is scalar untaint_profile_name( 'a' x 33 ), undef, 'reject 33 characters';
+        ok !tainted( untaint_profile_name( taint( 'default' ) ) ), 'launder taint';
+    };
+
     subtest 'untaint_non_negative_int' => sub {
         is scalar untaint_non_negative_int( '1' ),      '1',     'accept: 1';
         is scalar untaint_non_negative_int( '0' ),      '0',     'accept: 0';


### PR DESCRIPTION
## Purpose

This PR mainly does two things:
* It implements the validation rules already described the PUBLIC PROFILES and PRIVATE PROFILES sections.
* It fixes a bug that prevented the use of profiles in the PRIVATE PROFILES section. (#808)

## Context

This PR currently contains all the commits from #802. After that PR is merged this one will be rebased onto the develop branch.

This is the last leg of #685.

Fixes #808.

## Changes

This PR contains lots of tiny changes that update the same parts of the code. To understand the changes I recommend going through the changes commit by commit. When adding review comments, keep in mind that lines changed in an earlier commit may well be updated in a later commit.

* It adds getters for the validation of the PUBLIC PROFILES and PRIVATE PROFILES sections.
* It simplifies the internal representation of the profiles settings in the Config and RPCAPI modules.
* It moves some profile merging operation to load-time as opposed to performing them for each request.
* It adds unit tests for the validation rules.

## How to test this PR

### Verify that it's possible to specify a private profile in start_domain_test

Create an empty profile: `echo {} > /tmp/empty.profile`

Update the PRIVATE PROFILES section in your backend_config.ini:
```
[PRIVATE PROFILES]
private = /tmp/empty.profile
```

Restart zm-rpcapi and zm-testagent.

Run: `zmtest --profile private example.com`

Make sure that you get a test result.

### Verify that both zm-rpcapi and zm-testagent refuse to start if there is an invalidly named profile in the configuration

Update the PRIVATE PROFILES section in your backend_config.ini:
```
[PRIVATE PROFILES]
-invalid-name- = /tmp/empty.profile
```
Restart zm-rpcapi and zm-testagent and make sure that they refuse to come up. Also make sure that a log entries are written containing details of the errors.