### PR TITLE
Return an array of error for request validation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -529,7 +529,7 @@ Example response:
 
 #### `"params"`
 
-An object with the properties:
+An object with the property:
 
 * `"hostname"`: A *domain name*, required. The hostname whose IP addresses are to be resolved.
 
@@ -629,7 +629,7 @@ Example response:
 
 #### `"params"`
 
-An object with the properties:
+An object with the property:
 
 * `"domain"`: A *domain name*, required. The domain whose DNS records are requested.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -155,8 +155,8 @@ Properties:
 Basic data type: string
 
 This parameter is a string that is either
- - a valid IPv4 in [dot-decimal notation] ;
- - a valid IPv6 in [recommend text format for IPv6 addresses].
+ - a valid IPv4 address in [dot-decimal notation] ;
+ - a valid IPv6 address in [recommend text format for IPv6 addresses].
 
 ### Language tag
 
@@ -248,7 +248,12 @@ type, it returns the following error message:
     "id":1,
     "error":{
         "message":"Invalid method parameter(s).",
-        "data":"/profile: String does not match (?^ui:^[a-z0-9]$|^[a-z0-9][a-z0-9_-]{0,30}[a-z0-9]$).",
+        "data": [
+            {
+              "path": "/profile",
+              "message": "String does not match (?^ui:^[a-z0-9]$|^[a-z0-9][a-z0-9_-]{0,30}[a-z0-9]$)."
+            },
+        ],
         "code":"-32602"
     }
 }
