### PR TITLE
Refactorings in preparation for validation of profile config properties

### DIFF
--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -266,7 +266,7 @@ sub parse {
     }
 
     $obj->{_public_profiles} = {
-        default => '',
+        default => undef,
     };
     for my $name ( $ini->Parameters( 'PUBLIC PROFILES' ) ) {
         $obj->{_public_profiles}{lc $name} = $get_and_clear->( 'PUBLIC PROFILES', $name );
@@ -622,7 +622,7 @@ sub ReadProfilesInfo {
     my $profiles;
     foreach my $public_profile ( keys %{ $self->{_public_profiles} } ) {
         $profiles->{$public_profile}->{type} = 'public';
-        $profiles->{$public_profile}->{profile_file_name} = $self->{_public_profiles}{$public_profile};
+        $profiles->{$public_profile}->{profile_file_name} = $self->{_public_profiles}{$public_profile} // "";
     }
 
     foreach my $private_profile ( keys %{ $self->{_private_profiles} } ) {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -103,12 +103,9 @@ sub profile_names {
     my ( $self ) = @_;
 
     my @profiles;
-    eval {
-        @profiles = $self->{config}->ListPublicProfiles();
-
-    };
-    if ($@) {
-        handle_exception('profile_names', $@, '004');
+    eval { @profiles = $self->{config}->ListPublicProfiles() };
+    if ( $@ ) {
+        handle_exception( 'profile_names', $@, '004' );
     }
 
     return \@profiles;

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -21,7 +21,7 @@ sub new {
     my ( $class, $params ) = @_;
     my $self = {};
 
-    if ( ! $params || ! $params->{config} ) {
+    if ( !$params || !$params->{config} ) {
         die "missing 'config' parameter";
     }
 
@@ -29,7 +29,7 @@ sub new {
 
     my $dbtype;
     if ( $params->{dbtype} ) {
-        $dbtype = $self->{config}->check_db($params->{dbtype});
+        $dbtype = $self->{config}->check_db( $params->{dbtype} );
     }
     else {
         $dbtype = $self->{config}->DB_engine;
@@ -40,13 +40,13 @@ sub new {
     $self->{db} = $backend_module->new( { config => $self->{config} } );
 
     $self->{profiles} = $self->{config}->ReadProfilesInfo();
-    foreach my $profile (keys %{$self->{profiles}}) {
-        die "default profile cannot be private" if ($profile eq 'default' && $self->{profiles}->{$profile}->{type} eq 'private');
-        if ( -e $self->{profiles}->{$profile}->{profile_file_name} ) {
-            my $json = read_file( $self->{profiles}->{$profile}->{profile_file_name}, err_mode => 'croak' );
-            $self->{profiles}->{$profile}->{zm_profile} = Zonemaster::Engine::Profile->from_json( $json );
+    foreach my $profile ( keys %{ $self->{profiles} } ) {
+        die "default profile cannot be private" if ( $profile eq 'default' && $self->{profiles}{$profile}{type} eq 'private' );
+        if ( -e $self->{profiles}{$profile}{profile_file_name} ) {
+            my $json = read_file( $self->{profiles}{$profile}{profile_file_name}, err_mode => 'croak' );
+            $self->{profiles}{$profile}{zm_profile} = Zonemaster::Engine::Profile->from_json( $json );
         }
-        elsif ($profile ne 'default') {
+        elsif ( $profile ne 'default' ) {
             die "the profile definition json file of the profile [$profile] defined in the backend config file can't be read";
         }
     }

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -25,25 +25,25 @@ sub new {
         die "missing 'config' parameter";
     }
 
-    $self->{config} = $params->{config};
+    my $config = $params->{config};
 
     my $dbtype;
     if ( $params->{dbtype} ) {
-        $dbtype = $self->{config}->check_db( $params->{dbtype} );
+        $dbtype = $config->check_db( $params->{dbtype} );
     }
     else {
-        $dbtype = $self->{config}->DB_engine;
+        $dbtype = $config->DB_engine;
     }
 
     my $backend_module = "Zonemaster::Backend::DB::" . $dbtype;
     eval "require $backend_module";
-    $self->{db} = $backend_module->new( { config => $self->{config} } );
+    $self->{db} = $backend_module->new( { config => $config } );
 
-    $self->{profiles} = $self->{config}->ReadProfilesInfo();
-    foreach my $profile ( keys %{ $self->{profiles} } ) {
-        die "default profile cannot be private" if ( $profile eq 'default' && $self->{profiles}{$profile}{type} eq 'private' );
-        if ( -e $self->{profiles}{$profile}{profile_file_name} ) {
-            my $json = read_file( $self->{profiles}{$profile}{profile_file_name}, err_mode => 'croak' );
+    my %all_profiles = %{ $config->ReadProfilesInfo() };
+    foreach my $profile ( keys %all_profiles ) {
+        die "default profile cannot be private" if ( $profile eq 'default' && $all_profiles{$profile}{type} eq 'private' );
+        if ( -e $all_profiles{$profile}{profile_file_name} ) {
+            my $json = read_file( $all_profiles{$profile}{profile_file_name}, err_mode => 'croak' );
             $self->{profiles}{$profile}{zm_profile} = Zonemaster::Engine::Profile->from_json( $json );
         }
         elsif ( $profile ne 'default' ) {

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -44,7 +44,7 @@ sub new {
         die "default profile cannot be private" if ( $profile eq 'default' && $all_profiles{$profile}{type} eq 'private' );
         if ( -e $all_profiles{$profile}{profile_file_name} ) {
             my $json = read_file( $all_profiles{$profile}{profile_file_name}, err_mode => 'croak' );
-            $self->{profiles}{$profile}{zm_profile} = Zonemaster::Engine::Profile->from_json( $json );
+            $self->{profiles}{$profile} = Zonemaster::Engine::Profile->from_json( $json );
         }
         elsif ( $profile ne 'default' ) {
             die "the profile definition json file of the profile [$profile] defined in the backend config file can't be read";
@@ -138,9 +138,9 @@ sub run {
     # If the profile parameter has been set in the API, then load a profile
     if ( $params->{profile} ) {
         $params->{profile} = lc($params->{profile});
-        if (defined $self->{profiles}->{$params->{profile}} && $self->{profiles}->{$params->{profile}}->{zm_profile}) { 
+        if ( defined $self->{profiles}{ $params->{profile} } ) {
             my $profile = Zonemaster::Engine::Profile->default;
-            $profile->merge( $self->{profiles}->{$params->{profile}}->{zm_profile} );
+            $profile->merge( $self->{profiles}{$params->{profile}} );
             Zonemaster::Engine::Profile->effective->merge( $profile );
         }
         else {

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -45,12 +45,12 @@ sub new {
 
         die "default profile cannot be private" if ( $name eq 'default' && $all_profiles{$name}{type} eq 'private' );
         my $profile = Zonemaster::Engine::Profile->default;
-        if ( -e $path ) {
-            my $json = read_file( $path, err_mode => 'croak' );
-            $profile->merge( Zonemaster::Engine::Profile->from_json( $json ) );
-        }
-        elsif ( $name ne 'default' ) {
-            die "the profile definition json file of the profile [$name] defined in the backend config file can't be read";
+        if ( $path ne "" ) {
+            my $json = eval { read_file( $path, err_mode => 'croak' ) }    #
+              // die "Error loading profile '$name': $@";
+            my $named_profile = eval { Zonemaster::Engine::Profile->from_json( $json ) }    #
+              // die "Error loading profile '$name' at '$path': $@";
+            $profile->merge( $named_profile );
         }
         $self->{_profiles}{$name} = $profile;
     }

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -44,13 +44,15 @@ sub new {
         my $path = $all_profiles{$name}{profile_file_name};
 
         die "default profile cannot be private" if ( $name eq 'default' && $all_profiles{$name}{type} eq 'private' );
+        my $profile = Zonemaster::Engine::Profile->default;
         if ( -e $path ) {
             my $json = read_file( $path, err_mode => 'croak' );
-            $self->{_profiles}{$name} = Zonemaster::Engine::Profile->from_json( $json );
+            $profile->merge( Zonemaster::Engine::Profile->from_json( $json ) );
         }
         elsif ( $name ne 'default' ) {
             die "the profile definition json file of the profile [$name] defined in the backend config file can't be read";
         }
+        $self->{_profiles}{$name} = $profile;
     }
 
     bless( $self, $class );
@@ -141,12 +143,10 @@ sub run {
     if ( $params->{profile} ) {
         $params->{profile} = lc($params->{profile});
         if ( defined $self->{_profiles}{ $params->{profile} } ) {
-            my $profile = Zonemaster::Engine::Profile->default;
-            $profile->merge( $self->{_profiles}{$params->{profile}} );
-            Zonemaster::Engine::Profile->effective->merge( $profile );
+            Zonemaster::Engine::Profile->effective->merge( $self->{_profiles}{ $params->{profile} } );
         }
         else {
-            die "The profile [$params->{profile}] is not defined in the backend_config ini file" if ($params->{profile} ne 'default')
+            die "The profile [$params->{profile}] is not defined in the backend_config ini file";
         }
     }
 

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -163,20 +163,20 @@ sub main {
 }
 
 
+# Initialize logging
+my $dispatcher;
+if ( $logfile eq '-' ) {
+    $dispatcher = log_dispatcher_dup_stdout( $loglevel );
+}
+else {
+    $dispatcher = log_dispatcher_file( $loglevel, $logfile );
+    print STDERR "zonemaster-testagent logging to file $logfile\n";
+}
+Log::Any::Adapter->set( 'Dispatch', dispatcher => $dispatcher );
+
 # Make sure the environment is alright before forking
 my $initial_config;
 eval {
-    # Initialize logging
-    my $dispatcher;
-    if ( $logfile eq '-' ) {
-        $dispatcher = log_dispatcher_dup_stdout( $loglevel );
-    }
-    else {
-        $dispatcher = log_dispatcher_file( $loglevel, $logfile );
-        print STDERR "zonemaster-testagent logging to file $logfile\n";
-    }
-    Log::Any::Adapter->set( 'Dispatch', dispatcher => $dispatcher );
-
     # Make sure we can load the configuration file
     $log->debug("Starting pre-flight check");
     $initial_config = Zonemaster::Backend::Config->load_config();
@@ -189,6 +189,7 @@ eval {
     $log->debug("Completed pre-flight check");
 };
 if ( $@ ) {
+    $log->critical( "Aborting startup: $@" );
     print STDERR "Aborting startup: $@";
     exit 1;
 }


### PR DESCRIPTION
## Purpose

This PR is mainly a refactoring in preparation for implementing the validation of the PUBLIC PROFILES and PRIVATE PROFILES sections, but it also includes some improvements to error handling.


## Context

This PR is a step towards #685.

## Changes

When zm-testagent fails to start, the error is written to the log file.

A weird behavior is fixed. Normally when you specify a non-existing path for a profile, zm-testagent refuses to start. But if the name of the profile is "default", zm-testagent starts anyway and the default profile is used instead of the non-existent one. After this PR zm-testagent will refuse to start if a profile path does not exist - no matter what name the profile has.

Error messages from two sources are updated with more context. In one case the path of the offending profile file is included, and in the other case both the name of the profile and its path is included in the error message.

Some work (merging of profile objects) is moved from being done once per test item into being done once at startup.

In terms of refactorings, some private data representations are simplified, some variables are rename, some formatting is updated.


## How to test this PR

1. Update the PUBLIC PROFILES section in your backend_config.ini:
    ```
    [PUBLIC PROFILES]
    default = /non-existent
    ```
    Restart zm-testagent and make sure that it refuses to come up. Also make sure that a log entry is written containing details of the error.

2. Update the PUBLIC PROFILES section in your backend_config.ini:
    ```
    [PUBLIC PROFILES]
    default = /etc/shadow
    ```
    Restart zm-testagent and make sure that it refuses to come up. Also make sure that a log entry is written containing details of the error.

3. Update the PUBLIC PROFILES section in your backend_config.ini:
    ```
    [PUBLIC PROFILES]
    default = /bin/false
    ```
    Restart zm-testagent and make sure that it refuses to come up. Also make sure that a log entry is written containing details of the error.

4. Update the PUBLIC PROFILES section in your backend_config.ini:
    ```
    [PUBLIC PROFILES]
    default = /tmp/empty.profile
    ```
    Run `echo {} > /tmp/empty.profile`.
    Restart zm-testagent and make sure that you are able to complete a test with it.