### PR TITLE
Corrects zmb

### DIFF
--- a/script/zmb
+++ b/script/zmb
@@ -464,7 +464,7 @@ sub json_tern {
         return undef;
     }
     else {
-        die "unknown ternary value";
+        die 'Illegal value. Expects "true", "false" or "null" ';
     }
 }
 

--- a/script/zmb
+++ b/script/zmb
@@ -368,7 +368,7 @@ sub cmd_get_test_history {
     );
 
     if ( $opt_filter ) {
-        unless ( $opt_filer =~ /^(?:all|delegated|undelegated)$/ ) {
+        unless ( $opt_filter =~ /^(?:all|delegated|undelegated)$/ ) {
             die 'Illegal filter value. Expects "all", "delegated" or "undelegated" ';
         }
         $params{filter} = $opt_filter;

--- a/script/zmb
+++ b/script/zmb
@@ -340,7 +340,7 @@ sub cmd_get_test_results {
 
  Options:
    --domain DOMAIN_NAME
-   --nameserver true|false|null
+   --filter all|delegated|undelegated
    --offset COUNT
    --limit COUNT
 
@@ -348,7 +348,7 @@ sub cmd_get_test_results {
 
 sub cmd_get_test_history {
     my @opts = @_;
-    my $opt_nameserver;
+    my $opt_filter;
     my $opt_domain;
     my $opt_offset;
     my $opt_limit;
@@ -356,7 +356,7 @@ sub cmd_get_test_history {
     GetOptionsFromArray(
         \@opts,
         'domain|d=s'     => \$opt_domain,
-        'nameserver|n=s' => \$opt_nameserver,
+        'filter|n=s'     => \$opt_filter,
         'offset|o=i'     => \$opt_offset,
         'limit|l=i'      => \$opt_limit,
     ) or pod2usage( 2 );
@@ -367,8 +367,11 @@ sub cmd_get_test_history {
         },
     );
 
-    if ( $opt_nameserver ) {
-        $params{frontend_params}{nameservers} = json_tern( $opt_nameserver );
+    if ( $opt_filter ) {
+        unless ( $opt_filer =~ /^(?:all|delegated|undelegated)$/ ) {
+            die 'Illegal filter value. Expects "all", "delegated" or "undelegated" ';
+        }
+        $params{filter} = $opt_filter;
     }
 
     if ( defined $opt_offset ) {


### PR DESCRIPTION
## Purpose

For RPCAPI method get_test_history zmb has a non-supported parameter "nameservers" and a missing parameter "filter". This PR corrects that.

This PR also clarifies a cryptic error message.

Before this PR from `zmb man`:
```
   get_test_history
        zmb [GLOBAL OPTIONS] get_test_history [OPTIONS]

        Options:
          --domain DOMAIN_NAME
          --nameserver true|false|null
          --offset COUNT
          --limit COUNT
```
Before this PR:
```
# zmb --verbose get_test_history --domain xb --nameserver true | jq .
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "get_test_history",
  "params": {
    "frontend_params": {
      "nameservers": true,
      "domain": "xb"
    }
  }
}
{
  "id": 1,
  "error": {
    "message": "Invalid method parameter(s).",
    "code": "-32602",
    "data": "/frontend_params: Properties not allowed: nameservers."
  },
  "jsonrpc": "2.0"
}
```

Issue #812 is related to this issue.

## Changes

This PR removes the incorrect parameter and implements the missing "filter" parameter. It also clarifies an unrelated error message.

## How to test this PR

* Run `get_test_history` for some domain with the incorrect "nameservers" parameter and make sure that the program outputs an error.
* Run `get_test_history` for some domain with the "filter" parameter. Use value "all". The other values work, but not fully correctly, in MySQL, but currently not in SQLite.
* Run `get_test_history` for some domain with the "filter" parameter. Use value "nisse" (illegal) to get an error message directly from `zmb`.
* Run `start_domain_test` with some domain and the parameter "ipv6" with the incorrect value "nisse" to get the clarified error message directly from `zmb`.
