### PR TITLE
add scripts to backfill undelegated fields in db

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -56,9 +56,11 @@ share/patch_db_README.txt
 share/patch_mysql_db_zonemaster_backend_ver_1.0.3.pl
 share/patch_mysql_db_zonemaster_backend_ver_5.0.0.pl
 share/patch_mysql_db_zonemaster_backend_ver_5.0.2.pl
+share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
 share/patch_postgresql_db_zonemaster_backend_ver_1.0.3.pl
 share/patch_postgresql_db_zonemaster_backend_ver_5.0.0.pl
 share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
+share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
 share/tmpfiles.conf
 share/travis_mysql_backend_config.ini
 share/travis_postgresql_backend_config.ini

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Older than 1.0.3                      | [Upgrade to 1.0.3]    |
 At least 1.0.3 but older than 1.1.0   | [Upgrade to 1.1.0]    |
 At least 1.1.0 but older than 5.0.0   | [Upgrade to 5.0.0]    |
 At least 5.0.0 but older than 5.0.2   | [Upgrade to 5.0.2]    | For MySQL/MariaDB only
-At least 5.0.2 but older than 7.0.0   | [Upgrade to 7.0.0]    | For all database types
+At least 5.0.2 but older than 7.0.0   | [Upgrade to 7.0.0]    |
 
 If the database was created before Zonemaster-Backend version 5.0.2, then you
 have to upgrade it in several steps.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Zonemaster Engine installed. Please see the
 instructions](https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md).
 
 
-### Upgrade 
+### Upgrade
 
 If you upgrade Zonemaster-Backend and want to keep the content of the database
 (SQLite, MySQL/MariaDB or PostgreSQL) then you should not reset the database when
@@ -40,7 +40,7 @@ Older than 1.0.3                      | [Upgrade to 1.0.3]    |
 At least 1.0.3 but older than 1.1.0   | [Upgrade to 1.1.0]    |
 At least 1.1.0 but older than 5.0.0   | [Upgrade to 5.0.0]    |
 At least 5.0.0 but older than 5.0.2   | [Upgrade to 5.0.2]    | For MySQL/MariaDB only
-At least 5.0.2 but older than 7.0.0   | [Upgrade to 7.0.0]    | For PostgreSQL only
+At least 5.0.2 but older than 7.0.0   | [Upgrade to 7.0.0]    | For all database types
 
 If the database was created before Zonemaster-Backend version 5.0.2, then you
 have to upgrade it in several steps.

--- a/docs/upgrade_db_zonemaster_backend_ver_7.0.0.md
+++ b/docs/upgrade_db_zonemaster_backend_ver_7.0.0.md
@@ -1,15 +1,6 @@
 If your zonemaster database was created by a Zonemaster-Backend version smaller
 than v7.0.0, and not upgraded, use the instructions in this file.
 
-### FreeBSD
-
-If the installation is on FreeBSD, then set the environment before running any
-of the commands below:
-
-```sh
-export ZONEMASTER_BACKEND_CONFIG_FILE="/usr/local/etc/zonemaster/backend_config.ini"
-```
-
 ### SQLite
 
 Run

--- a/docs/upgrade_db_zonemaster_backend_ver_7.0.0.md
+++ b/docs/upgrade_db_zonemaster_backend_ver_7.0.0.md
@@ -12,14 +12,20 @@ export ZONEMASTER_BACKEND_CONFIG_FILE="/usr/local/etc/zonemaster/backend_config.
 
 ### SQLite
 
-No patching (upgrading) is needed on zonemaster database on SQLite for this
-version of Zonemaster-Backend.
+Run
+```sh
+cd $(perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')
+perl patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
+```
 
 
 ### MySQL (or MariaDB)
 
-No patching (upgrading) is needed on zonemaster database on MySQL (or MariaDB)
-for this version of Zonemaster-Backend.
+Run
+```sh
+cd $(perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')
+perl patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
+```
 
 
 ### PostgreSQL
