### PR TITLE
improve config search and add default freebsd config location

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,10 @@ before_install:
   - git clone --depth=1 --branch=$TRAVIS_BRANCH https://github.com/zonemaster/zonemaster-engine.git
   - ( cd zonemaster-engine && cpanm --verbose --notest . ) && rm -rf zonemaster-engine
 
+    # Install share files
+  - mkdir -p ./lib/auto/share/dist/
+  - ln -s ../../../../share ./lib/auto/share/dist/Zonemaster-Backend
+
 before_script:
     - if [[ "$TARGET" == "PostgreSQL" ]]; then psql -c "create user travis_zonemaster WITH PASSWORD 'travis_zonemaster';" -U postgres; fi
     - if [[ "$TARGET" == "PostgreSQL" ]]; then psql -c 'create database travis_zonemaster OWNER travis_zonemaster;' -U postgres; fi
@@ -122,4 +126,3 @@ before_script:
 
 script:
     - perl Makefile.PL && make test
-

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -17,16 +17,16 @@ use Zonemaster::Backend::DB;
 
 our $path;
 
-my @search_paths = (
-    '/etc/zonemaster/backend_config.ini',
-    '/usr/local/etc/zonemaster/backend_config.ini',
-    dist_file('Zonemaster-Backend', "backend_config.ini")
-);
-
 if ($ENV{ZONEMASTER_BACKEND_CONFIG_FILE}) {
     $path = $ENV{ZONEMASTER_BACKEND_CONFIG_FILE};
 }
 else {
+    my @search_paths = (
+        '/etc/zonemaster/backend_config.ini',
+        '/usr/local/etc/zonemaster/backend_config.ini',
+        dist_file('Zonemaster-Backend', "backend_config.ini")
+    );
+
     for my $default_path (@search_paths) {
         if ( -e $default_path ) {
             $path = $default_path;

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -17,7 +17,7 @@ use Zonemaster::Backend::DB;
 
 our $path;
 
-my @seatch_paths = (
+my @search_paths = (
     '/etc/zonemaster/backend_config.ini',
     '/usr/local/etc/zonemaster/backend_config.ini',
     dist_file('Zonemaster-Backend', "backend_config.ini")
@@ -27,7 +27,7 @@ if ($ENV{ZONEMASTER_BACKEND_CONFIG_FILE}) {
     $path = $ENV{ZONEMASTER_BACKEND_CONFIG_FILE};
 }
 else {
-    for my $default_path (@seatch_paths) {
+    for my $default_path (@search_paths) {
         if ( -e $default_path ) {
             $path = $default_path;
             last;

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -16,14 +16,23 @@ use Zonemaster::Backend::Validator qw( :untaint );
 use Zonemaster::Backend::DB;
 
 our $path;
+
+my @seatch_paths = (
+    '/etc/zonemaster/backend_config.ini',
+    '/usr/local/etc/zonemaster/backend_config.ini',
+    dist_file('Zonemaster-Backend', "backend_config.ini")
+);
+
 if ($ENV{ZONEMASTER_BACKEND_CONFIG_FILE}) {
     $path = $ENV{ZONEMASTER_BACKEND_CONFIG_FILE};
 }
-elsif ( -e '/etc/zonemaster/backend_config.ini' ) {
-    $path = '/etc/zonemaster/backend_config.ini';
-}
 else {
-    $path = dist_file('Zonemaster-Backend', "backend_config.ini");
+    for my $default_path (@seatch_paths) {
+        if ( -e $default_path ) {
+            $path = $default_path;
+            last;
+        }
+    }
 }
 
 Readonly my @SIG_NAME => split ' ', $Config{sig_name};


### PR DESCRIPTION
## Purpose

Improve the config search mechanism 

## Context
Following the comment https://github.com/zonemaster/zonemaster-backend/pull/833#issuecomment-888965227

## Changes

* iterate through a default config location list to find an existing file
* add default freebsd location to the search list (`/usr/local/etc/zonemaster/backend_config.ini`)
* update travis file to correctly install the share directory

## How to test this PR

* Create the file `/etc/zonemaster/backend_config.ini`, run the backend, check that this is the config file loaded, then delete it
* Create the file `/usr/local/etc/zonemaster/backend_config.ini`, run the backend, check that this is the config file loaded, then delete it
* Create the file `/tmp/my_config.ini`, set the environment variable `ZONEMASTER_BACKEND_CONFIG_FILE` to `/tmp/my_config.ini`, run the backend, check that this is the config file loaded, then delete it