### PR TITLE
Fix translation

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -5,13 +5,14 @@ use warnings;
 use 5.14.2;
 
 # Public Modules
-use JSON::PP;
 use DBI qw(:utils);
 use Digest::MD5 qw(md5_hex);
-use String::ShellQuote;
 use File::Slurp qw(append_file);
 use HTML::Entities;
+use JSON::PP;
 use JSON::Validator::Joi;
+use Log::Any qw($log);
+use String::ShellQuote;
 
 # Zonemaster Modules
 use Zonemaster::LDNS;
@@ -450,7 +451,7 @@ sub get_test_results {
 
     my %locales = $self->{config}->LANGUAGE_locale;
 
-    my $locale_tag;
+    my $locale;
     if ( length $language == 2 ) {
         if ( !exists $locales{$language} ) {
             die "Undefined language string: '$language'\n";
@@ -458,21 +459,24 @@ sub get_test_results {
         elsif ( scalar keys %{ $locales{$language} } > 1 ) {
             die "Language string not unique: '$language'\n";
         }
-        ( $locale_tag ) = keys %{ $locales{$language} };
+        ( $locale ) = keys %{ $locales{$language} };
     }
     else {
         if ( !exists $locales{substr $language, 0, 2}{$language} ) {
             die "Undefined language string: '$language'\n";
         }
-        $locale_tag = $language;
+        $locale = $language;
     }
+    $locale .= '.UTF-8';
 
     my $result;
     my $translator;
     $translator = Zonemaster::Backend::Translator->new;
 
     my $previous_locale = $translator->locale;
-    $translator->locale( $locale_tag );
+    if ( !$translator->locale( $locale ) ) {
+        handle_exception( 'get_test_results', "Failed to set locale: $locale", '017' );
+    }
 
     eval { $translator->data } if $translator;    # Provoke lazy loading of translation data
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -493,7 +493,7 @@ sub get_test_results {
             }
 
             $res->{module} = $test_res->{module};
-            $res->{message} = $translator->translate_tag( $test_res, $locale_tag ) . "\n";
+            $res->{message} = $translator->translate_tag( $test_res ) . "\n";
             $res->{message} =~ s/,/, /isg;
             $res->{message} =~ s/;/; /isg;
             $res->{level} = $test_res->{level};

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -16,21 +16,7 @@ require Zonemaster::Engine::Logger::Entry;
 extends 'Zonemaster::Engine::Translator';
 
 sub translate_tag {
-    my ( $self, $hashref, $browser_lang ) = @_;
-
-    # Workaround for broken Zonemaster::Engine::translate_tag in Zonemaster-Engine 3.1.2.
-    # Make locale really be set. Fix that makes translation work on FreeBSD 12.1. Solution copied from
-    # CLI.pm in the Zonemaster-CLI repository.
-    undef $ENV{LANGUAGE};
-    $ENV{LC_ALL} = $self->locale;
-    if ( not defined setlocale( LC_MESSAGES, "" ) ) {
-        warn sprintf "Warning: setting locale category LC_MESSAGES to %s failed (is it installed on this system?).",
-        $ENV{LANGUAGE} || $ENV{LC_ALL} || $ENV{LC_MESSAGES};
-    }
-    if ( not defined setlocale( LC_CTYPE, "" ) ) {
-        warn sprintf "Warning: setting locale category LC_CTYPE to %s failed (is it installed on this system?)." ,
-        $ENV{LC_ALL} || $ENV{LC_CTYPE};
-    }
+    my ( $self, $hashref ) = @_;
 
     my $entry = Zonemaster::Engine::Logger::Entry->new( %{ $hashref } );
     my $octets = Zonemaster::Engine::Translator::translate_tag( $self, $entry );


### PR DESCRIPTION
## Purpose

This PR fixes a problem where translations don't work unless you have more locales installed than the ones prescribed in the installation instruction.

## Context

Fixes #809.

## Changes

This PR corrects the usage of Zonemaster::Engine::Translator->locale().

## How to test this PR

Make sure that your LANGUAGE.locale contains da_DK:
```sh
cat /etc/zonemaster/backend_config.ini
```

Make sure that the only locale listed for Danish is `da_DK.utf8`:
```sh
locale -a
```

Restart you daemons:
```sh
sudo systemctl restart zm-rpcapi zm-testagent
```

Acquire a test id:
```sh
zmtest zonemaster.net
```

Verify that you can get the results in Danish (make sure to set $TESTID or replace it with a test id that exists in the database):
```sh
zmb get_test_results --lang da --test-id $TESTID | jq -S .result.results[0]
```