### PR TITLE
Remove "priority" and "queue" parameters from fingerprint computation

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -691,8 +691,8 @@ the `test id` of the previous test will be returned. The default value of
 key in the configuration file.
 
 The parameters that are compared when to determine if two requests are to be
-considered to be the same are `domain`, `ipv6`, `ipv4`, `nameservers`, `ds_info`
-and `profile`.
+considered to be the same are `domain`, `ipv6`, `ipv4`, `nameservers`, `ds_info`,
+`profile` and `queue`.
 
 
 #### `"error"`

--- a/docs/API.md
+++ b/docs/API.md
@@ -691,8 +691,8 @@ the `test id` of the previous test will be returned. The default value of
 key in the configuration file.
 
 The parameters that are compared when to determine if two requests are to be
-considered to be the same are `domain`, `ipv6`, `ipv4`, `nameservers`, `ds_info`,
-`profile` and `queue`.
+considered to be the same are `domain`, `ipv6`, `ipv4`, `nameservers`, `ds_info`
+and `profile`.
 
 
 #### `"error"`

--- a/docs/API.md
+++ b/docs/API.md
@@ -691,8 +691,8 @@ the `test id` of the previous test will be returned. The default value of
 key in the configuration file.
 
 The parameters that are compared when to determine if two requests are to be
