### PR TITLE
allow ipv4 mapped addresses

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -579,7 +579,7 @@ sub add_api_user {
     eval {
         my $allow = 0;
         if ( defined $remote_ip ) {
-            $allow = 1 if ( $remote_ip eq '::1' || $remote_ip eq '127.0.0.1' );
+            $allow = 1 if ( $remote_ip eq '::1' || $remote_ip eq '127.0.0.1' || $remote_ip eq '::ffff:127.0.0.1' );
         }
         else {
             $allow = 1;


### PR DESCRIPTION
## Context

Fix add_api_user method on dual stack computer when querying 127.0.0.1.

## Changes

Add the mapped address `::ffff:127.0.0.1` to the list of authorized remotes.

## How to test this PR

executing `zmb -s http://127.0.0.1:5000 add_api_user --username toto --api-key secret` on a dual stack computer should work and return 1 as result.
