### PR TITLE
add undelegated value in results history

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -944,12 +944,12 @@ Example response:
     {
       "id": "c45a3f8256c4a155",
       "creation_time": "2016-11-15 11:53:13.965982",
-      "undelegated": 1,
+      "undelegated": true,
       "overall_result": "error",
     },
     {
       "id": "32dd4bc0582b6bf9",
-      "undelegated": 0,
+      "undelegated": false,
       "creation_time": "2016-11-14 08:46:41.532047",
       "overall_result": "error",
     },

--- a/docs/API.md
+++ b/docs/API.md
@@ -1000,7 +1000,7 @@ An object with the following properties:
     `"ERROR"`, but none with `"CRITICAL"`.
   * `"critical"`, if there is at least one message with *severity level*
     `"CRITICAL"`.
-* `"undelegated"`: `1` if the test is undelegated, `0` otherwise.
+* `"undelegated"`: `true` if the test is undelegated, `false` otherwise.
 
 #### `"error"`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -255,7 +255,7 @@ Properties:
 ### Non-negative integer
 
 Basic data type: number (integer)
- 
+
 A non-negative integer is either zero or strictly positive.
 
 
@@ -371,7 +371,7 @@ The object has three keys, `"module"`, `"message"` and `"level"`.
 
 Sometimes additional keys are present.
 
-* `"ns"`: a *domain name*. The name server used by the *test module*. 
+* `"ns"`: a *domain name*. The name server used by the *test module*.
 This key is added when the module name is `"NAMESERVER"`.
 
 
@@ -734,7 +734,7 @@ An object with the following properties:
 
 #### `"result"`
 
-A *test id*. 
+A *test id*.
 
 If a test has been requested with the same parameters (as listed below) not more
 than "reuse time" ago, then a new request will not trigger a new test. Instead
@@ -887,7 +887,7 @@ In the case of a test created with `start_domain_test`:
 
 * `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued.
 * `"id"`: An integer.
-* `"hash_id"`: A *test id*. The *test* in question. 
+* `"hash_id"`: A *test id*. The *test* in question.
 * `"params"`: A normalized version `"params"` object sent to
   `start_domain_test` when the *test* was started.
 * `"results"`: A list of *test result* objects.
@@ -896,7 +896,7 @@ In the case of a test created with `start_domain_test`:
 In the case of a test created with `add_batch_job`:
 * `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued.
 * `"id"`: An integer.
-* `"hash_id"`: A *test id*. The *test* in question. 
+* `"hash_id"`: A *test id*. The *test* in question.
 * `"params"`: A normalized version `"params"` object sent to `add_batch_job`
   when the *test* was started.
 * `"results"`: the result is a list of *test id* corresponding to each tested
@@ -944,10 +944,12 @@ Example response:
     {
       "id": "c45a3f8256c4a155",
       "creation_time": "2016-11-15 11:53:13.965982",
+      "undelegated": 1,
       "overall_result": "error",
     },
     {
       "id": "32dd4bc0582b6bf9",
+      "undelegated": 0,
       "creation_time": "2016-11-14 08:46:41.532047",
       "overall_result": "error",
     },
@@ -1013,7 +1015,7 @@ In order to use advanced api features such as the *batch test*, it's necessaire 
 This key can be obtained with the creation of a user in the system.
 This function allow the creation of a new user and so, the creation of a new api key.
 
-Add a new *user* 
+Add a new *user*
 
 This method requires the *administrative* *privilege level*.
 
@@ -1067,7 +1069,7 @@ Trying to add a already existing user:
 ```
 
 Ommitting params:
-```json 
+```json
 {
   "message": "username or api_key not provided to the method add_api_user\n",
   "code": -32603
@@ -1129,7 +1131,7 @@ An object with the following properties:
 The value of `"test_params"` is an object with the following properties:
 
 * `"client_id"`: A *client id*, optional. (default: unset)
-* `"profile"`: A [*profile name*][profile name], optional (default: 
+* `"profile"`: A [*profile name*][profile name], optional (default:
   `"default"`). Run the tests using the given profile.
 * `"client_version"`: A *client version*, optional. (default: unset)
 * `"nameservers"`: A list of [*name server*][Name server] objects, optional. (default: `[]`)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1000,7 +1000,7 @@ An object with the following properties:
     `"ERROR"`, but none with `"CRITICAL"`.
   * `"critical"`, if there is at least one message with *severity level*
     `"CRITICAL"`.
-
+* `"undelegated"`: `1` if the test is undelegated, `0` otherwise.
 
 #### `"error"`
 

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -275,6 +275,7 @@ sub get_test_history {
                 hash_id,
                 CONVERT_TZ(`creation_time`, @@session.time_zone, '+00:00') AS creation_time,
                 params,
+                undelegated,
                 results
             FROM
                 test_results
@@ -291,6 +292,7 @@ sub get_test_history {
                 hash_id,
                 CONVERT_TZ(`creation_time`, @@session.time_zone, '+00:00') AS creation_time,
                 params,
+                undelegated,
                 results
             FROM
                 test_results
@@ -321,6 +323,7 @@ sub get_test_history {
             {
                 id               => $h->{hash_id},
                 creation_time    => $h->{creation_time},
+                undelegated      => $h->{undelegated},
                 overall_result   => $overall,
             }
         );

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -267,6 +267,7 @@ sub get_test_history {
             (SELECT count(*) FROM (SELECT json_array_elements(results) AS result) AS t1 WHERE result->>'level'='WARNING') AS nb_warning,
             id,
             hash_id,
+            undelegated,
             creation_time at time zone current_setting('TIMEZONE') at time zone 'UTC' as creation_time
         FROM test_results
         WHERE params->>'domain'=" . $dbh->quote( $p->{frontend_params}->{domain} ) . " $undelegated
@@ -291,6 +292,7 @@ sub get_test_history {
             {
                 id               => $h->{hash_id},
                 creation_time    => $h->{creation_time},
+                undelegated      => $h->{undelegated},
                 overall_result   => $overall_result,
             }
         );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -290,6 +290,7 @@ sub get_test_history {
                     hash_id,
                     creation_time,
                     params,
+                    undelegated,
                     results
                  FROM
                     test_results
@@ -314,6 +315,7 @@ sub get_test_history {
               {
                   id => $h->{hash_id},
                   creation_time => $h->{creation_time},
+                  undelegated      => $h->{undelegated},
                   overall_result   => $overall,
               }
             );

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -559,6 +559,9 @@ sub get_test_history {
         $params->{filter} //= "all";
 
         $results = $self->{db}->get_test_history( $params );
+        my @results = map { { %$_, undelegated => $_->{undelegated} ? JSON::PP::true : JSON::PP::false } } @$results;
+        $results = \@results;
+
     };
     if ($@) {
         handle_exception('get_test_history', $@, '013');


### PR DESCRIPTION
## Purpose

Add more information on the tests in history.

## Context

#830

## Changes

Return an `undelegated` in the test history items.

## How to test this PR

Create a delegated and undelegated test, then query the history and check the `undelegated` property:    
`./script/zmb get_test_history --domain toto.com --filter all | jq`

```json
{
  "jsonrpc": "2.0",
  "result": [
    {
      "creation_time": "2021-08-04 08:13:16",
      "id": "9aa193588f53b8d8",
      "overall_result": "error",
      "undelegated": 1
    },
    {
      "id": "b60fb8f881b199f8",
      "creation_time": "2021-07-20 08:39:01",
      "undelegated": 0,
      "overall_result": "error"
    }
  ],
  "id": 1
}
```