@@ -262,8 +267,14 @@ with this type, it returns the following error message:
     "jsonrpc":"2.0",
     "id":1,
     "error":{
-        "message":"Internal error 009 \n",
-        "code":-32603
+        "message":"Invalid method parameter(s).",
+        "data": [
+            {
+              "path": "/profile",
+              "message": "Unknown profile"
+            },
+        ],
+        "code":"-32602"
     }
 }
 ```

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -380,5 +380,3 @@ Otherwise a new test request is enqueued.
 [US ASCII printable characters]:      https://en.wikipedia.org/wiki/ASCII#Printable_characters
 [Zonemaster-Engine share directory]:  https://github.com/zonemaster/zonemaster-engine/tree/master/share
 [Zonemaster::Engine::Profile]:        https://metacpan.org/pod/Zonemaster::Engine::Profile#PROFILE-PROPERTIES
-
-

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -740,7 +740,6 @@ sub _reset_LANGUAGE_locale {
     my ( $self ) = @_;
 
     delete $self->{_LANGUAGE_locale};
-
     return;
 }
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -29,6 +29,7 @@ use Zonemaster::Backend::Validator;
 
 my $zm_validator = Zonemaster::Backend::Validator->new;
 my %json_schemas;
+my %extra_validators;
 my $recursor = Zonemaster::Engine::Recursor->new;
 
 sub joi {
@@ -151,19 +152,26 @@ sub get_host_by_name {
     return \@adresses;
 }
 
+sub get_data_from_parent_zone_validate_syntax {
+    my ( $self, $syntax_input ) = @_;
+    my @errors;
+
+    if ( defined $syntax_input->{domain} ) {
+        my ( undef, $dn_syntax ) = $self->_check_domain( $syntax_input->{domain} );
+        push @errors, { path => "/domain", message => $dn_syntax->{message} } if ( $dn_syntax->{status} eq 'nok' );
+    }
+    return @errors;
+}
 $json_schemas{get_data_from_parent_zone} = joi->object->strict->props(
     domain   => $zm_validator->domain_name->required
 );
+$extra_validators{get_data_from_parent_zone} = \&get_data_from_parent_zone_validate_syntax;
 sub get_data_from_parent_zone {
     my ( $self, $params ) = @_;
 
     my $result = eval {
         my %result;
-
         my $domain = $params->{domain};
-
-        my ( $dn, $dn_syntax ) = $self->_check_domain( $domain, 'Domain name' );
-        return $dn_syntax if ( $dn_syntax->{status} eq 'nok' );
 
         my @ns_list;
         my @ns_names;
@@ -198,10 +206,10 @@ sub get_data_from_parent_zone {
 
 
 sub _check_domain {
-    my ( $self, $domain, $type ) = @_;
+    my ( $self, $domain ) = @_;
 
     if ( !defined( $domain ) ) {
-        return ( $domain, { status => 'nok', message => encode_entities( "$type required" ) } );
+        return ( $domain, { status => 'nok', message => 'Domain name required' } );
     }
 
     if ( $domain =~ m/[^[:ascii:]]+/ ) {
@@ -212,7 +220,7 @@ sub _check_domain {
                     $domain,
                     {
                         status  => 'nok',
-                        message => encode_entities( "The domain name is not a valid IDNA string and cannot be converted to an A-label" )
+                        message => 'The domain name is not a valid IDNA string and cannot be converted to an A-label'
                     }
                 );
             }
@@ -222,7 +230,7 @@ sub _check_domain {
                 $domain,
                 {
                     status  => 'nok',
-                    message => encode_entities( "$type contains non-ascii characters and IDNA is not installed" )
+                    message => 'The domain name contains non-ascii characters and IDNA is not installed'
                 }
             );
         }
@@ -233,7 +241,7 @@ sub _check_domain {
             $domain,
             {
                 status  => 'nok',
-                message => encode_entities( "The domain name character(s) not supported" )
+                message => 'The domain name character(s) are not supported'
             }
         );
     }
@@ -243,117 +251,50 @@ sub _check_domain {
     @res = Zonemaster::Engine::Test::Basic->basic00( $domain );
     @res = grep { $_->numeric_level >= $levels{ERROR} } @res;
     if ( @res != 0 ) {
-        return ( $domain, { status => 'nok', message => encode_entities( "$type name or label is too long" ) } );
+        return ( $domain, { status => 'nok', message => 'The domain name or label is too long' } );
     }
 
     return ( $domain, { status => 'ok', message => 'Syntax ok' } );
 }
 
-sub validate_syntax {
+sub start_domain_test_validate_syntax {
     my ( $self, $syntax_input ) = @_;
 
-    my $result = eval {
-        my @allowed_params_keys = (
-            'domain',   'ipv4',      'ipv6', 'ds_info', 'nameservers', 'profile',
-            'client_id', 'client_version', 'config', 'priority', 'queue'
-        );
-
-        foreach my $k ( keys %$syntax_input ) {
-            return { status => 'nok', message => encode_entities( "Unknown option [$k] in parameters" ) }
-            unless ( grep { $_ eq $k } @allowed_params_keys );
-        }
-
-        if ( ( defined $syntax_input->{nameservers} && @{ $syntax_input->{nameservers} } ) ) {
-            foreach my $ns_ip ( @{ $syntax_input->{nameservers} } ) {
-                foreach my $k ( keys %$ns_ip ) {
-                    delete( $ns_ip->{$k} ) unless ( $k eq 'ns' || $k eq 'ip' );
-                }
-            }
-        }
-
-        if ( ( defined $syntax_input->{ds_info} && @{ $syntax_input->{ds_info} } ) ) {
-            foreach my $ds_digest ( @{ $syntax_input->{ds_info} } ) {
-                foreach my $k ( keys %$ds_digest ) {
-                    delete( $ds_digest->{$k} ) unless ( $k eq 'algorithm' || $k eq 'digest' || $k eq 'digtype' || $k eq 'keytag' );
-                }
-            }
-        }
-
-        if ( defined $syntax_input->{ipv4} ) {
-            return { status => 'nok', message => encode_entities( "Invalid IPv4 transport option format" ) }
-            unless ( $syntax_input->{ipv4} eq JSON::PP::false
-                || $syntax_input->{ipv4} eq JSON::PP::true
-                || $syntax_input->{ipv4} eq '1'
-                || $syntax_input->{ipv4} eq '0' );
-        }
-
-        if ( defined $syntax_input->{ipv6} ) {
-            return { status => 'nok', message => encode_entities( "Invalid IPv6 transport option format" ) }
-            unless ( $syntax_input->{ipv6} eq JSON::PP::false
-                || $syntax_input->{ipv6} eq JSON::PP::true
-                || $syntax_input->{ipv6} eq '1'
-                || $syntax_input->{ipv6} eq '0' );
-        }
+    my @errors = eval {
+        my @errors;
 
         if ( defined $syntax_input->{profile} ) {
             $syntax_input->{profile} = lc $syntax_input->{profile};
             my %profiles = ( $self->{config}->PUBLIC_PROFILES, $self->{config}->PRIVATE_PROFILES );
             if ( !exists $profiles{ $syntax_input->{profile} } ) {
-                return { status => 'nok', message => encode_entities( "Unrecognized profile name" ) };
+                push @errors, { path => '/profile', message => 'Unknown profile' };
             }
         }
 
-        my ( undef, $dn_syntax ) = $self->_check_domain( $syntax_input->{domain}, 'Domain name' );
+        if ( defined $syntax_input->{domain} ) {
+            my ( undef, $dn_syntax ) = $self->_check_domain( $syntax_input->{domain} );
+            push @errors, { path => "/domain", message => $dn_syntax->{message} } if ( $dn_syntax->{status} eq 'nok' );
+        }
 
-        return $dn_syntax if ( $dn_syntax->{status} eq 'nok' );
+        if ( defined $syntax_input->{nameservers} && ref $syntax_input->{nameservers} eq 'ARRAY' && @{ $syntax_input->{nameservers} } ) {
+            while (my ($index, $ns_ip) = each @{ $syntax_input->{nameservers} }) {
+                my ( $ns, $ns_syntax ) = $self->_check_domain( $ns_ip->{ns} );
+                push @errors, { path => "/nameservers/$index/ns", message => $ns_syntax->{message} } if ( $ns_syntax->{status} eq 'nok' );
 
-        if ( defined $syntax_input->{nameservers} && @{ $syntax_input->{nameservers} } ) {
-            foreach my $ns_ip ( @{ $syntax_input->{nameservers} } ) {
-                my ( $ns, $ns_syntax ) = $self->_check_domain( $ns_ip->{ns}, "NS [$ns_ip->{ns}]" );
-                return $ns_syntax if ( $ns_syntax->{status} eq 'nok' );
-            }
-
-            foreach my $ns_ip ( @{ $syntax_input->{nameservers} } ) {
-                # Although counterintuitive both tests are necessary as Zonemaster::Engine::Net::IP accepts incomplete IP adresses (network adresses) as valid IP adresses
-                return { status => 'nok', message => encode_entities( "Invalid IP address: [$ns_ip->{ip}]" ) }
-                    unless( !$ns_ip->{ip} || $ns_ip->{ip} =~ /^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/ || $ns_ip->{ip} =~ /^([0-9A-Fa-f]{1,4}:[0-9A-Fa-f:]{1,}(:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?)|([0-9A-Fa-f]{1,4}::[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})$/);
-
-                return { status => 'nok', message => encode_entities( "Invalid IP address: [$ns_ip->{ip}]" ) }
+                push @errors, { path => "/nameservers/$index/ip", message => 'Invalid IP address' }
                 unless ( !$ns_ip->{ip}
                     || Zonemaster::Engine::Net::IP::ip_is_ipv4( $ns_ip->{ip} )
                     || Zonemaster::Engine::Net::IP::ip_is_ipv6( $ns_ip->{ip} ) );
             }
-
-            foreach my $ds_digest ( @{ $syntax_input->{ds_info} } ) {
-                return {
-                    status  => 'nok',
-                    message => encode_entities( "Invalid algorithm type: [$ds_digest->{algorithm}]" )
-                }
-                if ( $ds_digest->{algorithm} =~ /\D/ );
-            }
-
-            foreach my $ds_digest ( @{ $syntax_input->{ds_info} } ) {
-                return {
-                    status  => 'nok',
-                    message => encode_entities( "Invalid digest format: [$ds_digest->{digest}]" )
-                }
-                if (
-                    ( length( $ds_digest->{digest} ) != 96 &&
-                        length( $ds_digest->{digest} ) != 64 &&
-                        length( $ds_digest->{digest} ) != 40 ) ||
-                        $ds_digest->{digest} =~ /[^A-Fa-f0-9]/
-                );
-            }
         }
+
+        return @errors;
     };
     if ($@) {
-        handle_exception('validate_syntax', $@, '008');
-    }
-    elsif ($result) {
-        return $result;
+        handle_exception('start_domain_test_validate_syntax', $@, '008');
     }
     else {
-        return { status => 'ok', message =>  encode_entities( 'Syntax ok' ) };
+        return @errors;
     }
 }
 
@@ -362,26 +303,26 @@ $json_schemas{start_domain_test} = joi->object->strict->props(
     ipv4 => joi->boolean,
     ipv6 => joi->boolean,
     nameservers => joi->array->items(
-        $zm_validator->nameserver
+        # NOTE: Array items are not compiled automatically, so to enforce all properties we need to do it by hand
+        $zm_validator->nameserver->compile
     ),
     ds_info => joi->array->items(
-        $zm_validator->ds_info
+        $zm_validator->ds_info->compile
     ),
     profile => $zm_validator->profile_name,
     client_id => $zm_validator->client_id,
     client_version => $zm_validator->client_version,
     config => joi->string,
     priority => $zm_validator->priority,
-    queue => $zm_validator->queue
+    queue => $zm_validator->queue,
 );
+$extra_validators{start_domain_test} = \&start_domain_test_validate_syntax;
 sub start_domain_test {
     my ( $self, $params ) = @_;
 
     my $result = 0;
     eval {
         $params->{domain} =~ s/^\.// unless ( !$params->{domain} || $params->{domain} eq '.' );
-        my $syntax_result = $self->validate_syntax( $params );
-        die "$syntax_result->{message} \n" unless ( $syntax_result && $syntax_result->{status} eq 'ok' );
 
         die "No domain in parameters\n" unless ( $params->{domain} );
 
@@ -688,15 +629,17 @@ sub jsonrpc_validate {
                 }
             };
         }
-        my @error = $method_schema->validate($jsonrpc_request->{params});
-        if ( @error ) {
+
+        my  @error_response = $self->validate_params($jsonrpc_request->{method}, $jsonrpc_request->{params});
+
+        if ( scalar @error_response ) {
             return {
                 jsonrpc => '2.0',
                 id => $jsonrpc_request->{id},
                 error => {
                     code => '-32602',
                     message => 'Invalid method parameter(s).',
-                    data => "@error"
+                    data => \@error_response
                 }
             };
         }
@@ -704,4 +647,23 @@ sub jsonrpc_validate {
 
     return '';
 }
+
+sub validate_params {
+    my ( $self, $method, $params ) = @_;
+    my $method_schema = $json_schemas{$method};
+
+    my @error_response = ();
+
+    my @json_validation_error = $method_schema->validate( $params );
+
+    push @error_response, map { { message => $_->message, path => $_->path } } @json_validation_error;
+
+    # Add messages from extra validation function
+    if ( $extra_validators{$method} ) {
+        my $sub_validator = $extra_validators{$method};
+        push @error_response, $self->$sub_validator($params);
+    }
+    return @error_response;
+}
+
 1;

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -29,7 +29,7 @@ use Zonemaster::Backend::Validator;
 
 my $zm_validator = Zonemaster::Backend::Validator->new;
 my %json_schemas;
-my %extra_validators;
+our %extra_validators;
 my $recursor = Zonemaster::Engine::Recursor->new;
 
 sub joi {
@@ -152,7 +152,7 @@ sub get_host_by_name {
     return \@adresses;
 }
 
-sub get_data_from_parent_zone_validate_syntax {
+$extra_validators{get_data_from_parent_zone} = sub {
     my ( $self, $syntax_input ) = @_;
     my @errors;
 
@@ -161,11 +161,10 @@ sub get_data_from_parent_zone_validate_syntax {
         push @errors, { path => "/domain", message => $dn_syntax->{message} } if ( $dn_syntax->{status} eq 'nok' );
     }
     return @errors;
-}
+};
 $json_schemas{get_data_from_parent_zone} = joi->object->strict->props(
     domain   => $zm_validator->domain_name->required
 );
-$extra_validators{get_data_from_parent_zone} = \&get_data_from_parent_zone_validate_syntax;
 sub get_data_from_parent_zone {
     my ( $self, $params ) = @_;
 
@@ -257,7 +256,7 @@ sub _check_domain {
     return ( $domain, { status => 'ok', message => 'Syntax ok' } );
 }
 
-sub start_domain_test_validate_syntax {
+$extra_validators{start_domain_test} = sub {
     my ( $self, $syntax_input ) = @_;
 
     my @errors = eval {
@@ -296,7 +295,7 @@ sub start_domain_test_validate_syntax {
     else {
         return @errors;
     }
-}
+};
 
 $json_schemas{start_domain_test} = joi->object->strict->props(
     domain => $zm_validator->domain_name->required,
@@ -316,7 +315,6 @@ $json_schemas{start_domain_test} = joi->object->strict->props(
     priority => $zm_validator->priority,
     queue => $zm_validator->queue,
 );
-$extra_validators{start_domain_test} = \&start_domain_test_validate_syntax;
 sub start_domain_test {
     my ( $self, $params ) = @_;
 

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -58,7 +58,7 @@ our %EXPORT_TAGS = (
 Readonly my $IPV4_RE => qr/^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$/;
 
 # Does not check the length and number of the hex groups, nor the value ranges in the IPv4 groups
-Readonly my $IPV6_RE => qr/^[0-9a-f:]+(:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?$/i;
+Readonly my $IPV6_RE => qr/^[0-9a-f:]*:[0-9a-f:]+(:[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})?$/i;
 
 Readonly my $API_KEY_RE                 => qr/^[a-z0-9-_]{1,512}$/i;
 Readonly my $CLIENT_ID_RE               => qr/^[a-z0-9-+~_.: ]{1,50}$/i;

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -157,7 +157,7 @@ sub {
     };
 
     if ($json_error eq '') {
-        my $errors = Zonemaster::Backend::RPCAPI->jsonrpc_validate($content);
+        my $errors = $handler->jsonrpc_validate($content);
         if ($errors ne '') {
           $res = Plack::Response->new(200);
           $res->content_type('application/json');

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -40,4 +40,3 @@ locale = da_DK en_US fi_FI fr_FR nb_NO sv_SE
 
 [PRIVATE PROFILES]
 #example_profile_2=/example/directory/test2_profile.json
-

--- a/t/test01.t
+++ b/t/test01.t
@@ -135,12 +135,6 @@ sub run_zonemaster_test_with_backend_API {
     ok( defined $test_results->{creation_time},      'TEST1 $test_results->{creation_time} defined' );
     ok( defined $test_results->{results},            'TEST1 $test_results->{results} defined' );
     cmp_ok( scalar( @{ $test_results->{results} } ), '>', 1, 'TEST1 got some results' );
-
-    dies_ok { $engine->get_test_results( { id => $hash_id, language => 'fr-FR' } ); }
-    'API get_test_results -> [results] parameter not present (wrong language tag: underscore not hyphen)'; # Should be underscore, not hyphen.
-
-    dies_ok { $engine->get_test_results( { id => $hash_id, language => 'zz' } ); }
-    'API get_test_results -> [results] parameter not present (wrong language tag: "zz" unknown)'; # "zz" is not our configuration file.
 }
 
 run_zonemaster_test_with_backend_API(1);

--- a/t/test01.t
+++ b/t/test01.t
@@ -135,6 +135,12 @@ sub run_zonemaster_test_with_backend_API {
     ok( defined $test_results->{creation_time},      'TEST1 $test_results->{creation_time} defined' );
     ok( defined $test_results->{results},            'TEST1 $test_results->{results} defined' );
     cmp_ok( scalar( @{ $test_results->{results} } ), '>', 1, 'TEST1 got some results' );
+
+    dies_ok { $engine->get_test_results( { id => $hash_id, language => 'fr-FR' } ); }
+    'API get_test_results -> [results] parameter not present (wrong language tag: underscore not hyphen)'; # Should be underscore, not hyphen.
+
+    dies_ok { $engine->get_test_results( { id => $hash_id, language => 'zz' } ); }
+    'API get_test_results -> [results] parameter not present (wrong language tag: "zz" unknown)'; # "zz" is not our configuration file.
 }
 
 run_zonemaster_test_with_backend_API(1);

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -238,8 +238,17 @@ subtest 'Everything but NoWarnings' => sub {
     is( scalar $engine->validate_params( "start_domain_test", $frontend_params ), 1, encode_utf8( 'Invalid digest length' ) )
         or diag( encode_json $engine->validate_params( "start_domain_test", $frontend_params ) );
 
-    $frontend_params->{ds_info}->[0]->{algorithm} = 1;
     $frontend_params->{ds_info}->[0]->{digest}    = 'Z123456789012345678901234567890123456789';
     is( scalar $engine->validate_params( "start_domain_test", $frontend_params ), 1, encode_utf8( 'Invalid digest format' ) )
+        or diag(  encode_json $engine->validate_params( "start_domain_test", $frontend_params ) );
+
+    $frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
+    $frontend_params->{ds_info}->[0]->{digtype} = -1;
+    is( scalar $engine->validate_params( "start_domain_test", $frontend_params ), 1, encode_utf8( 'Invalid digest type' ) )
+        or diag(  encode_json $engine->validate_params( "start_domain_test", $frontend_params ) );
+
+    $frontend_params->{ds_info}->[0]->{digtype} = 1;
+    $frontend_params->{ds_info}->[0]->{keytag} = 'not a int';
+    is( scalar $engine->validate_params( "start_domain_test", $frontend_params ), 1, encode_utf8( 'Invalid keytag' ) )
         or diag(  encode_json $engine->validate_params( "start_domain_test", $frontend_params ) );
 };

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -30,6 +30,8 @@ my $engine = Zonemaster::Backend::RPCAPI->new(
     }
 );
 
+my $start_domain_test_validate_syntax = $Zonemaster::Backend::RPCAPI::extra_validators{start_domain_test};
+
 subtest 'Everything but NoWarnings' => sub {
 
     my $can_use_threads = eval 'use threads; 1';
@@ -45,93 +47,90 @@ subtest 'Everything but NoWarnings' => sub {
     ];
 
     subtest 'domain present' => sub {
-        my $res = $engine->start_domain_test_validate_syntax(
+        my @res = $engine->$start_domain_test_validate_syntax(
             {
                 %$frontend_params, domain => 'afnic.fr'
             }
         );
 
-        is( $res->{status}, 'ok' );
+        is( scalar @res, 0 );
     };
 
     subtest encode_utf8( 'idn domain=[é]' ) => sub {
-        my $res = $engine->start_domain_test_validate_syntax(
+        my @res = $engine->$start_domain_test_validate_syntax(
             {
                 %$frontend_params, domain => 'é'
             }
         );
 
-        is( $res->{status}, 'ok' )
-            or diag( $res->{message} );
+        is( scalar @res, 0 )
+            or diag( encode_json @res );
     };
 
     subtest encode_utf8( 'idn domain=[éé]' ) => sub {
-        my $res = $engine->start_domain_test_validate_syntax(
+        my @res = $engine->$start_domain_test_validate_syntax(
             {
                 %$frontend_params, domain => 'éé'
             }
         );
 
-        is( $res->{status}, 'ok' )
-            or diag( $res->{message} );
+        is( scalar @res, 0 )
+            or diag( encode_json @res );
     };
 
     subtest '253 characters long domain without dot' => sub {
-        my $res = $engine->start_domain_test_validate_syntax(
+        my @res = $engine->$start_domain_test_validate_syntax(
             {
                 %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com'
             }
         );
 
-        is(
-            $res->{status}, 'ok'
-        ) or diag( $res->{message} );
+        is( scalar @res, 0 )
+            or diag( encode_json @res );
     };
 
     subtest '254 characters long domain with trailing dot' => sub {
-        my $res = $engine->start_domain_test_validate_syntax(
+        my @res = $engine->$start_domain_test_validate_syntax(
             {
                 %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.'
             }
         );
 
-        is(
-            $res->{status}, 'ok'
-        ) or diag( $res->{message} );
+        is( scalar @res, 0 )
+            or diag( encode_json @res );
     };
 
     subtest '254 characters long domain without trailing dot' => sub {
-        my $res = $engine->start_domain_test_validate_syntax(
+        my @res = $engine->$start_domain_test_validate_syntax(
             {
                 %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club'
             }
         );
 
-        is(
-            $res->{status}, 'nok'
-        ) or diag( $res->{message} );
+        cmp_ok( scalar @res, '>', 0 )
+            or diag( encode_json @res );
     };
 
     subtest '63 characters long domain label' => sub {
-        my $res = $engine->start_domain_test_validate_syntax(
+        my @res = $engine->$start_domain_test_validate_syntax(
             {
                 %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789-63.fr'
             }
         );
 
-        is( $res->{status}, 'ok' )
-            or diag( $res->{message} );
+        is( scalar @res, 0 )
+            or diag( encode_json @res );
     };
 
     subtest '64 characters long domain label' => sub {
-        my $res = $engine->start_domain_test_validate_syntax(
+        my @res = $engine->$start_domain_test_validate_syntax(
             {
                 %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789--64.fr'
             }
         );
 
-        is( $res->{status}, 'nok')
-            or diag( $res->{message} );
+        cmp_ok( scalar @res, '>', 0 )
+            or diag( encode_json @res );
     };
 
     #TEST NS
@@ -140,80 +139,81 @@ subtest 'Everything but NoWarnings' => sub {
 
     # domain present?
     $frontend_params->{nameservers}->[0]->{ns} = 'afnic.fr';
-    is( $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'ok', 'domain present' );
+    is( scalar $engine->$start_domain_test_validate_syntax( $frontend_params ), 0, 'domain present' );
 
     # idn
     $frontend_params->{nameservers}->[0]->{ns} = 'é';
-    is( $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[é]' ) )
-        or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    is( scalar $engine->$start_domain_test_validate_syntax( $frontend_params ), 0, encode_utf8( 'idn domain=[é]' ) )
+        or diag( encode_json $engine->start_domain_test_validate_syntax( $frontend_params ) );
 
     # idn
     $frontend_params->{nameservers}->[0]->{ns} = 'éé';
-    is( $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'idn domain=[éé]' ) )
-        or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    is( scalar $engine->$start_domain_test_validate_syntax( $frontend_params ), 0, encode_utf8( 'idn domain=[éé]' ) )
+        or diag( encode_json $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     # 253 characters long domain without dot
     $frontend_params->{nameservers}->[0]->{ns} =
     '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com';
     is(
-        $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'ok',
+        scalar $engine->$start_domain_test_validate_syntax( $frontend_params ), 0,
         encode_utf8( '253 characters long domain without dot' )
-    ) or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    ) or diag( encode_json $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     # 254 characters long domain with trailing dot
     $frontend_params->{nameservers}->[0]->{ns} =
     '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.';
     is(
-        $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'ok',
+        $engine->$start_domain_test_validate_syntax( $frontend_params ), 0,
         encode_utf8( '254 characters long domain with trailing dot' )
-    ) or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    ) or diag( encode_json $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     # 254 characters long domain without trailing
     $frontend_params->{nameservers}->[0]->{ns} =
     '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club';
-    is(
-        $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'nok',
+    cmp_ok(
+        $engine->$start_domain_test_validate_syntax( $frontend_params ), '>', 0,
         encode_utf8( '254 characters long domain without trailing dot' )
-    ) or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    ) or diag( encode_json $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     # 63 characters long domain label
     $frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-63.fr';
-    is( $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'ok',
-        encode_utf8( '63 characters long domain label' ) )
-        or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    is(
+        scalar $engine->$start_domain_test_validate_syntax( $frontend_params ), 0,
+        encode_utf8( '63 characters long domain label' )
+    ) or diag( encode_json $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     # 64 characters long domain label
     $frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-64-.fr';
-    is( $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'nok',
+    cmp_ok( scalar $engine->$start_domain_test_validate_syntax( $frontend_params ), '>', 0,
         encode_utf8( '64 characters long domain label' ) )
-        or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+        or diag(encode_json  $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     # DELEGATED TEST
     delete( $frontend_params->{nameservers} );
 
     $frontend_params->{domain} = 'afnic.fr';
-    is( $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'delegated domain exists' ) )
-        or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    is( scalar $engine->$start_domain_test_validate_syntax( $frontend_params ), 0, encode_utf8( 'delegated domain exists' ) )
+        or diag( encode_json $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     # IP ADDRESS FORMAT
     $frontend_params->{domain} = 'afnic.fr';
     $frontend_params->{nameservers}->[0]->{ns} = 'ns1.nic.fr';
 
     $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
-    is( $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid IPV4' ) )
-        or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    is( scalar $engine->$start_domain_test_validate_syntax( $frontend_params ), 0, encode_utf8( 'Valid IPV4' ) )
+        or diag( encode_json $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4444';
-    is( $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid IPV4' ) )
-        or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    cmp_ok( scalar $engine->$start_domain_test_validate_syntax( $frontend_params ), '>', 0, encode_utf8( 'Invalid IPV4' ) )
+        or diag( encode_json $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     $frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bb';
-    is( $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'ok', encode_utf8( 'Valid IPV6' ) )
-        or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    is( $engine->$start_domain_test_validate_syntax( $frontend_params ), 0, encode_utf8( 'Valid IPV6' ) )
+        or diag( encode_json $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     $frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bbffffff';
-    is( $engine->start_domain_test_validate_syntax( $frontend_params )->{status}, 'nok', encode_utf8( 'Invalid IPV6' ) )
-        or diag( $engine->start_domain_test_validate_syntax( $frontend_params )->{message} );
+    cmp_ok( $engine->$start_domain_test_validate_syntax( $frontend_params ), '>', 0, encode_utf8( 'Invalid IPV6' ) )
+        or diag( encode_json $engine->$start_domain_test_validate_syntax( $frontend_params ) );
 
     # DS
     $frontend_params->{domain}                 = 'afnic.fr';
@@ -225,21 +225,21 @@ subtest 'Everything but NoWarnings' => sub {
     $frontend_params->{ds_info}->[0]->{digtype}   = 1;
     $frontend_params->{ds_info}->[0]->{keytag}   = 5000;
 
-    is( @{$engine->validate_params( "start_domain_test", $frontend_params )}, 0, encode_utf8( 'Valid Algorithm Type [numeric format]' ) )
+    is( scalar $engine->validate_params( "start_domain_test", $frontend_params ), 0, encode_utf8( 'Valid Algorithm Type [numeric format]' ) )
         or diag( encode_json $engine->validate_params( "start_domain_test", $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{algorithm} = 'a';
     $frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
-    is( @{$engine->validate_params( "start_domain_test", $frontend_params )}, 1, encode_utf8( 'Invalid Algorithm Type' ) )
+    is( scalar $engine->validate_params( "start_domain_test", $frontend_params ), 1, encode_utf8( 'Invalid Algorithm Type' ) )
         or diag(  encode_json $engine->validate_params( "start_domain_test", $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{algorithm} = 1;
     $frontend_params->{ds_info}->[0]->{digest}    = '01234567890123456789012345678901234567890';
-    is( @{$engine->validate_params( "start_domain_test", $frontend_params )}, 1, encode_utf8( 'Invalid digest length' ) )
+    is( scalar $engine->validate_params( "start_domain_test", $frontend_params ), 1, encode_utf8( 'Invalid digest length' ) )
         or diag( encode_json $engine->validate_params( "start_domain_test", $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{algorithm} = 1;
     $frontend_params->{ds_info}->[0]->{digest}    = 'Z123456789012345678901234567890123456789';
-    is( @{$engine->validate_params( "start_domain_test", $frontend_params )}, 1, encode_utf8( 'Invalid digest format' ) )
+    is( scalar $engine->validate_params( "start_domain_test", $frontend_params ), 1, encode_utf8( 'Invalid digest format' ) )
         or diag(  encode_json $engine->validate_params( "start_domain_test", $frontend_params ) );
 };

--- a/t/validator.t
+++ b/t/validator.t
@@ -58,6 +58,7 @@ subtest 'Everything but NoWarnings' => sub {
     subtest 'untaint_ip_address' => sub {
         is scalar untaint_ip_address( '192.0.2.1' ),                              '192.0.2.1',                              'accept: 192.0.2.1';
         is scalar untaint_ip_address( '192.0.2' ),                                undef,                                    'reject: 192.0.2';
+        is scalar untaint_ip_address( '192' ),                                    undef,                                    'reject: 192';
         is scalar untaint_ip_address( '192.0.2.1:3306' ),                         undef,                                    'reject: 192.0.2.1:3306';
         is scalar untaint_ip_address( '2001:db8::' ),                             '2001:db8::',                             'accept: 2001:db8::';
         is scalar untaint_ip_address( '2001:db8::/32' ),                          undef,                                    'reject: 2001:db8::/32';


### PR DESCRIPTION
## Purpose

This PR changes how error related to param validation are return to the client to allow better analysis client side. It also prevent the internal error due to failed validation.

## Context

Replaces #795.

Addresses #703, is a requirement for https://github.com/zonemaster/zonemaster-gui/issues/177 and https://github.com/zonemaster/zonemaster-gui/issues/178. Dependency for  #230.

## Changes

* The json validation error are split in an array of object to allow better parsing client side (thus enabling better error message on the GUI). The json validation error are mapped to a set of custom defined messages to allow more user friendly messages but also translation.
 
## How to test this PR

`curl -sH "Content-Type: application/json" --data '{"method":"start_domain_test","params":{"nameservers":[{"ns":"/!\\", "ip":":::1"}], "ds_info":[{"algorithm":-1, "digest":"not a keytag"}], "profile":"toto", "client_id":"toto", "domain":"dfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdfsdiis.se"},"id":1,"jsonrpc":"2.0"}' localhost:5000/api  | jq`
```json
{
  "id": 1,
  "jsonrpc": "2.0",
  "error": {
    "message": "Invalid method parameter(s).",
    "code": "-32602",
    "data": [
      {
        "path": "/ds_info/0/algorithm",
        "message": "-1 < minimum(0)"
      },
      {
        "message": "String does not match (?^ui:^[a-f0-9]{40}$|^[a-f0-9]{64}$|^[a-f0-9]{96}$).",
        "path": "/ds_info/0/digest"
      },
      {
        "path": "/ds_info/0/digtype",
        "message": "Missing property."
      },
      {
        "message": "Missing property.",
        "path": "/ds_info/0/keytag"
      },
      {
        "path": "/profile",
        "message": "Unknown profile"
      },
      {
        "message": "The domain name or label is too long",
        "path": "/domain"
      },
      {
        "message": "The domain name character(s) are not supported",
        "path": "/nameservers/0/ns"
      },
      {
        "message": "Invalid IP address",
        "path": "/nameservers/0/ip"
      }
    ]
  }
}
```