@@ -29,4 +35,3 @@ Run
 cd $(perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')
 perl patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
 ```
-

--- a/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
@@ -1,8 +1,5 @@
 use strict;
 use warnings;
-use utf8;
-use Data::Dumper;
-use Encode;
 use JSON::PP;
 
 use DBI qw(:utils);

--- a/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
@@ -21,8 +21,8 @@ sub patch_db {
     while ( my $row = $sth1->fetchrow_hashref ) {
         my $id = $row->{id};
         my $raw_params = decode_json($row->{params});
-        my $ds_info_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{ds_info}});
-        my $nameservers_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{nameservers}});
+        my $ds_info_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{ds_info}};
+        my $nameservers_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{nameservers}};
         my $undelegated = $ds_info_values > 0 || $nameservers_values > 0 || 0;
 
         $dbh->do('UPDATE test_results SET undelegated = ? where id = ?', undef, $undelegated, $id);

--- a/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
@@ -16,10 +16,11 @@ my $dbh = $db->dbh;
 
 
 sub patch_db {
-    my @arefs = $dbh->selectall_array('SELECT id, params from test_results', undef);
-    foreach my $row (@arefs) {
-        my $id = @$row[0];
-        my $raw_params = decode_json(@$row[1]);
+    my $sth1 = $dbh->prepare('SELECT id, params from test_results', undef);
+    $sth1->execute;
+    while ( my $row = $sth1->fetchrow_hashref ) {
+        my $id = $row->{id};
+        my $raw_params = decode_json($row->{params});
         my $ds_info_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{ds_info}});
         my $nameservers_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{nameservers}});
         my $undelegated = $ds_info_values > 0 || $nameservers_values > 0 || 0;

--- a/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use utf8;
+use Data::Dumper;
+use Encode;
+use JSON::PP;
+
+use DBI qw(:utils);
+
+use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB::MySQL;
+
+my $config = Zonemaster::Backend::Config->load_config();
+if ( $config->DB_engine ne 'MySQL' ) {
+    die "The configuration file does not contain the MySQL backend";
+}
+my $db = Zonemaster::Backend::DB::MySQL->from_config( $config );
+my $dbh = $db->dbh;
+
+
+sub patch_db {
+    my @arefs = $dbh->selectall_array('SELECT id, params from test_results', undef);
+    foreach my $row (@arefs) {
+        my $id = @$row[0];
+        my $raw_params = decode_json(@$row[1]);
+        my $ds_info_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{ds_info}});
+        my $nameservers_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{nameservers}});
+        my $undelegated = $ds_info_values > 0 || $nameservers_values > 0 || 0;
+
+        $dbh->do('UPDATE test_results SET undelegated = ? where id = ?', undef, $undelegated, $id);
+    }
+}
+
+patch_db();

--- a/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
@@ -20,7 +20,9 @@ sub patch_db {
     eval {
         $dbh->do( 'ALTER TABLE test_results ADD COLUMN undelegated integer NOT NULL DEFAULT 0' );
     };
-    print "Error while changing DB schema:  " . $@;
+    if ($@) {
+        print "Error while changing DB schema:  " . $@;
+    }
 
     $dbh->do( qq[
 update test_results set undelegated = test_results_undelegated.undelegated_bool::int

--- a/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
@@ -1,8 +1,5 @@
 use strict;
 use warnings;
-use utf8;
-use Data::Dumper;
-use Encode;
 
 use DBI qw(:utils);
 

--- a/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
@@ -20,8 +20,56 @@ sub patch_db {
     ####################################################################
     # TEST RESULTS
     ####################################################################
-    $dbh->do( 'ALTER TABLE test_results ADD COLUMN undelegated integer NOT NULL DEFAULT 0' );
+    $dbh->do( 'ALTER TABLE test_results ADD COLUMN IF NOT EXISTS undelegated integer NOT NULL DEFAULT 0' );
+    $dbh->do( qq[
+update test_results set undelegated = test_results_undelegated.undelegated_bool::int
+from (
+    select
+        test_results.id,
+        (
+            case when ds_filled.ds_filled is null then false else ds_filled.ds_filled end
+            or
+            case when ns_filled.ns_filled is null then false else ns_filled.ns_filled end
+        ) as undelegated_bool
+    from test_results
+    left join (
+        select
+            count(*) > 0 as ds_filled,
+            id
+        from (
+            select
+                jd.value,
+                id
+            from
+            (
+                select json_array_elements(params->'ds_info') as ja, id
+                from test_results
+            )  as s1,
+            json_each_text(ja) as jd
+        ) as s2
+        where value is not null and value::text != ''::text
+        group by id
+    ) as ds_filled on ds_filled.id = test_results.id
+    left join (
+            select
+            count(*) > 0 as ns_filled,
+            id
+        from (
+            select
+                jd.value,
+                id
+            from
+            (
+                select json_array_elements(params->'nameservers') as ja, id
+                from test_results
+            )  as s1,
+            json_each_text(ja) as jd
+        ) as s2
+        where value is not null and value::text != ''::text
+        group by id
+    ) as ns_filled on ns_filled.id = test_results.id
+) as test_results_undelegated where test_results.id = test_results_undelegated.id;
+    ] );
 }
 
 patch_db();
-

--- a/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
@@ -20,7 +20,11 @@ sub patch_db {
     ####################################################################
     # TEST RESULTS
     ####################################################################
-    $dbh->do( 'ALTER TABLE test_results ADD COLUMN IF NOT EXISTS undelegated integer NOT NULL DEFAULT 0' );
+    eval {
+        $dbh->do( 'ALTER TABLE test_results ADD COLUMN undelegated integer NOT NULL DEFAULT 0' );
+    };
+    print "Error while changing DB schema:  " . $@;
+
     $dbh->do( qq[
 update test_results set undelegated = test_results_undelegated.undelegated_bool::int
 from (

--- a/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
@@ -1,5 +1,7 @@
 use strict;
 use warnings;
+use JSON::PP;
+use Encode;
 
 use DBI qw(:utils);
 
@@ -10,69 +12,29 @@ my $config = Zonemaster::Backend::Config->load_config();
 if ( $config->DB_engine ne 'PostgreSQL' ) {
     die "The configuration file does not contain the PostgreSQL backend";
 }
-my $dbh = Zonemaster::Backend::DB::PostgreSQL->from_config( $config )->dbh;
+my $db = Zonemaster::Backend::DB::PostgreSQL->from_config( $config );
+my $dbh = $db->dbh;
+
 
 sub patch_db {
+    my $sth1 = $dbh->prepare('SELECT id, params from test_results', undef);
+    $sth1->execute;
+    while ( my $row = $sth1->fetchrow_hashref ) {
+        my $id = $row->{id};
+        my $raw_params;
 
-    ####################################################################
-    # TEST RESULTS
-    ####################################################################
-    eval {
-        $dbh->do( 'ALTER TABLE test_results ADD COLUMN undelegated integer NOT NULL DEFAULT 0' );
-    };
-    if ($@) {
-        print "Error while changing DB schema:  " . $@;
+        if (utf8::is_utf8($row->{params}) ) {
+            $raw_params = decode_json( encode_utf8 ( $row->{params} ) );
+        } else {
+            $raw_params = decode_json( $row->{params} );
+        }
+
+        my $ds_info_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{ds_info}};
+        my $nameservers_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{nameservers}};
+        my $undelegated = $ds_info_values > 0 || $nameservers_values > 0 || 0;
+
+        $dbh->do('UPDATE test_results SET undelegated = ? where id = ?', undef, $undelegated, $id);
     }
-
-    $dbh->do( qq[
-update test_results set undelegated = test_results_undelegated.undelegated_bool::int
-from (
-    select
-        test_results.id,
-        (
-            case when ds_filled.ds_filled is null then false else ds_filled.ds_filled end
-            or
-            case when ns_filled.ns_filled is null then false else ns_filled.ns_filled end
-        ) as undelegated_bool
-    from test_results
-    left join (
-        select
-            count(*) > 0 as ds_filled,
-            id
-        from (
-            select
-                jd.value,
-                id
-            from
-            (
-                select json_array_elements(params->'ds_info') as ja, id
-                from test_results
-            )  as s1,
-            json_each_text(ja) as jd
-        ) as s2
-        where value is not null and value::text != ''::text
-        group by id
-    ) as ds_filled on ds_filled.id = test_results.id
-    left join (
-            select
-            count(*) > 0 as ns_filled,
-            id
-        from (
-            select
-                jd.value,
-                id
-            from
-            (
-                select json_array_elements(params->'nameservers') as ja, id
-                from test_results
-            )  as s1,
-            json_each_text(ja) as jd
-        ) as s2
-        where value is not null and value::text != ''::text
-        group by id
-    ) as ns_filled on ns_filled.id = test_results.id
-) as test_results_undelegated where test_results.id = test_results_undelegated.id;
-    ] );
 }
 
 patch_db();

--- a/share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
@@ -1,8 +1,5 @@
 use strict;
 use warnings;
-use utf8;
-use Data::Dumper;
-use Encode;
 use JSON::PP;
 
 use DBI qw(:utils);

--- a/share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
@@ -21,8 +21,8 @@ sub patch_db {
     while ( my $row = $sth1->fetchrow_hashref ) {
         my $id = $row->{id};
         my $raw_params = decode_json($row->{params});
-        my $ds_info_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{ds_info}});
-        my $nameservers_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{nameservers}});
+        my $ds_info_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{ds_info}};
+        my $nameservers_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{nameservers}};
         my $undelegated = $ds_info_values > 0 || $nameservers_values > 0 || 0;
 
         $dbh->do('UPDATE test_results SET undelegated = ? where id = ?', undef, $undelegated, $id);

--- a/share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
@@ -16,10 +16,11 @@ my $dbh = $db->dbh;
 
 
 sub patch_db {
-    my @arefs = $dbh->selectall_array('SELECT id, params from test_results', undef);
-    foreach my $row (@arefs) {
-        my $id = @$row[0];
-        my $raw_params = decode_json(@$row[1]);
+    my $sth1 = $dbh->prepare('SELECT id, params from test_results', undef);
+    $sth1->execute;
+    while ( my $row = $sth1->fetchrow_hashref ) {
+        my $id = $row->{id};
+        my $raw_params = decode_json($row->{params});
         my $ds_info_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{ds_info}});
         my $nameservers_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{nameservers}});
         my $undelegated = $ds_info_values > 0 || $nameservers_values > 0 || 0;

--- a/share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+use utf8;
+use Data::Dumper;
+use Encode;
+use JSON::PP;
+
+use DBI qw(:utils);
+
+use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB::SQLite;
+
+my $config = Zonemaster::Backend::Config->load_config();
+if ( $config->DB_engine ne 'SQLite' ) {
+    die "The configuration file does not contain the SQLite backend";
+}
+my $db = Zonemaster::Backend::DB::SQLite->from_config( $config );
+my $dbh = $db->dbh;
+
+
+sub patch_db {
+    my @arefs = $dbh->selectall_array('SELECT id, params from test_results', undef);
+    foreach my $row (@arefs) {
+        my $id = @$row[0];
+        my $raw_params = decode_json(@$row[1]);
+        my $ds_info_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{ds_info}});
+        my $nameservers_values = scalar( map { grep (!/^$/, values( %$_ ) ) } @{$raw_params->{nameservers}});
+        my $undelegated = $ds_info_values > 0 || $nameservers_values > 0 || 0;
+
+        $dbh->do('UPDATE test_results SET undelegated = ? where id = ?', undef, $undelegated, $id);
+    }
+}
+
+patch_db();


### PR DESCRIPTION
## Purpose

Update the old 'undelegated' values in the database.
- [x] PostgreSQL tested with ~1% of the records of the zonemaster.net database on Postgres 9.3 and 13.3
- [x] SQLite
- [x] MySQL tested with  ~1% of the records of the zonemaster.net database on MariaDB 10.3

## Context

Fixes #829

## Changes

Add patch scripts.

## How to test this PR

### Postgres

* Check the value of delegated vs undelegated tests (all test are delegated, so the second query should return nothing except if you have the patch for undelegated tests in which case there can be a few).

  ```pgsql
  select DISTINCT params->>'ds_info' as ds_info, params->>'nameservers'  as nameservers from test_results where undelegated = 0 ;
  
  select DISTINCT params->>'ds_info' as ds_info, params->>'nameservers' as nameservers from test_results where undelegated = 1 ;
  ```
* Apply update script `perl zonemaster-backend/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl` (ignore error if the table has already been changed, "if not exists" is not compatible with PG 9.3)

* Repeat the first step to verify that all tests has been classified correctly.

### MySQL

* Check the value of delegated vs undelegated tests (all test are delegated, so the second query should return nothing except if you have the patch for undelegated tests in which case there can be a few).

  ```sql
   select distinct json_extract(params, '$.nameservers'), json_extract(params, '$.ds_info') from test_results where undelegated = 0;
  
   select distinct json_extract(params, '$.nameservers'), json_extract(params, '$.ds_info') from test_results where undelegated = 1;
  ```
* Apply update script `perl zonemaster-backend/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl`

* Repeat the first step to verify that all tests has been classified correctly.

