### PR TITLE
Update severity

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -290,12 +290,19 @@ Basic data type: string
 
 One of the strings (in order from least to most severe):
 
-* `"DEBUG"`
 * `"INFO"`
 * `"NOTICE"`
 * `"WARNING"`
 * `"ERROR"`
 * `"CRITICAL"`
+
+Severity levels in Zonemaster are defined in the [Severity Level Definitions]
+document. The following severity levels are not available through the RPCAPI
+(in order from least to most severe):
+
+* DEBUG3
+* DEBUG2
+* DEBUG
 
 
 ### Test id
@@ -931,15 +938,16 @@ An object with the following properties:
 
 * `"id"` A *test id*.
 * `"creation_time"`: A *timestamp*. Time when the Test was enqueued.
-* `"overall_result"`: A string. The most severe problem level logged in the test results.
-It could be:
-    * `"ok"`, all is normal
-    * `"warning"`, equivalent to the `"WARNING"` *severity level*.
-    * `"error"`, equivalent to the `"ERROR"` *severity level*.
-    * `"critical"`, equivalent to the `"CRITICAL"` *severity level*.
-
-
-> TODO: What about if the *test* was created with `add_batch_job` or something else?
+* `"overall_result"`: A string. It reflects the most severe problem level among
+  the test results for the test. It has one of the following values:
+  * `"ok"`, if there are only messages with *severity level* `"INFO"` or
+    `"NOTICE"`.
+  * `"warning"`, if there is at least one message with *severity level*
+    `"WARNING"`, but none with `"ERROR"` or `"CRITICAL"`.
+  * `"error"`, if there is at least one message with *severity level*
+    `"ERROR"`, but none with `"CRITICAL"`.
+  * `"critical"`, if there is at least one message with *severity level*
+    `"CRITICAL"`.
 
 
 #### `"error"`
@@ -1229,3 +1237,4 @@ The `"params"` object sent to `start_domain_test` or `add_batch_job` when the *t
 [Start_domain_test]:            #api-method-start_domain_test
 [net.ipv4]:                     https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv4
 [net.ipv6]:                     https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv6
+[Severity Level Definitions]:   https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -310,7 +310,7 @@ sub get_test_history {
         my $warning  = ( grep { $_->{level} eq 'WARNING' } @{ $h->{results} } );
 
         # More important overwrites
-        my $overall = 'INFO';
+        my $overall = 'ok';
         $overall = 'warning'  if $warning;
         $overall = 'error'    if $error;
         $overall = 'critical' if $critical;

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -305,7 +305,7 @@ sub get_test_history {
         my $warning  = ( grep { $_->{level} eq 'WARNING' } @{ $h->{results} } );
 
         # More important overwrites
-        my $overall = 'INFO';
+        my $overall = 'ok';
         $overall = 'warning'  if $warning;
         $overall = 'error'    if $error;
         $overall = 'critical' if $critical;


### PR DESCRIPTION
## Purpose

The specification of overall_severity and severity section were unclear. The implementation of overall_result was incorrect in MySQL and SQLite.

## Changes

Updates API.md, MySQL.pm and SQLite.pm.

## How to test this PR

Verify that all database engines reports overall_result "ok" for historic tests when all messages are INFO or NOTICE.
