### PR TITLE
Clarifies profiles in the documentation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -227,19 +227,37 @@ The drawback of this setup will be that the GUI will have to wait for at least o
 Basic data type: string
 
 This parameter is a case-insensitive string validated with the case-insensitive
-regex `/^[a-z0-9]$|^[a-z0-9][a-z0-9_-]{0,30}[a-z0-9]$/i`.
+regex `/^[a-z0-9]$|^[a-z0-9][a-z0-9_-]{0,30}[a-z0-9]$/i` which must be predefined
+in the configuration file as specified in the Configuration document
+[profile sections].
 
 The name of a [*profile*](Architecture.md#profile).
 
-When a method received an unknown *profile name* value for in parameter with this type, it returns the following error message:
+When a method receives an illegal *profile name* value for a parameter with this
+type, it returns the following error message:
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "result": {
-        "message": "Invalid profile option format",
-        "status": "nok"
+    "jsonrpc":"2.0",
+    "id":1,
+    "error":{
+        "message":"Invalid method parameter(s).",
+        "data":"/profile: String does not match (?^ui:^[a-z0-9]$|^[a-z0-9][a-z0-9_-]{0,30}[a-z0-9]$).",
+        "code":"-32602"
+    }
+}
+```
+
+When a method receives a legal but undefined *profile name* value for a parameter
+with this type, it returns the following error message:
+
+```json
+{
+    "jsonrpc":"2.0",
+    "id":1,
+    "error":{
+        "message":"Internal error 009 \n",
+        "code":-32603
     }
 }
 ```
@@ -361,7 +379,8 @@ An object with the following properties:
 
 ## API method: `profile_names`
 
-Returns the names of the public subset of the [available profiles].
+Returns the names of the public subset of the
+[available profiles][Profile sections].
 
 Example request:
 ```json
@@ -643,7 +662,8 @@ An object with the following properties:
 * `"ipv4"`: A boolean, optional. (default: [`net.ipv6`][net.ipv6] profile value). Used to enable or disable testing over IPv6 transport protocol.
 * `"nameservers"`: A list of [*name server*][Name server] objects, optional. (default: `[]`). Used to perform un-delegated test.
 * `"ds_info"`: A list of [*DS info*][DS info] objects, optional. (default: `[]`). Used to perform un-delegated test.
-* `"profile"`: A *profile name*, optional. (default: `"default"`). Run the tests using the given profile.
+* `"profile"`: A [*profile name*][profile name], optional. (default:
+  `"default"`). Run the tests using the given profile.
 * `"client_id"`: A *client id*, optional. (default: unset). Used to monitor which client uses the API.
 * `"client_version"`: A *client version*, optional. (default: unset). Used to monitor which client use the API
 * `"priority"`: A *priority*, optional. (default: `10`)
@@ -664,12 +684,8 @@ then the new request does not trigger a new test, but returns with the results o
 
 #### `"error"`
 
-* If the given `profile` is not among the [available profiles], a user
-  error is returned.
-
->
-> TODO: List all possible error codes and describe what they mean enough for clients to know how react to them.
->
+* If the given `profile` is not among the [available profiles][Profile sections],
+  a user error is returned, see [profile name section][profile name].
 
 
 ## API method: `test_progress`
@@ -1042,7 +1058,8 @@ An object with the following properties:
 The value of `"test_params"` is an object with the following properties:
 
 * `"client_id"`: A *client id*, optional. (default: unset)
-* `"profile"`: A *profile name*, optional (default: `"default"`). Run the tests using the given profile.
+* `"profile"`: A [*profile name*][profile name], optional (default: 
+  `"default"`). Run the tests using the given profile.
 * `"client_version"`: A *client version*, optional. (default: unset)
 * `"nameservers"`: A list of [*name server*][Name server] objects, optional. (default: `[]`)
 * `"ds_info"`: A list of [*DS info*][DS info] objects, optional. (default: `[]`)
@@ -1061,13 +1078,8 @@ A *batch id*.
 
 * You can't create a new batch job.
   A *batch* with unfinished *tests* already exists for this *api user*.
-* If the given `profile` is not among the [available profiles], a user
-  error is returned.
-
-
->
-> TODO: List all possible error codes and describe what they mean enough for clients to know how react to them.
->
+* If the given `profile` is not among the [available profiles][Profile sections],
+  a user error is returned, see the [profile name section][profile name].
 
 
 ## API method: `get_batch_job_result`
@@ -1190,7 +1202,6 @@ The `"params"` object sent to `start_domain_test` or `add_batch_job` when the *t
 > TODO: List all possible error codes and describe what they mean enough for clients to know how react to them.
 >
 
-[Available profiles]:           Configuration.md#profiles-section
 [DS info]:                      #ds-info
 [ISO 3166-1 alpha-2]:           https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                    https://en.wikipedia.org/wiki/ISO_639-1
@@ -1200,3 +1211,5 @@ The `"params"` object sent to `start_domain_test` or `add_batch_job` when the *t
 [net.ipv4]:                     https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv4
 [net.ipv6]:                     https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv6
 [Privilege levels]:             #privilege-levels
+[Profile name]:                 #profile-name
+[Profile sections]:             Configuration.md#public-profiles-and-private-profiles-sections

--- a/docs/API.md
+++ b/docs/API.md
@@ -233,6 +233,10 @@ in the configuration file as specified in the Configuration document
 
 The name of a [*profile*](Architecture.md#profile).
 
+Below are the current error messages for an incorrect *profile name*. The
+messages should, however, considered to be unstable and are planned to be updated
+to gain consistent error messages from the RPCAPI.
+
 When a method receives an illegal *profile name* value for a parameter with this
 type, it returns the following error message:
 
@@ -261,6 +265,8 @@ with this type, it returns the following error message:
     }
 }
 ```
+The error code is "009" (as above) if method [start_domain_test] was requested.
+Instead it will be "015" if method [add_batch_job] is requested.
 
 
 ### Progress percentage
@@ -1202,14 +1208,16 @@ The `"params"` object sent to `start_domain_test` or `add_batch_job` when the *t
 > TODO: List all possible error codes and describe what they mean enough for clients to know how react to them.
 >
 
+[Add_batch_job]:                #api-method-add_batch_job
 [DS info]:                      #ds-info
 [ISO 3166-1 alpha-2]:           https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                    https://en.wikipedia.org/wiki/ISO_639-1
 [LANGUAGE.locale]:              Configuration.md#locale
 [Language tag]:                 #language-tag
 [Name server]:                  #name-server
-[net.ipv4]:                     https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv4
-[net.ipv6]:                     https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv6
 [Privilege levels]:             #privilege-levels
 [Profile name]:                 #profile-name
 [Profile sections]:             Configuration.md#public-profiles-and-private-profiles-sections
+[Start_domain_test]:            #api-method-start_domain_test
+[net.ipv4]:                     https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv4
+[net.ipv6]:                     https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv6

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -257,9 +257,12 @@ running the RPCAPI daemon for the translation to work correctly.
 
 The PUBLIC PROFILES and PRIVATE PROFILES sections together define the available [profiles].
 
-Keys in both sections are [profile names], and values are absolute file system paths to
-[profile JSON files]. Keys must not be duplicated between the sections, and the
-key `default` must not be present in the PRIVATE PROFILES sections.
+Keys in both sections are `profile names`, and values are absolute file system
+paths to [profile JSON files]. The key must conform to the character limitation
+specified for `profile name` as specified in the API document
+[Profile name section]. Keys that only differ in case are considered to be equal.
+Keys must not be duplicated between or within the sections, and the key
+`default` must not be present in the PRIVATE PROFILES section.
 
 There is a `default` profile that is special. It is always available even
 if not specified. If it is not explicitly mapped to a profile JSON file, it is implicitly
@@ -374,7 +377,7 @@ Otherwise a new test request is enqueued.
 [POSTGRESQL.password]:                #password-2
 [POSTGRESQL.user]:                    #user-2
 [Profile JSON files]:                 https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Profiles.md
-[Profile names]:                      API.md#profile-name
+[Profile name section]:               API.md#profile-name
 [Profiles]:                           Architecture.md#profile
 [SQLITE.database_file]:               #database_file
 [US ASCII printable characters]:      https://en.wikipedia.org/wiki/ASCII#Printable_characters


### PR DESCRIPTION
## Purpose

Clarifies the limitations on profiles in the configuration and updates the documentation in the API documentation.

## How to test this PR

Documentation only, no change of implementation.