### PR TITLE
Update database connection code

### DIFF
--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -636,7 +636,7 @@ sub new_DB {
 
     # Load and construct DB adapter
     my $dbclass = Zonemaster::Backend::DB->get_db_class( $self->DB_engine );
-    my $db      = $dbclass->new( { config => $self } );
+    my $db      = $dbclass->from_config( $self );
 
     return $db;
 }

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -630,12 +630,10 @@ A configured L<Zonemaster::Backend::DB> object.
 =cut
 
 sub new_DB {
-    my ($self) = @_;
+    my ( $self ) = @_;
 
-    my $dbtype = $self->DB_engine;
-
-    # Load and construct DB adapter
-    my $dbclass = Zonemaster::Backend::DB->get_db_class( $self->DB_engine );
+    my $dbtype  = $self->DB_engine;
+    my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
     my $db      = $dbclass->from_config( $self );
 
     return $db;

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -638,9 +638,6 @@ sub new_DB {
     my $dbclass = Zonemaster::Backend::DB->get_db_class( $self->DB_engine );
     my $db      = $dbclass->new( { config => $self } );
 
-    # Connect or die
-    $db->dbh;
-
     return $db;
 }
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -620,8 +620,6 @@ A configured L<Zonemaster::Backend::DB> object.
 
 =over 4
 
-=item Dies if no database engine type is defined in the configuration.
-
 =item Dies if no adapter for the configured database engine can be loaded.
 
 =item Dies if the adapter is unable to connect to the database.
@@ -633,11 +631,7 @@ A configured L<Zonemaster::Backend::DB> object.
 sub new_DB {
     my ($self) = @_;
 
-    # Get DB type from config
     my $dbtype = $self->DB_engine;
-    if (!defined $dbtype) {
-        die "Unrecognized DB.engine in backend config";
-    }
 
     # Load and construct DB adapter
     my $dbclass = 'Zonemaster::Backend::DB::' . $dbtype;

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -13,6 +13,7 @@ use File::Slurp qw( read_file );
 use Log::Any qw( $log );
 use Readonly;
 use Zonemaster::Backend::Validator qw( :untaint );
+use Zonemaster::Backend::DB;
 
 our $path;
 if ($ENV{ZONEMASTER_BACKEND_CONFIG_FILE}) {
@@ -634,11 +635,8 @@ sub new_DB {
     my $dbtype = $self->DB_engine;
 
     # Load and construct DB adapter
-    my $dbclass = 'Zonemaster::Backend::DB::' . $dbtype;
-    require( join( "/", split( /::/, $dbclass ) ) . ".pm" );
-    $dbclass->import();
-
-    my $db = $dbclass->new({ config => $self });
+    my $dbclass = Zonemaster::Backend::DB->get_db_class( $self->DB_engine );
+    my $db      = $dbclass->new( { config => $self } );
 
     # Connect or die
     $db->dbh;

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -74,7 +74,6 @@ sub get_test_request {
     my $result_id;
     my $dbh = $self->dbh;
     
-    
     my ( $id, $hash_id );
     if ( defined $queue_label ) {
         ( $id, $hash_id ) = $dbh->selectrow_array( qq[ SELECT id, hash_id FROM test_results WHERE progress=0 AND queue=? ORDER BY priority DESC, id ASC LIMIT 1 ], undef, $queue_label );

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -14,6 +14,7 @@ requires qw(
   add_batch_job
   create_new_batch_job
   create_new_test
+  from_config
   get_test_history
   get_test_params
   process_unfinished_tests_give_up

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -24,6 +24,25 @@ requires qw(
   user_exists_in_db
 );
 
+=head2 get_db_class
+
+Get the database adapter class for the given database type.
+
+Throws and exception if the database adapter class cannot be loaded.
+
+=cut
+
+sub get_db_class {
+    my ( $class, $db_type ) = @_;
+
+    my $db_class = "Zonemaster::Backend::DB::$db_type";
+
+    require( "$db_class.pm" =~ s{::}{/}gr );
+    $db_class->import();
+
+    return $db_class;
+}
+
 sub user_exists {
     my ( $self, $user ) = @_;
 

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -39,10 +39,18 @@ has 'dbhandle' => (
     required => 1,
 );
 
-around BUILDARGS => sub {
-    my ( $orig, $class, $args ) = @_;
+=head1 CLASS METHODS
 
-    my $config = $args->{config};
+=head2 from_config
+
+Construct a new instance from a Zonemaster::Backend::Config.
+
+    my $db = Zonemaster::Backend::DB::MySQL->from_config( $config );
+
+=cut
+
+sub from_config {
+    my ( $class, $config ) = @_;
 
     my $database = $config->MYSQL_database;
     my $host     = $config->MYSQL_host;
@@ -62,7 +70,7 @@ around BUILDARGS => sub {
         $password,
     );
 
-    return $class->$orig(
+    return $class->new(
         {
             data_source_name => $data_source_name,
             user             => $user,
@@ -70,7 +78,7 @@ around BUILDARGS => sub {
             dbhandle         => $dbh,
         }
     );
-};
+}
 
 sub dbh {
     my ( $self ) = @_;

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -82,21 +82,18 @@ sub from_config {
 
 sub dbh {
     my ( $self ) = @_;
-    my $dbh = $self->dbhandle;
 
-    if ( $dbh and $dbh->ping ) {
-        return $dbh;
-    }
-    else {
-        $dbh = $self->_new_dbh(
+    if ( !$self->dbhandle->ping ) {
+        my $dbh = $self->_new_dbh(    #
             $self->data_source_name,
             $self->user,
             $self->password,
         );
 
         $self->dbhandle( $dbh );
-        return $dbh;
     }
+
+    return $self->dbhandle;
 }
 
 sub user_exists_in_db {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -163,8 +163,8 @@ sub create_new_test {
     my $test_params_deterministic_hash = md5_hex( $encoded_params );
     my $result_id;
 
-    my $priority = $test_params->{priority};
-    my $queue = $test_params->{queue};
+    my $priority    = $test_params->{priority};
+    my $queue_label = $test_params->{queue};
 
     eval {
         $dbh->do( q[LOCK TABLES test_results WRITE] );
@@ -187,7 +187,7 @@ sub create_new_test {
                 undef,
                 $batch_id,
                 $priority,
-                $queue,
+                $queue_label,
                 $test_params_deterministic_hash,
                 $encoded_params,
                 $test_params->{domain},
@@ -341,8 +341,8 @@ sub add_batch_job {
         $batch_id = $self->create_new_batch_job( $params->{username} );
 
         my $test_params = $params->{test_params};
-        my $priority = $test_params->{priority};
-        my $queue = $test_params->{queue};
+        my $priority    = $test_params->{priority};
+        my $queue_label = $test_params->{queue};
 
         $dbh->{AutoCommit} = 0;
         eval {$dbh->do( "DROP INDEX test_results__hash_id ON test_results" );};
@@ -357,7 +357,7 @@ sub add_batch_job {
             my $encoded_params                 = $js->encode( $test_params );
             my $test_params_deterministic_hash = md5_hex( encode_utf8( $encoded_params ) );
 
-            $sth->execute( $test_params->{domain}, $batch_id, $priority, $queue, $test_params_deterministic_hash, $encoded_params );
+            $sth->execute( $test_params->{domain}, $batch_id, $priority, $queue_label, $test_params_deterministic_hash, $encoded_params );
         }
         $dbh->do( "CREATE INDEX test_results__hash_id ON test_results (hash_id, creation_time)" );
         $dbh->do( "CREATE INDEX test_results__params_deterministic_hash ON test_results (params_deterministic_hash)" );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -34,8 +34,9 @@ has 'password' => (
 );
 
 has 'dbhandle' => (
-    is  => 'rw',
-    isa => 'DBI::db',
+    is       => 'rw',
+    isa      => 'DBI::db',
+    required => 1,
 );
 
 around BUILDARGS => sub {
@@ -55,11 +56,18 @@ around BUILDARGS => sub {
 
     my $data_source_name = "DBI:mysql:database=$database;host=$host;port=$port";
 
+    my $dbh = $class->_new_dbh(
+        $data_source_name,
+        $user,
+        $password,
+    );
+
     return $class->$orig(
         {
             data_source_name => $data_source_name,
             user             => $user,
             password         => $password,
+            dbhandle         => $dbh,
         }
     );
 };

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -346,9 +346,9 @@ sub add_batch_job {
 }
 
 sub select_unfinished_tests {
-    my ( $self ) = @_;
+    my ( $self, $queue_label, $test_run_timeout, $test_run_max_retries ) = @_;
 
-    if ( $self->config->ZONEMASTER_lock_on_queue ) {
+    if ( $queue_label ) {
         my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
@@ -358,9 +358,9 @@ sub select_unfinished_tests {
             AND progress < 100
             AND queue = ?" );
         $sth->execute(    #
-            $self->config->ZONEMASTER_max_zonemaster_execution_time,
-            $self->config->ZONEMASTER_maximal_number_of_retries,
-            $self->config->ZONEMASTER_lock_on_queue,
+            $test_run_timeout,
+            $test_run_max_retries,
+            $queue_label,
         );
         return $sth;
     }
@@ -373,8 +373,8 @@ sub select_unfinished_tests {
             AND progress > 0
             AND progress < 100" );
         $sth->execute(    #
-            $self->config->ZONEMASTER_max_zonemaster_execution_time,
-            $self->config->ZONEMASTER_maximal_number_of_retries,
+            $test_run_timeout,
+            $test_run_max_retries,
         );
         return $sth;
     }

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -10,7 +10,6 @@ use DBI qw(:utils);
 use Digest::MD5 qw(md5_hex);
 use Encode;
 use JSON::PP;
-use Log::Any qw($log);
 
 use Zonemaster::Backend::Config;
 use Zonemaster::Backend::Validator qw( untaint_ipv6_address );
@@ -42,25 +41,18 @@ sub dbh {
         my $user     = $self->config->MYSQL_user;
         my $password = $self->config->MYSQL_password;
 
-        $log->notice( "Connecting to MySQL: database=$database host=$host user=$user" ) if $log->is_notice;
-
         if ( untaint_ipv6_address( $host ) ) {
             $host = "[$host]";
         }
 
         my $data_source_name = "DBI:mysql:database=$database;host=$host;port=$port";
 
-        $dbh = DBI->connect(
+        $dbh = $self->_new_dbh(
             $data_source_name,
             $user,
             $password,
-            {
-                RaiseError => 1,
-                AutoCommit => 1
-            }
         );
 
-        $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );
         return $dbh;
     }

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -42,13 +42,13 @@ sub dbh {
         my $user     = $self->config->MYSQL_user;
         my $password = $self->config->MYSQL_password;
 
-        my $data_source_name = "DBI:mysql:database=$database;host=$host;port=$port";
-
         $log->notice( "Connecting to MySQL: database=$database host=$host user=$user" ) if $log->is_notice;
 
         if ( untaint_ipv6_address( $host ) ) {
             $host = "[$host]";
         }
+
+        my $data_source_name = "DBI:mysql:database=$database;host=$host;port=$port";
 
         $dbh = DBI->connect(
             $data_source_name,

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -33,8 +33,9 @@ has 'password' => (
 );
 
 has 'dbhandle' => (
-    is  => 'rw',
-    isa => 'DBI::db',
+    is       => 'rw',
+    isa      => 'DBI::db',
+    required => 1,
 );
 
 around BUILDARGS => sub {
@@ -50,11 +51,18 @@ around BUILDARGS => sub {
 
     my $data_source_name = "DBI:Pg:database=$database;host=$host;port=$port";
 
+    my $dbh = $class->_new_dbh(
+        $data_source_name,
+        $user,
+        $password,
+    );
+
     return $class->$orig(
         {
             data_source_name => $data_source_name,
             user             => $user,
             password         => $password,
+            dbhandle         => $dbh,
         }
     );
 };

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -38,10 +38,18 @@ has 'dbhandle' => (
     required => 1,
 );
 
-around BUILDARGS => sub {
-    my ( $orig, $class, $args ) = @_;
+=head1 CLASS METHODS
 
-    my $config = $args->{config};
+=head2 from_config
+
+Construct a new instance from a Zonemaster::Backend::Config.
+
+    my $db = Zonemaster::Backend::DB::PostgreSQL->from_config( $config );
+
+=cut
+
+sub from_config {
+    my ( $class, $config ) = @_;
 
     my $database = $config->POSTGRESQL_database;
     my $host     = $config->POSTGRESQL_host;
@@ -57,7 +65,7 @@ around BUILDARGS => sub {
         $password,
     );
 
-    return $class->$orig(
+    return $class->new(
         {
             data_source_name => $data_source_name,
             user             => $user,
@@ -65,7 +73,7 @@ around BUILDARGS => sub {
             dbhandle         => $dbh,
         }
     );
-};
+}
 
 sub dbh {
     my ( $self ) = @_;

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -318,9 +318,9 @@ sub add_batch_job {
 }
 
 sub select_unfinished_tests {
-    my ( $self ) = @_;
+    my ( $self, $queue_label, $test_run_timeout, $test_run_max_retries ) = @_;
 
-    if ( $self->config->ZONEMASTER_lock_on_queue ) {
+    if ( $queue_label ) {
         my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
@@ -330,9 +330,9 @@ sub select_unfinished_tests {
             AND progress < 100
             AND queue = ?" );
         $sth->execute(    #
-            sprintf( "%d seconds", $self->config->ZONEMASTER_max_zonemaster_execution_time ),
-            $self->config->ZONEMASTER_maximal_number_of_retries,
-            $self->config->ZONEMASTER_lock_on_queue,
+            sprintf( "%d seconds", $test_run_timeout ),
+            $test_run_max_retries,
+            $queue_label,
         );
         return $sth;
     }
@@ -345,8 +345,8 @@ sub select_unfinished_tests {
             AND progress > 0
             AND progress < 100" );
         $sth->execute(    #
-            sprintf( "%d seconds", $self->config->ZONEMASTER_max_zonemaster_execution_time ),
-            $self->config->ZONEMASTER_maximal_number_of_retries,
+            sprintf( "%d seconds", $test_run_timeout ),
+            $test_run_max_retries,
         );
         return $sth;
     }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -173,8 +173,8 @@ sub create_new_test {
     my $encoded_params                 = $js->encode( $test_params );
     my $test_params_deterministic_hash = md5_hex( encode_utf8( $encoded_params ) );
 
-    my $priority = $test_params->{priority};
-    my $queue = $test_params->{queue};
+    my $priority    = $test_params->{priority};
+    my $queue_label = $test_params->{queue};
 
     my $sth = $dbh->prepare( "
         INSERT INTO test_results (batch_id, priority, queue, params_deterministic_hash, params)
@@ -187,7 +187,7 @@ sub create_new_test {
     my $nb_inserted = $sth->execute(    #
         $batch_id,
         $priority,
-        $queue,
+        $queue_label,
         $test_params_deterministic_hash,
         $encoded_params,
         $test_params_deterministic_hash,
@@ -312,8 +312,8 @@ sub add_batch_job {
 
         my $test_params = $params->{test_params};
 
-        my $priority = $test_params->{priority};
-        my $queue = $test_params->{queue};
+        my $priority    = $test_params->{priority};
+        my $queue_label = $test_params->{queue};
 
         $dbh->begin_work();
         $dbh->do( "ALTER TABLE test_results DROP CONSTRAINT IF EXISTS test_results_pkey" );
@@ -329,7 +329,7 @@ sub add_batch_job {
             my $encoded_params                 = $js->encode( $test_params );
             my $test_params_deterministic_hash = md5_hex( encode_utf8( $encoded_params ) );
 
-            $dbh->pg_putcopydata("$batch_id\t$priority\t$queue\t$test_params_deterministic_hash\t$encoded_params\n");
+            $dbh->pg_putcopydata("$batch_id\t$priority\t$queue_label\t$test_params_deterministic_hash\t$encoded_params\n");
         }
         $dbh->pg_putcopyend();
         $dbh->do( "ALTER TABLE test_results ADD PRIMARY KEY (id)" );

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -77,21 +77,18 @@ sub from_config {
 
 sub dbh {
     my ( $self ) = @_;
-    my $dbh = $self->dbhandle;
 
-    if ( $dbh and $dbh->ping ) {
-        return $dbh;
-    }
-    else {
-        $dbh = $self->_new_dbh(
+    if ( !$self->dbhandle->ping ) {
+        my $dbh = $self->_new_dbh(    #
             $self->data_source_name,
             $self->user,
             $self->password,
         );
 
         $self->dbhandle( $dbh );
-        return $dbh;
     }
+
+    return $self->dbhandle;
 }
 
 sub user_exists_in_db {

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -57,7 +57,7 @@ sub from_config {
     my $user     = $config->POSTGRESQL_user;
     my $password = $config->POSTGRESQL_password;
 
-    my $data_source_name = "DBI:Pg:database=$database;host=$host;port=$port";
+    my $data_source_name = "DBI:Pg:dbname=$database;host=$host;port=$port";
 
     my $dbh = $class->_new_dbh(
         $data_source_name,

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -9,7 +9,6 @@ use DBI qw(:utils);
 use Digest::MD5 qw(md5_hex);
 use Encode;
 use JSON::PP;
-use Log::Any qw($log);
 
 use Zonemaster::Backend::DB;
 use Zonemaster::Backend::Config;
@@ -43,18 +42,12 @@ sub dbh {
 
         my $data_source_name = "DBI:Pg:database=$database;host=$host;port=$port";
 
-        $log->notice( "Connecting to PostgreSQL: database=$database host=$host user=$user" ) if $log->is_notice;
-        $dbh = DBI->connect(
+        $dbh = $self->_new_dbh(
             $data_source_name,
             $user,
             $password,
-            {
-                RaiseError => 1,
-                AutoCommit => 1
-            }
         );
 
-        $dbh->{AutoInactiveDestroy} = 1;
         $self->dbhandle( $dbh );
         return $dbh;
     }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -178,8 +178,8 @@ sub create_new_test {
     my $test_params_deterministic_hash = md5_hex( $encoded_params );
     my $result_id;
 
-    my $priority = $test_params->{priority};
-    my $queue = $test_params->{queue};
+    my $priority    = $test_params->{priority};
+    my $queue_label = $test_params->{queue};
 
     # Search for recent test result with the test same parameters, where "$seconds"
     # gives the time limit for how old test result that is accepted.
@@ -208,7 +208,7 @@ sub create_new_test {
             $hash_id,
             $batch_id,
             $priority,
-            $queue,
+            $queue_label,
             $test_params_deterministic_hash,
             $encoded_params,
             $test_params->{domain},
@@ -334,8 +334,8 @@ sub add_batch_job {
         $batch_id = $self->create_new_batch_job( $params->{username} );
 
         my $test_params = $params->{test_params};
-        my $priority = $test_params->{priority};
-        my $queue = $test_params->{queue};
+        my $priority    = $test_params->{priority};
+        my $queue_label = $test_params->{queue};
 
         $dbh->{AutoCommit} = 0;
         eval {$dbh->do( "DROP INDEX IF EXISTS test_results__hash_id " );};
@@ -350,7 +350,7 @@ sub add_batch_job {
             my $encoded_params                 = $js->encode( $test_params );
             my $test_params_deterministic_hash = md5_hex( encode_utf8( $encoded_params ) );
 
-            $sth->execute( substr(md5_hex(time().rand()), 0, 16), $test_params->{domain}, $batch_id, $priority, $queue, $test_params_deterministic_hash, $encoded_params );
+            $sth->execute( substr(md5_hex(time().rand()), 0, 16), $test_params->{domain}, $batch_id, $priority, $queue_label, $test_params_deterministic_hash, $encoded_params );
         }
         $dbh->do( "CREATE INDEX test_results__hash_id ON test_results (hash_id, creation_time)" );
         $dbh->do( "CREATE INDEX test_results__params_deterministic_hash ON test_results (params_deterministic_hash)" );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -373,9 +373,9 @@ sub add_batch_job {
 }
 
 sub select_unfinished_tests {
-    my ( $self ) = @_;
+    my ( $self, $queue_label, $test_run_timeout, $test_run_max_retries ) = @_;
 
-    if ( $self->config->ZONEMASTER_lock_on_queue ) {
+    if ( $queue_label ) {
         my $sth = $self->dbh->prepare( "
             SELECT hash_id, results, nb_retries
             FROM test_results
@@ -385,9 +385,9 @@ sub select_unfinished_tests {
             AND progress < 100
             AND queue = ?" );
         $sth->execute(    #
-            sprintf( "-%d seconds", $self->config->ZONEMASTER_max_zonemaster_execution_time ),
-            $self->config->ZONEMASTER_maximal_number_of_retries,
-            $self->config->ZONEMASTER_lock_on_queue,
+            sprintf( "-%d seconds", $test_run_timeout ),
+            $test_run_max_retries,
+            $queue_label,
         );
         return $sth;
     }
@@ -400,8 +400,8 @@ sub select_unfinished_tests {
             AND progress > 0
             AND progress < 100" );
         $sth->execute(    #
-            sprintf( "-%d seconds", $self->config->ZONEMASTER_max_zonemaster_execution_time ),
-            $self->config->ZONEMASTER_maximal_number_of_retries,
+            sprintf( "-%d seconds", $test_run_timeout ),
+            $test_run_max_retries,
         );
         return $sth;
     }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -19,23 +19,31 @@ has 'dbh' => (
     isa => 'DBI::db',
 );
 
-around BUILDARGS => sub {
-    my ( $orig, $class, $args ) = @_;
+=head1 CLASS METHODS
 
-    my $config = $args->{config};
+=head2 from_config
+
+Construct a new instance from a Zonemaster::Backend::Config.
+
+    my $db = Zonemaster::Backend::DB::SQLite->from_config( $config );
+
+=cut
+
+sub from_config {
+    my ( $class, $config ) = @_;
 
     my $file = $config->SQLITE_database_file;
 
     my $data_source_name = "DBI:SQLite:dbname=$file";
 
-    my $dbh = $args->{dbh} // $class->_new_dbh( $data_source_name, '', '' );
+    my $dbh = $class->_new_dbh( $data_source_name, '', '' );
 
-    return $class->$orig(
+    return $class->new(
         {
             dbh => $dbh,
         }
     );
-};
+}
 
 sub DEMOLISH {
     my ( $self ) = @_;

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -33,14 +33,10 @@ sub BUILD {
     if ( !defined $self->dbh ) {
         my $file = $self->config->SQLITE_database_file;
 
-        $log->notice( "Opening SQLite: file=$file" ) if $log->is_notice;
-        my $dbh = DBI->connect(
+        my $dbh = $self->_new_dbh(    #
             "DBI:SQLite:dbname=$file",
-            undef, undef,
-            {
-                AutoCommit => 1,
-                RaiseError => 1,
-            }
+            '',
+            '',
         );
 
         $self->dbh( $dbh );

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -63,7 +63,7 @@ sub _init_db {
 
     eval {
         my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
-        $self->{db} = $dbclass->new( { config => $self->{config} } );
+        $self->{db} = $dbclass->from_config( $self->{config} );
     };
     if ($@) {
         handle_exception('_init_db', "Failed to initialize the [$dbtype] database backend module: [$@]", '002');

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -62,10 +62,8 @@ sub _init_db {
     my ( $self, $dbtype ) = @_;
 
     eval {
-        my $backend_module = "Zonemaster::Backend::DB::" . $dbtype;
-        eval "require $backend_module";
-        die "$@ \n" if $@;
-        $self->{db} = $backend_module->new( { config => $self->{config} } );
+        my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
+        $self->{db} = $dbclass->new( { config => $self->{config} } );
     };
     if ($@) {
         handle_exception('_init_db', "Failed to initialize the [$dbtype] database backend module: [$@]", '002');

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -35,9 +35,8 @@ sub new {
         $dbtype = $config->DB_engine;
     }
 
-    my $db_module = "Zonemaster::Backend::DB::" . $dbtype;
-    eval "require $db_module";
-    $self->{_db} = $db_module->new( { config => $config } );
+    my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
+    $self->{_db} = $dbclass->new( { config => $config } );
 
     my %all_profiles = %{ $config->ReadProfilesInfo() };
     foreach my $name ( keys %all_profiles ) {

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -36,22 +36,22 @@ sub new {
     }
 
     my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
-    $self->{_db} = $dbclass->new( { config => $config } );
+    $self->{_db} = $dbclass->from_config( $config );
 
     my %all_profiles = %{ $config->ReadProfilesInfo() };
     foreach my $name ( keys %all_profiles ) {
         my $path = $all_profiles{$name}{profile_file_name};
 
         die "default profile cannot be private" if ( $name eq 'default' && $all_profiles{$name}{type} eq 'private' );
-        my $profile = Zonemaster::Engine::Profile->default;
+        my $full_profile = Zonemaster::Engine::Profile->default;
         if ( $path ne "" ) {
             my $json = eval { read_file( $path, err_mode => 'croak' ) }    #
               // die "Error loading profile '$name': $@";
             my $named_profile = eval { Zonemaster::Engine::Profile->from_json( $json ) }    #
               // die "Error loading profile '$name' at '$path': $@";
-            $profile->merge( $named_profile );
+            $full_profile->merge( $named_profile );
         }
-        $self->{_profiles}{$name} = $profile;
+        $self->{_profiles}{$name} = $full_profile;
     }
 
     bless( $self, $class );

--- a/script/create_db_mysql.pl
+++ b/script/create_db_mysql.pl
@@ -13,7 +13,7 @@ my $config = Zonemaster::Backend::Config->load_config();
 if ( $config->DB_engine ne 'MySQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
-my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;
+my $dbh = Zonemaster::Backend::DB::MySQL->from_config( $config )->dbh;
 
 sub create_db {
 

--- a/script/create_db_postgresql_9.3.pl
+++ b/script/create_db_postgresql_9.3.pl
@@ -13,7 +13,7 @@ my $config = Zonemaster::Backend::Config->load_config();
 if ( $config->DB_engine ne 'PostgreSQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
-my $dbh     = Zonemaster::Backend::DB::PostgreSQL->new( { config => $config } )->dbh;
+my $dbh     = Zonemaster::Backend::DB::PostgreSQL->from_config( $config )->dbh;
 my $db_user = $config->POSTGRESQL_user;
 
 sub create_db {

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -131,9 +131,12 @@ sub main {
         $self->pm->reap_finished_children();    # Reaps terminated child processes
         $self->pm->on_wait();                   # Sends SIGKILL to overdue child processes
 
-        my $id = $self->db->get_test_request();
-        $self->db->process_unfinished_tests();
-
+        my $id = $self->db->get_test_request( $self->config->ZONEMASTER_lock_on_queue );
+        $self->db->process_unfinished_tests(
+            $self->config->ZONEMASTER_lock_on_queue,
+            $self->config->ZONEMASTER_max_zonemaster_execution_time,
+            $self->config->ZONEMASTER_maximal_number_of_retries,
+        );
         if ( $id ) {
             $log->info( "Test found: $id" );
             if ( $self->pm->start( $id ) == 0 ) {    # Forks off child process

--- a/share/create_db_sqlite.pl
+++ b/share/create_db_sqlite.pl
@@ -13,5 +13,5 @@ my $config = Zonemaster::Backend::Config->load_config();
 if ( $config->DB_engine ne 'SQLite' ) {
     die "The configuration file does not contain the SQLite backend";
 }
-my $db = Zonemaster::Backend::DB::SQLite->new( { config => $config } );
+my $db = Zonemaster::Backend::DB::SQLite->from_config( $config );
 $db->create_db();

--- a/share/patch_mysql_db_zonemaster_backend_ver_1.0.3.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_1.0.3.pl
@@ -13,7 +13,7 @@ my $config = Zonemaster::Backend::Config->load_config();
 if ( $config->DB_engine ne 'MySQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
-my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;
+my $dbh = Zonemaster::Backend::DB::MySQL->from_config( $config )->dbh;
 
 sub patch_db {
 

--- a/share/patch_mysql_db_zonemaster_backend_ver_5.0.0.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_5.0.0.pl
@@ -13,7 +13,7 @@ my $config = Zonemaster::Backend::Config->load_config();
 if ( $config->DB_engine ne 'MySQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
-my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;
+my $dbh = Zonemaster::Backend::DB::MySQL->from_config( $config )->dbh;
 
 sub patch_db {
     ####################################################################

--- a/share/patch_mysql_db_zonemaster_backend_ver_5.0.2.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_5.0.2.pl
@@ -13,7 +13,7 @@ my $config = Zonemaster::Backend::Config->load_config();
 if ( $config->DB_engine ne 'MySQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
-my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;
+my $dbh = Zonemaster::Backend::DB::MySQL->from_config( $config )->dbh;
 
 sub patch_db {
     ############################################################################

--- a/share/patch_postgresql_db_zonemaster_backend_ver_1.0.3.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_1.0.3.pl
@@ -13,7 +13,7 @@ my $config = Zonemaster::Backend::Config->load_config();
 if ( $config->DB_engine ne 'MySQL' ) {
     die "The configuration file does not contain the MySQL backend";
 }
-my $dbh = Zonemaster::Backend::DB::MySQL->new( { config => $config } )->dbh;
+my $dbh = Zonemaster::Backend::DB::MySQL->from_config( $config )->dbh;
 
 sub patch_db {
 

--- a/share/patch_postgresql_db_zonemaster_backend_ver_5.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_5.0.0.pl
@@ -13,7 +13,7 @@ my $config = Zonemaster::Backend::Config->load_config();
 if ( $config->DB_engine ne 'PostgreSQL' ) {
     die "The configuration file does not contain the PostgreSQL backend";
 }
-my $dbh = Zonemaster::Backend::DB::PostgreSQL->new( { config => $config } )->dbh;
+my $dbh = Zonemaster::Backend::DB::PostgreSQL->from_config( $config )->dbh;
 
 sub patch_db {
 


### PR DESCRIPTION
## Purpose

This PR updates the database connection code so that it's possible to get a database adapter instance that doesn't correspond to the contents of a configuration file. This is useful if you want to include database schema definition in the database adapter code.

This is mostly about refactoring, but it also includes fixing of a bug (introduced since last release) and some minor improvements.

## Context

This PR is a step towards both #805 and #806.

## Changes

* Fixes connecting to MySQL over IPv6.

* Fixes the syntax of the data source name for PostgreSQL. I'm not sure why the old syntax used to work or why it doesn't anymore (on CentOS 8), but this PR changes the syntax to the one specified in [DBD::Pg::connect](https://metacpan.org/pod/DBD::Pg#connect).

* The database adapter constructor interfaces are changed from `new({ config => $config })`to `from_config( $config )`. This makes room for adding other constructors that don't take their parameters straight out of a Config instance.

* There are a number of methods in the database adapters that used to look into the configuration for parameters. Now they are updated to take those parameters as arguments instead.

* Database adapters used to defer the database connection for as long as possible. However in order to avoid failures in inconvenient places we were explicitly working around that feature by forcing the opening of a database connection as early as possible. This PR removes the connection deferral feature.

* The DRY principle is applied to getting the database adapter class and to opening database connections. The consistency across adapters is improved regarding log messages and database connection settings, and it also helps us stay consistent.

## How to test this PR

1. Verify that Travis was able to run the tests using all database engines.
2. For each database engine:
    1. Configure Backend to use this database engine
    2. Restart zm-rpcapi and zm-testagent
    3. Run a test using zmtest and verify you get a result back.