-considered to be the same are `domain`, `ipv6`, `ipv4`, `nameservers`, `ds_info`,
-`profile`, `priority` and `queue`.
+considered to be the same are `domain`, `ipv6`, `ipv4`, `nameservers`, `ds_info`
+and `profile`.
 
 
 #### `"error"`

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -196,6 +196,7 @@ sub _normalize_params {
     $normalized{ipv4}     = $$params{ipv4}      // $profile->get( 'net.ipv4' );
     $normalized{ipv6}     = $$params{ipv6}      // $profile->get( 'net.ipv6' );
     $normalized{profile}  = $$params{profile}   // "default";
+    $normalized{queue}    = $$params{queue}     // 0;
 
     my $array_ds_info = $$params{ds_info} // [];
     my @array_ds_info_sort = sort {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -190,13 +190,10 @@ sub _project_params {
 
     my %projection = ();
 
-    # some of these values are already set in RPCAPI
-    # however setting them here again is required for testing purpose
     $projection{domain}   = lc $$params{domain} // "";
     $projection{ipv4}     = $$params{ipv4}      // $profile->get( 'net.ipv4' );
     $projection{ipv6}     = $$params{ipv6}      // $profile->get( 'net.ipv6' );
     $projection{profile}  = $$params{profile}   // "default";
-    $projection{queue}    = $$params{queue}     // 0;
 
     my $array_ds_info = $$params{ds_info} // [];
     my @array_ds_info_sort = sort {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -183,20 +183,20 @@ sub _new_dbh {
     return $dbh;
 }
 
-sub _normalize_params {
+sub _project_params {
     my ( $self, $params ) = @_;
 
     my $profile = Zonemaster::Engine::Profile->effective;
 
-    my %normalized = ();
+    my %projection = ();
 
     # some of these values are already set in RPCAPI
     # however setting them here again is required for testing purpose
-    $normalized{domain}   = lc $$params{domain} // "";
-    $normalized{ipv4}     = $$params{ipv4}      // $profile->get( 'net.ipv4' );
-    $normalized{ipv6}     = $$params{ipv6}      // $profile->get( 'net.ipv6' );
-    $normalized{profile}  = $$params{profile}   // "default";
-    $normalized{queue}    = $$params{queue}     // 0;
+    $projection{domain}   = lc $$params{domain} // "";
+    $projection{ipv4}     = $$params{ipv4}      // $profile->get( 'net.ipv4' );
+    $projection{ipv6}     = $$params{ipv6}      // $profile->get( 'net.ipv6' );
+    $projection{profile}  = $$params{profile}   // "default";
+    $projection{queue}    = $$params{queue}     // 0;
 
     my $array_ds_info = $$params{ds_info} // [];
     my @array_ds_info_sort = sort {
@@ -206,7 +206,7 @@ sub _normalize_params {
         $a->{keytag}    <=> $b->{keytag}
     } @$array_ds_info;
 
-    $normalized{ds_info} = \@array_ds_info_sort;
+    $projection{ds_info} = \@array_ds_info_sort;
 
     my $array_nameservers = $$params{nameservers} // [];
     for my $nameserver (@$array_nameservers) {
@@ -220,9 +220,9 @@ sub _normalize_params {
         ( defined $a->{ip} and defined $b->{ip} and $a->{ip} cmp $b->{ip} )
     } @$array_nameservers;
 
-    $normalized{nameservers} = \@array_nameservers_sort;
+    $projection{nameservers} = \@array_nameservers_sort;
 
-    return \%normalized;
+    return \%projection;
 }
 
 sub _params_to_json_str {
@@ -238,9 +238,10 @@ sub _params_to_json_str {
 
 =head2 encode_params
 
-Encode the params object into a JSON string. The object is first normalized and
-additional properties are kept.  Returns a JSON string of a the using a union
-of the given hash and its normalization using default values, see
+Encode the params object into a JSON string. First a projection of some
+parameters is performed then all additional properties are kept.
+Returns a JSON string of a the using a union of the given hash and its
+normalization using default values, see
 L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/API.md#params-2>
 
 =cut
@@ -248,8 +249,8 @@ L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/API.md#param
 sub encode_params {
     my ( $self, $params ) = @_;
 
-    my $normalized_params = $self->_normalize_params( $params );
-    $params = { %$params, %$normalized_params };
+    my $projected_params = $self->_project_params( $params );
+    $params = { %$params, %$projected_params };
     my $encoded_params = $self->_params_to_json_str( $params );
 
     return $encoded_params;
@@ -258,7 +259,7 @@ sub encode_params {
 =head2 generate_fingerprint
 
 Returns a fingerprint of the hash passed in argument.
-The fingerprint is computed after normalizing the hash.
+The fingerprint is computed after projecting the hash.
 Such fingerprint are usefull to find similar tests in the database.
 
 =cut
@@ -266,8 +267,8 @@ Such fingerprint are usefull to find similar tests in the database.
 sub generate_fingerprint {
     my ( $self, $params ) = @_;
 
-    my $normalized_params = $self->_normalize_params( $params );
-    my $encoded_params = $self->_params_to_json_str( $normalized_params );
+    my $projected_params = $self->_project_params( $params );
+    my $encoded_params = $self->_params_to_json_str( $projected_params );
     my $fingerprint = md5_hex( encode_utf8( $encoded_params ) );
 
     return $fingerprint;
@@ -278,20 +279,19 @@ sub generate_fingerprint {
 
 Returns the value 1 if the test to be created is if type undelegated,
 else value 0. The test is considered to be undelegated if the "ds_info" or
-"nameservers" parameters is are defined with data after normalization.
+"nameservers" parameters is are defined with data after projection.
 
 =cut
 
 sub undelegated {
     my ( $self, $params ) = @_;
 
-    my $normalized_params = $self->_normalize_params( $params );
+    my $projected_params = $self->_project_params( $params );
 
-    return 1 if defined( $$normalized_params{ds_info}[0] );
-    return 1 if defined( $$normalized_params{nameservers}[0] );
+    return 1 if defined( $$projected_params{ds_info}[0] );
+    return 1 if defined( $$projected_params{nameservers}[0] );
     return 0;
 }
-
 
 
 no Moose::Role;

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -196,8 +196,6 @@ sub _normalize_params {
     $normalized{ipv4}     = $$params{ipv4}      // $profile->get( 'net.ipv4' );
     $normalized{ipv6}     = $$params{ipv6}      // $profile->get( 'net.ipv6' );
     $normalized{profile}  = $$params{profile}   // "default";
-    $normalized{priority} = $$params{priority}  // 10;
-    $normalized{queue}    = $$params{queue}     // 0;
 
     my $array_ds_info = $$params{ds_info} // [];
     my @array_ds_info_sort = sort {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -358,7 +358,6 @@ sub add_batch_job {
             my $undelegated = $self->undelegated ( $test_params );
 
             $sth->execute( $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params, $undelegated );
-            # $sth->execute( $test_params->{domain}, $batch_id, $priority, $queue_label, $fingerprint, $encoded_params, $undelegated );
         }
         $dbh->do( "CREATE INDEX test_results__hash_id ON test_results (hash_id, creation_time)" );
         $dbh->do( "CREATE INDEX test_results__params_deterministic_hash ON test_results (params_deterministic_hash)" );

--- a/t/db.t
+++ b/t/db.t
@@ -150,6 +150,22 @@ subtest 'encoding and fingerprint' => sub {
 
             isnt $fingerprint1, $fingerprint2, 'different profiles, different fingerprints';
         };
+        subtest 'different IP protocols' => sub {
+            my %params1 = (
+                domain => "example.com",
+                ipv4 => "true",
+                ipv6 => "false"
+            );
+            my %params2 = (
+                domain => "example.com",
+                ipv4 => "false",
+                ipv6 => "true"
+            );
+            my ( undef, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
+            my ( undef, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
+
+            isnt $fingerprint1, $fingerprint2, 'different IP protocols, different fingerprints';
+        };
     }
 };
 

--- a/t/db.t
+++ b/t/db.t
@@ -19,7 +19,7 @@ sub encode_and_fingerprint {
 subtest 'encoding and fingerprint' => sub {
 
     subtest 'missing properties' => sub {
-        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}';
+        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default","queue":0}';
 
         my %params = ( domain => "example.com" );
 
@@ -120,7 +120,7 @@ subtest 'encoding and fingerprint' => sub {
     };
 
     subtest 'garbage properties set' => sub {
-        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}';
+        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default","queue":0}';
         my %params1 = (
             domain => "example.com",
         );

--- a/t/db.t
+++ b/t/db.t
@@ -19,7 +19,7 @@ sub encode_and_fingerprint {
 subtest 'encoding and fingerprint' => sub {
 
     subtest 'missing properties' => sub {
-        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default","queue":0}';
+        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}';
 
         my %params = ( domain => "example.com" );
 
@@ -120,7 +120,7 @@ subtest 'encoding and fingerprint' => sub {
     };
 
     subtest 'garbage properties set' => sub {
-        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default","queue":0}';
+        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}';
         my %params1 = (
             domain => "example.com",
         );
@@ -149,20 +149,6 @@ subtest 'encoding and fingerprint' => sub {
             my ( undef, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
 
             isnt $fingerprint1, $fingerprint2, 'different profiles, different fingerprints';
-        };
-        subtest 'different queues' => sub {
-            my %params1 = (
-                domain => "example.com",
-                queue => 1
-            );
-            my %params2 = (
-                domain => "example.com",
-                queue => 2
-            );
-            my ( undef, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
-            my ( undef, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
-
-            isnt $fingerprint1, $fingerprint2, 'different queues, different fingerprints';
         };
     }
 };

--- a/t/db.t
+++ b/t/db.t
@@ -134,6 +134,37 @@ subtest 'encoding and fingerprint' => sub {
         is $fingerprint1, $fingerprint2, 'leave out garbage property in fingerprint computation...';
         is $encoded_params2, $expected_encoded_params, '...but keep it in the encoded string';
     };
+
+    subtest 'should have different fingerprints' => sub {
+        subtest 'different profiles' => sub {
+            my %params1 = (
+                domain => "example.com",
+                profile => "profile_1"
+            );
+            my %params2 = (
+                domain => "example.com",
+                profile => "profile_2"
+            );
+            my ( undef, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
+            my ( undef, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
+
+            isnt $fingerprint1, $fingerprint2, 'different profiles, different fingerprints';
+        };
+        subtest 'different queues' => sub {
+            my %params1 = (
+                domain => "example.com",
+                queue => 1
+            );
+            my %params2 = (
+                domain => "example.com",
+                queue => 2
+            );
+            my ( undef, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
+            my ( undef, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
+
+            isnt $fingerprint1, $fingerprint2, 'different queues, different fingerprints';
+        };
+    }
 };
 
 done_testing();

--- a/t/db.t
+++ b/t/db.t
@@ -19,7 +19,7 @@ sub encode_and_fingerprint {
 subtest 'encoding and fingerprint' => sub {
 
     subtest 'missing properties' => sub {
-        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"priority":10,"profile":"default","queue":0}';
+        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}';
 
         my %params = ( domain => "example.com" );
 
@@ -120,7 +120,7 @@ subtest 'encoding and fingerprint' => sub {
     };
 
     subtest 'garbage properties set' => sub {
-        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"priority":10,"profile":"default","queue":0}';
+        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}';
         my %params1 = (
             domain => "example.com",
         );


### PR DESCRIPTION
## Purpose

This PR removes the use of `queue` and `priority` in the fingerprint computation.

## Context

Fixes #815 

## Changes

Revert the use of `priority` and `queue` to compute the fingerprint added in #798.

**Remark**: this value is still kept in the JSON string stored into the `params` column.

## How to test this PR

1. create a test using `add_batch_job`:
    ```
    BATCHID=$(zmb add_batch_job --username zmb --api-key zmb --domain example.com | jq -r .result)
    ```
2. create a test using `start_domain_test` for the same domain:
    ```
    TESTID=$(zmb start_domain_test --domain example.com | jq -r .result)
    ```
3. wait for the batch job to finish:
    ```
    zmb get_batch_job_result --batch-id $BATCHID
    ```
4. check that `$TESTID` is the same as the id in the batch job
    ```
    diff <(echo $TESTID) <(zmb get_batch_job_result --batch-id $BATCHID | jq -r .result.finished_test_ids[0])
    ```

**Remark**: testing the other way around (starting with a single test and then the batch job) will result in the creation of 2 different tests. Currently there is no logic to reuse a previous test within the batch job.