### PR TITLE
use plack reverse proxy middleware to get real remote ip

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,6 +33,7 @@ requires
   'Try::Tiny'                   => 0.12,
   'Zonemaster::Engine'          => 4.002,
   'Zonemaster::LDNS'            => 2.002,
+  'Plack::Middleware::ReverseProxy' => 0,
   ;
 
 test_requires 'DBD::SQLite';

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -59,13 +59,15 @@ Available keys: `enable_batch_jobs`, `enable_add_api_user`.
 
 Boolean value to enable the batch jobs methods of the API.
 
-Accpected values: 0 or 1, default to 0 (disabled).
+Accpected values: `yes` (or `true`) or `no` (or `false`),
+default to `no` (disabled).
 
 ### enable_add_api_user
 
 Boolean value to enable the `add_api_user` method of the API.
 
-Accpected values: 0 or 1, default to 0 (disabled).
+Accpected values: `yes` (or `true`) or `no` (or `false`),
+default to `no` (disabled).
 
 
 ## DB section

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -53,11 +53,11 @@ Each section in `backend_config.ini` is documented below.
 
 ## RPCAPI section
 
-Available keys: `enable_batch_jobs`, `enable_add_api_user`.
+Available keys: `enable_add_batch_job`, `enable_add_api_user`.
 
-### enable_batch_jobs
+### enable_add_batch_job
 
-Boolean value to enable the batch jobs methods of the API.
+Boolean value to enable the `enable_add_batch_job` methods of the API.
 
 Accpected values: `yes` (or `true`) or `no` (or `false`),
 default to `no` (disabled).

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -51,6 +51,23 @@ Repeating a key name in one section is forbidden.
 
 Each section in `backend_config.ini` is documented below.
 
+## API section
+
+Available keys: `enable_batch_jobs`, `enable_add_api_user`.
+
+### enable_batch_jobs
+
+Boolean value to enable the batch jobs methods of the API.
+
+Accpected values: 0 or 1, default to 0 (disabled).
+
+### enable_add_api_user
+
+Boolean value to enable the `add_api_user` method of the API.
+
+Accpected values: 0 or 1, default to 0 (disabled).
+
+
 ## DB section
 
 Available keys : `engine`, `user`, `password`, `database_name`,

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -59,14 +59,14 @@ Available keys: `enable_add_batch_job`, `enable_add_api_user`.
 
 Boolean value to enable the `enable_add_batch_job` methods of the API.
 
-Accpected values: `yes` (or `true`) or `no` (or `false`),
+Accepted values: `yes` (or `true`) or `no` (or `false`),
 default to `no` (disabled).
 
 ### enable_add_api_user
 
 Boolean value to enable the `add_api_user` method of the API.
 
-Accpected values: `yes` (or `true`) or `no` (or `false`),
+Accepted values: `yes` (or `true`) or `no` (or `false`),
 default to `no` (disabled).
 
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -60,14 +60,14 @@ Available keys: `enable_add_batch_job`, `enable_add_api_user`.
 Boolean value to enable the `enable_add_batch_job` methods of the API.
 
 Accepted values: `yes` (or `true`) or `no` (or `false`),
-default to `no` (disabled).
+default to `yes` (enabled).
 
 ### enable_add_api_user
 
 Boolean value to enable the `add_api_user` method of the API.
 
 Accepted values: `yes` (or `true`) or `no` (or `false`),
-default to `yes` (enabled).
+default to `no` (disabled).
 
 
 ## DB section

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -67,7 +67,7 @@ default to `no` (disabled).
 Boolean value to enable the `add_api_user` method of the API.
 
 Accepted values: `yes` (or `true`) or `no` (or `false`),
-default to `no` (disabled).
+default to `yes` (enabled).
 
 
 ## DB section

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -51,7 +51,7 @@ Repeating a key name in one section is forbidden.
 
 Each section in `backend_config.ini` is documented below.
 
-## API section
+## RPCAPI section
 
 Available keys: `enable_batch_jobs`, `enable_add_api_user`.
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -72,7 +72,7 @@ sudo yum -y install jq perl-Class-Method-Modifiers perl-Config-IniFiles perl-DBD
 Install dependencies not available from binary packages:
 
 ```sh
-sudo cpanm Daemon::Control JSON::Validator Log::Any Log::Any::Adapter::Dispatch Starman
+sudo cpanm Daemon::Control JSON::Validator Log::Any Log::Any::Adapter::Dispatch Starman Plack::Middleware::ReverseProxy
 ```
 
 Install Zonemaster::Backend:
@@ -195,7 +195,7 @@ sv_SE.utf8
 Install dependencies available from binary packages:
 
 ```sh
-sudo apt install jq libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libio-stringy-perl libjson-pp-perl libjson-rpc-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtest-nowarnings-perl libtry-tiny-perl starman
+sudo apt install jq libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libio-stringy-perl libjson-pp-perl libjson-rpc-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl libplack-middleware-reverseproxy-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtest-nowarnings-perl libtry-tiny-perl starman
 ```
 
 > **Note**: libio-stringy-perl is listed here even though it's not a direct
@@ -315,7 +315,7 @@ su -l
 Install dependencies available from binary packages:
 
 ```sh
-pkg install jq p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote p5-DBD-SQLite p5-Log-Dispatch p5-Log-Any p5-Log-Any-Adapter-Dispatch p5-JSON-Validator p5-YAML-LibYAML p5-Test-NoWarnings
+pkg install jq p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Plack-Middleware-ReverseProxy p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote p5-DBD-SQLite p5-Log-Dispatch p5-Log-Any p5-Log-Any-Adapter-Dispatch p5-JSON-Validator p5-YAML-LibYAML p5-Test-NoWarnings
 ```
 <!-- JSON::Validator requires YAML::PP, but p5-JSON-Validator currently lacks a dependency on p5-YAML-LibYAML -->
 

--- a/docs/upgrade_db_zonemaster_backend_ver_7.0.0.md
+++ b/docs/upgrade_db_zonemaster_backend_ver_7.0.0.md
@@ -8,6 +8,7 @@ Run
 cd $(perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')
 perl patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
 ```
+<<<<<<< HEAD
 
 
 ### MySQL (or MariaDB)
@@ -26,3 +27,5 @@ Run
 cd $(perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')
 perl patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
 ```
+=======
+>>>>>>> 10ff7f7 (remove new deps instruction)

--- a/docs/upgrade_db_zonemaster_backend_ver_7.0.0.md
+++ b/docs/upgrade_db_zonemaster_backend_ver_7.0.0.md
@@ -8,7 +8,6 @@ Run
 cd $(perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')
 perl patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
 ```
-<<<<<<< HEAD
 
 
 ### MySQL (or MariaDB)
@@ -27,5 +26,3 @@ Run
 cd $(perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')
 perl patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
 ```
-=======
->>>>>>> 10ff7f7 (remove new deps instruction)

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -146,7 +146,7 @@ sub parse {
     $obj->_set_ZONEMASTER_lock_on_queue( '0' );
     $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
     $obj->_set_RPCAPI_enable_add_api_user( 'no' );
-    $obj->_set_RPCAPI_enable_add_batch_job( 'yes' );
+    $obj->_set_RPCAPI_enable_add_batch_job( 'no' );
     $obj->_add_LANGUAGE_locale( 'en_US' );
     $obj->_add_public_profile( 'default', undef );
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -146,7 +146,7 @@ sub parse {
     $obj->_set_ZONEMASTER_lock_on_queue( '0' );
     $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
     $obj->_set_RPCAPI_enable_add_api_user( 'no' );
-    $obj->_set_RPCAPI_enable_batch_jobs( 'no' );
+    $obj->_set_RPCAPI_enable_add_batch_job( 'yes' );
     $obj->_add_LANGUAGE_locale( 'en_US' );
     $obj->_add_public_profile( 'default', undef );
 
@@ -280,8 +280,8 @@ sub parse {
     if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
         $obj->_set_RPCAPI_enable_add_api_user( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_batch_jobs' ) ) ) {
-        $obj->_set_RPCAPI_enable_batch_jobs( $value );
+    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
+        $obj->_set_RPCAPI_enable_add_batch_job( $value );
     }
     if ( defined( my $value = $get_and_clear->( 'LANGUAGE', 'locale' ) ) ) {
         if ( $value ne "" ) {
@@ -584,10 +584,10 @@ Return 0 or 1
 
 =cut
 
-=head2 RPCAPI_enable_batch_jobs
+=head2 RPCAPI_enable_add_batch_job
 
 Get the value of
-L<RPCAPI.enable_batch_jobs|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#enable_batch_jobs>.
+L<RPCAPI.enable_add_batch_job|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#enable_add_batch_job>.
 
 Return 0 or 1
 
@@ -615,8 +615,8 @@ sub ZONEMASTER_lock_on_queue                            { return $_[0]->{_ZONEMA
 sub ZONEMASTER_number_of_processes_for_frontend_testing { return $_[0]->{_ZONEMASTER_number_of_processes_for_frontend_testing}; }
 sub ZONEMASTER_number_of_processes_for_batch_testing    { return $_[0]->{_ZONEMASTER_number_of_processes_for_batch_testing}; }
 sub ZONEMASTER_age_reuse_previous_test                  { return $_[0]->{_ZONEMASTER_age_reuse_previous_test}; }
-sub RPCAPI_enable_add_api_user                             { return $_[0]->{_RPCAPI_enable_add_api_user}; }
-sub RPCAPI_enable_batch_jobs                               { return $_[0]->{_RPCAPI_enable_batch_jobs}; }
+sub RPCAPI_enable_add_api_user                          { return $_[0]->{_RPCAPI_enable_add_api_user}; }
+sub RPCAPI_enable_add_batch_job                         { return $_[0]->{_RPCAPI_enable_add_batch_job}; }
 
 # Compile time generation of setters for the properties documented above
 UNITCHECK {
@@ -639,7 +639,7 @@ UNITCHECK {
     _create_setter( '_set_ZONEMASTER_number_of_processes_for_batch_testing',    '_ZONEMASTER_number_of_processes_for_batch_testing',    \&untaint_non_negative_int );
     _create_setter( '_set_ZONEMASTER_age_reuse_previous_test',                  '_ZONEMASTER_age_reuse_previous_test',                  \&untaint_strictly_positive_int );
     _create_setter( '_set_RPCAPI_enable_add_api_user',                          '_RPCAPI_enable_add_api_user',                          \&untaint_bool );
-    _create_setter( '_set_RPCAPI_enable_batch_jobs',                            '_RPCAPI_enable_batch_jobs',                            \&untaint_bool );
+    _create_setter( '_set_RPCAPI_enable_add_batch_job',                         '_RPCAPI_enable_add_batch_job',                         \&untaint_bool );
 }
 
 =head2 new_DB

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -127,7 +127,7 @@ sub parse {
 
     # Validate section names
     {
-        my %sections = map { $_ => 1 } ( 'DB', 'MYSQL', 'POSTGRESQL', 'SQLITE', 'LANGUAGE', 'PUBLIC PROFILES', 'PRIVATE PROFILES', 'ZONEMASTER', 'API');
+        my %sections = map { $_ => 1 } ( 'DB', 'MYSQL', 'POSTGRESQL', 'SQLITE', 'LANGUAGE', 'PUBLIC PROFILES', 'PRIVATE PROFILES', 'ZONEMASTER', 'RPCAPI');
         for my $section ( $ini->Sections ) {
             if ( !exists $sections{$section} ) {
                 die "config: unrecognized section: $section\n";
@@ -145,8 +145,8 @@ sub parse {
     $obj->_set_ZONEMASTER_number_of_processes_for_batch_testing( '20' );
     $obj->_set_ZONEMASTER_lock_on_queue( '0' );
     $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
-    $obj->_set_API_enable_add_api_user( 'no' );
-    $obj->_set_API_enable_batch_jobs( 'no' );
+    $obj->_set_RPCAPI_enable_add_api_user( 'no' );
+    $obj->_set_RPCAPI_enable_batch_jobs( 'no' );
     $obj->_add_LANGUAGE_locale( 'en_US' );
     $obj->_add_public_profile( 'default', undef );
 
@@ -277,11 +277,11 @@ sub parse {
     if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'age_reuse_previous_test' ) ) ) {
         $obj->_set_ZONEMASTER_age_reuse_previous_test( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'API', 'enable_add_api_user' ) ) ) {
-        $obj->_set_API_enable_add_api_user( $value );
+    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
+        $obj->_set_RPCAPI_enable_add_api_user( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'API', 'enable_batch_jobs' ) ) ) {
-        $obj->_set_API_enable_batch_jobs( $value );
+    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_batch_jobs' ) ) ) {
+        $obj->_set_RPCAPI_enable_batch_jobs( $value );
     }
     if ( defined( my $value = $get_and_clear->( 'LANGUAGE', 'locale' ) ) ) {
         if ( $value ne "" ) {
@@ -575,19 +575,19 @@ Returns a number.
 
 =cut
 
-=head2 API_enable_add_api_user
+=head2 RPCAPI_enable_add_api_user
 
 Get the value of
-L<API.enable_add_api_user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#enable_add_api_user>.
+L<RPCAPI.enable_add_api_user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#enable_add_api_user>.
 
 Return 0 or 1
 
 =cut
 
-=head2 API_enable_batch_jobs
+=head2 RPCAPI_enable_batch_jobs
 
 Get the value of
-L<API.enable_batch_jobs|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#enable_batch_jobs>.
+L<RPCAPI.enable_batch_jobs|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#enable_batch_jobs>.
 
 Return 0 or 1
 
@@ -615,8 +615,8 @@ sub ZONEMASTER_lock_on_queue                            { return $_[0]->{_ZONEMA
 sub ZONEMASTER_number_of_processes_for_frontend_testing { return $_[0]->{_ZONEMASTER_number_of_processes_for_frontend_testing}; }
 sub ZONEMASTER_number_of_processes_for_batch_testing    { return $_[0]->{_ZONEMASTER_number_of_processes_for_batch_testing}; }
 sub ZONEMASTER_age_reuse_previous_test                  { return $_[0]->{_ZONEMASTER_age_reuse_previous_test}; }
-sub API_enable_add_api_user                             { return $_[0]->{_API_enable_add_api_user}; }
-sub API_enable_batch_jobs                               { return $_[0]->{_API_enable_batch_jobs}; }
+sub RPCAPI_enable_add_api_user                             { return $_[0]->{_RPCAPI_enable_add_api_user}; }
+sub RPCAPI_enable_batch_jobs                               { return $_[0]->{_RPCAPI_enable_batch_jobs}; }
 
 # Compile time generation of setters for the properties documented above
 UNITCHECK {
@@ -638,8 +638,8 @@ UNITCHECK {
     _create_setter( '_set_ZONEMASTER_number_of_processes_for_frontend_testing', '_ZONEMASTER_number_of_processes_for_frontend_testing', \&untaint_strictly_positive_int );
     _create_setter( '_set_ZONEMASTER_number_of_processes_for_batch_testing',    '_ZONEMASTER_number_of_processes_for_batch_testing',    \&untaint_non_negative_int );
     _create_setter( '_set_ZONEMASTER_age_reuse_previous_test',                  '_ZONEMASTER_age_reuse_previous_test',                  \&untaint_strictly_positive_int );
-    _create_setter( '_set_API_enable_add_api_user',                             '_API_enable_add_api_user',                             \&untaint_bool );
-    _create_setter( '_set_API_enable_batch_jobs',                               '_API_enable_batch_jobs',                               \&untaint_bool );
+    _create_setter( '_set_RPCAPI_enable_add_api_user',                          '_RPCAPI_enable_add_api_user',                          \&untaint_bool );
+    _create_setter( '_set_RPCAPI_enable_batch_jobs',                            '_RPCAPI_enable_batch_jobs',                            \&untaint_bool );
 }
 
 =head2 new_DB

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -145,8 +145,8 @@ sub parse {
     $obj->_set_ZONEMASTER_number_of_processes_for_batch_testing( '20' );
     $obj->_set_ZONEMASTER_lock_on_queue( '0' );
     $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
-    $obj->_set_API_enable_add_api_user( '0' );
-    $obj->_set_API_enable_batch_jobs( '0' );
+    $obj->_set_API_enable_add_api_user( 'no' );
+    $obj->_set_API_enable_batch_jobs( 'no' );
     $obj->_add_LANGUAGE_locale( 'en_US' );
     $obj->_add_public_profile( 'default', undef );
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -146,7 +146,7 @@ sub parse {
     $obj->_set_ZONEMASTER_lock_on_queue( '0' );
     $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
     $obj->_set_RPCAPI_enable_add_api_user( 'no' );
-    $obj->_set_RPCAPI_enable_add_batch_job( 'no' );
+    $obj->_set_RPCAPI_enable_add_batch_job( 'yes' );
     $obj->_add_LANGUAGE_locale( 'en_US' );
     $obj->_add_public_profile( 'default', undef );
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -127,7 +127,7 @@ sub parse {
 
     # Validate section names
     {
-        my %sections = map { $_ => 1 } ( 'DB', 'MYSQL', 'POSTGRESQL', 'SQLITE', 'LANGUAGE', 'PUBLIC PROFILES', 'PRIVATE PROFILES', 'ZONEMASTER' );
+        my %sections = map { $_ => 1 } ( 'DB', 'MYSQL', 'POSTGRESQL', 'SQLITE', 'LANGUAGE', 'PUBLIC PROFILES', 'PRIVATE PROFILES', 'ZONEMASTER', 'API');
         for my $section ( $ini->Sections ) {
             if ( !exists $sections{$section} ) {
                 die "config: unrecognized section: $section\n";
@@ -145,6 +145,8 @@ sub parse {
     $obj->_set_ZONEMASTER_number_of_processes_for_batch_testing( '20' );
     $obj->_set_ZONEMASTER_lock_on_queue( '0' );
     $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
+    $obj->_set_API_enable_add_api_user( '0' );
+    $obj->_set_API_enable_batch_jobs( '0' );
     $obj->_add_LANGUAGE_locale( 'en_US' );
     $obj->_add_public_profile( 'default', undef );
 
@@ -274,6 +276,12 @@ sub parse {
     }
     if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'age_reuse_previous_test' ) ) ) {
         $obj->_set_ZONEMASTER_age_reuse_previous_test( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'API', 'enable_add_api_user' ) ) ) {
+        $obj->_set_API_enable_add_api_user( $value );
+    }
+    if ( defined( my $value = $get_and_clear->( 'API', 'enable_batch_jobs' ) ) ) {
+        $obj->_set_API_enable_batch_jobs( $value );
     }
     if ( defined( my $value = $get_and_clear->( 'LANGUAGE', 'locale' ) ) ) {
         if ( $value ne "" ) {
@@ -567,6 +575,24 @@ Returns a number.
 
 =cut
 
+=head2 API_enable_add_api_user
+
+Get the value of
+L<API.enable_add_api_user|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#enable_add_api_user>.
+
+Return 0 or 1
+
+=cut
+
+=head2 API_enable_batch_jobs
+
+Get the value of
+L<API.enable_batch_jobs|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#enable_batch_jobs>.
+
+Return 0 or 1
+
+=cut
+
 # Getters for the properties documented above
 sub DB_polling_interval                                 { return $_[0]->{_DB_polling_interval}; }
 sub MYSQL_host                                          { return $_[0]->{_MYSQL_host}; }
@@ -589,6 +615,8 @@ sub ZONEMASTER_lock_on_queue                            { return $_[0]->{_ZONEMA
 sub ZONEMASTER_number_of_processes_for_frontend_testing { return $_[0]->{_ZONEMASTER_number_of_processes_for_frontend_testing}; }
 sub ZONEMASTER_number_of_processes_for_batch_testing    { return $_[0]->{_ZONEMASTER_number_of_processes_for_batch_testing}; }
 sub ZONEMASTER_age_reuse_previous_test                  { return $_[0]->{_ZONEMASTER_age_reuse_previous_test}; }
+sub API_enable_add_api_user                             { return $_[0]->{_API_enable_add_api_user}; }
+sub API_enable_batch_jobs                               { return $_[0]->{_API_enable_batch_jobs}; }
 
 # Compile time generation of setters for the properties documented above
 UNITCHECK {
@@ -610,6 +638,8 @@ UNITCHECK {
     _create_setter( '_set_ZONEMASTER_number_of_processes_for_frontend_testing', '_ZONEMASTER_number_of_processes_for_frontend_testing', \&untaint_strictly_positive_int );
     _create_setter( '_set_ZONEMASTER_number_of_processes_for_batch_testing',    '_ZONEMASTER_number_of_processes_for_batch_testing',    \&untaint_non_negative_int );
     _create_setter( '_set_ZONEMASTER_age_reuse_previous_test',                  '_ZONEMASTER_age_reuse_previous_test',                  \&untaint_strictly_positive_int );
+    _create_setter( '_set_API_enable_add_api_user',                             '_API_enable_add_api_user',                             \&untaint_bool );
+    _create_setter( '_set_API_enable_batch_jobs',                               '_API_enable_batch_jobs',                               \&untaint_bool );
 }
 
 =head2 new_DB

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -98,8 +98,10 @@ Readonly my $RELAXED_DOMAIN_NAME_RE => qr/^[.]$|^.{2,254}$/;
 Readonly my $TEST_ID_RE             => qr/^[0-9a-f]{16}$/;
 Readonly my $USERNAME_RE            => qr/^[a-z0-9-.@]{1,50}$/i;
 
-# Boolean 0 or 1
-Readonly my $BOOL_RE            => qr/^(0|1)$/;
+# Boolean
+Readonly my $BOOL_TRUE_RE           => qr/^(true|yes|1)$/i;
+Readonly my $BOOL_FALSE_RE          => qr/^(false|no|0)$/i;
+Readonly my $BOOL_RE                => qr/^$BOOL_TRUE_RE|$BOOL_FALSE_RE$/i;
 
 sub joi {
     return JSON::Validator::Joi->new;
@@ -324,7 +326,11 @@ sub untaint_profile_name {
 
 sub untaint_bool {
     my ( $value ) = @_;
-    return _untaint_pat( $value, $BOOL_RE );
+
+    my $ret;
+    $ret = 1 if defined _untaint_pat( $value, $BOOL_TRUE_RE );
+    $ret = 0 if defined _untaint_pat( $value, $BOOL_FALSE_RE );
+    return $ret;
 }
 
 sub _untaint_pat {

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -14,6 +14,7 @@ use Zonemaster::Engine::Net::IP;
 
 our @EXPORT_OK = qw(
   untaint_abs_path
+  untaint_bool
   untaint_engine_type
   untaint_ip_address
   untaint_ipv4_address
@@ -35,6 +36,7 @@ our %EXPORT_TAGS = (
     untaint => [
         qw(
           untaint_abs_path
+          untaint_bool
           untaint_engine_type
           untaint_ip_address
           untaint_ipv4_address
@@ -95,6 +97,9 @@ Readonly my $PROFILE_NAME_RE        => qr/^[a-z0-9]$|^[a-z0-9][a-z0-9_-]{0,30}[a
 Readonly my $RELAXED_DOMAIN_NAME_RE => qr/^[.]$|^.{2,254}$/;
 Readonly my $TEST_ID_RE             => qr/^[0-9a-f]{16}$/;
 Readonly my $USERNAME_RE            => qr/^[a-z0-9-.@]{1,50}$/i;
+
+# Boolean 0 or 1
+Readonly my $BOOL_RE            => qr/^(0|1)$/;
 
 sub joi {
     return JSON::Validator::Joi->new;
@@ -317,6 +322,11 @@ sub untaint_profile_name {
     return _untaint_pat( $value, $PROFILE_NAME_RE );
 }
 
+sub untaint_bool {
+    my ( $value ) = @_;
+    return _untaint_pat( $value, $BOOL_RE );
+}
+
 sub _untaint_pat {
     my ( $value, @patterns ) = @_;
 
@@ -341,5 +351,7 @@ sub _untaint_pred {
         return;
     }
 }
+
+
 
 1;

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -99,8 +99,8 @@ Readonly my $TEST_ID_RE             => qr/^[0-9a-f]{16}$/;
 Readonly my $USERNAME_RE            => qr/^[a-z0-9-.@]{1,50}$/i;
 
 # Boolean
-Readonly my $BOOL_TRUE_RE           => qr/^(true|yes|1)$/i;
-Readonly my $BOOL_FALSE_RE          => qr/^(false|no|0)$/i;
+Readonly my $BOOL_TRUE_RE           => qr/^(true|yes)$/i;
+Readonly my $BOOL_FALSE_RE          => qr/^(false|no)$/i;
 Readonly my $BOOL_RE                => qr/^$BOOL_TRUE_RE|$BOOL_FALSE_RE$/i;
 
 sub joi {

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -148,7 +148,7 @@ my $dispatch = JSON::RPC::Dispatch->new(
     router => $router,
 );
 
-sub {
+my $rpcapi_app = sub {
     my $env = shift;
     my $req = Plack::Request->new($env);
     my $res = {};
@@ -169,7 +169,7 @@ sub {
           $res->body( encode_json($errors) );
           $res->finalize;
         } else {
-            $dispatch->handle_psgi($env, $env->{REMOTE_HOST});
+            $dispatch->handle_psgi($env, $env->{REMOTE_ADDR});
         }
     } else {
         $res = Plack::Response->new(200);
@@ -185,4 +185,9 @@ sub {
         $res->finalize;
 
     }
+};
+
+builder {
+    enable "Plack::Middleware::ReverseProxy";
+    mount "/" => $rpcapi_app;
 };

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -127,7 +127,7 @@ my $router = router {
     };
 };
 
-if ($config->API_enable_add_api_user) {
+if ($config->RPCAPI_enable_add_api_user) {
     $log->info('Enabling add_api_user method');
     $router->connect("add_api_user", {
         handler => $handler,
@@ -135,7 +135,7 @@ if ($config->API_enable_add_api_user) {
     });
 }
 
-if ($config->API_enable_batch_jobs) {
+if ($config->RPCAPI_enable_batch_jobs) {
     $log->info('Enabling add_batch_job and get_batch_job_result methods');
     $router->connect("add_batch_job", {
         handler => $handler,

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -125,6 +125,11 @@ my $router = router {
         handler => $handler,
         action => "get_test_history"
     };
+
+    connect "get_batch_job_result" => {
+        handler => $handler,
+        action => "get_batch_job_result"
+    };
 };
 
 if ($config->RPCAPI_enable_add_api_user) {
@@ -135,16 +140,11 @@ if ($config->RPCAPI_enable_add_api_user) {
     });
 }
 
-if ($config->RPCAPI_enable_batch_jobs) {
-    $log->info('Enabling add_batch_job and get_batch_job_result methods');
+if ($config->RPCAPI_enable_add_batch_job) {
+    $log->info('Enabling add_batch_job method');
     $router->connect("add_batch_job", {
         handler => $handler,
         action => "add_batch_job"
-    });
-
-    $router->connect("get_batch_job_result", {
-        handler => $handler,
-        action => "get_batch_job_result"
     });
 }
 

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -125,24 +125,28 @@ my $router = router {
         handler => $handler,
         action => "get_test_history"
     };
+};
 
-############ BATCH MODE ####################
-
-    connect "add_api_user" => {
+if ($config->API_enable_add_api_user) {
+    $log->info('Enabling add_api_user method');
+    $router->connect("add_api_user", {
         handler => $handler,
         action => "add_api_user"
-    };
+    });
+}
 
-    connect "add_batch_job" => {
+if ($config->API_enable_batch_jobs) {
+    $log->info('Enabling add_batch_job and get_batch_job_result methods');
+    $router->connect("add_batch_job", {
         handler => $handler,
         action => "add_batch_job"
-    };
+    });
 
-    connect "get_batch_job_result" => {
+    $router->connect("get_batch_job_result", {
         handler => $handler,
         action => "get_batch_job_result"
-    };
-};
+    });
+}
 
 my $dispatch = JSON::RPC::Dispatch->new(
     router => $router,

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -31,9 +31,9 @@ database_file = /var/lib/zonemaster/db.sqlite
 #
 #maximal_number_of_retries=3
 
-[API]
+[RPCAPI]
 
-# Uncomment to enable the user and batch API methods.
+# Uncomment to enable the user and batch RPCAPI methods.
 # enable_add_api_user = yes
 # enable_batch_jobs = yes
 

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -32,8 +32,10 @@ database_file = /var/lib/zonemaster/db.sqlite
 #maximal_number_of_retries=3
 
 [API]
-enable_add_api_user = 0
-enable_add_batch_job = 0
+
+# Uncomment to enable the user and batch API methods.
+# enable_add_api_user = 1
+# enable_add_batch_job = 1
 
 [LANGUAGE]
 locale = da_DK en_US fi_FI fr_FR nb_NO sv_SE

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -33,7 +33,7 @@ database_file = /var/lib/zonemaster/db.sqlite
 
 [RPCAPI]
 
-# Uncomment to enable the user and batch RPCAPI methods.
+# Uncomment to enable API method "add_api_user"
 # enable_add_api_user = yes
 # enable_batch_jobs = yes
 

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -31,6 +31,10 @@ database_file = /var/lib/zonemaster/db.sqlite
 #
 #maximal_number_of_retries=3
 
+[API]
+enable_add_api_user = 0
+enable_add_batch_job = 0
+
 [LANGUAGE]
 locale = da_DK en_US fi_FI fr_FR nb_NO sv_SE
 

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -35,7 +35,7 @@ database_file = /var/lib/zonemaster/db.sqlite
 
 # Uncomment to enable the user and batch API methods.
 # enable_add_api_user = 1
-# enable_add_batch_job = 1
+# enable_batch_jobs = 1
 
 [LANGUAGE]
 locale = da_DK en_US fi_FI fr_FR nb_NO sv_SE

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -34,8 +34,9 @@ database_file = /var/lib/zonemaster/db.sqlite
 [RPCAPI]
 
 # Uncomment to enable API method "add_api_user"
-# enable_add_api_user = yes
-# enable_batch_jobs = yes
+#enable_add_api_user = yes
+# Uncomment to enable the API methods "add_batch_job" and "get_batch_job_result"
+#enable_batch_jobs = yes
 
 [LANGUAGE]
 locale = da_DK en_US fi_FI fr_FR nb_NO sv_SE

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -35,8 +35,8 @@ database_file = /var/lib/zonemaster/db.sqlite
 
 # Uncomment to enable API method "add_api_user"
 #enable_add_api_user = yes
-# Uncomment to enable the API methods "add_batch_job" and "get_batch_job_result"
-#enable_batch_jobs = yes
+# Uncomment to enable API method "add_batch_job"
+#enable_add_batch_job = yes
 
 [LANGUAGE]
 locale = da_DK en_US fi_FI fr_FR nb_NO sv_SE

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -35,8 +35,8 @@ database_file = /var/lib/zonemaster/db.sqlite
 
 # Uncomment to enable API method "add_api_user"
 #enable_add_api_user = yes
-# Uncomment to enable API method "add_batch_job"
-#enable_add_batch_job = yes
+# Uncomment to disable API method "add_batch_job"
+#enable_add_batch_job = no
 
 [LANGUAGE]
 locale = da_DK en_US fi_FI fr_FR nb_NO sv_SE

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -34,8 +34,8 @@ database_file = /var/lib/zonemaster/db.sqlite
 [API]
 
 # Uncomment to enable the user and batch API methods.
-# enable_add_api_user = 1
-# enable_batch_jobs = 1
+# enable_add_api_user = yes
+# enable_batch_jobs = yes
 
 [LANGUAGE]
 locale = da_DK en_US fi_FI fr_FR nb_NO sv_SE


### PR DESCRIPTION
## Purpose

Secure the add_api_user method.

## Context

Fixes #838 

## Changes

* Use `Plack::Middleware::ReverseProxy`  to set the environment according to the proxy headers
* Add two configuration keys `API.enable_add_batch_job` and `API.enable_add_api_user` to enable the corresponding api methods (disabled by default).

## How to test this PR

* Running `./script/zmb add_api_user --username toto --api-key secret` should return the error `"Procedure 'add_api_user' not found"`.
* Running `./script/zmb add_batch_job --domain example.com --username toto --api-key secret` should return the error `"Procedure 'add_batch_job' not found"`.
* Enable the add_api_user method.
  * run the API behind a reverse proxy on the same host
    ```
    curl -s "Content-Type: application/json" --data '{"method":"add_api_user","params":{"username":"toto","api_key":"toto"},"id":1,"jsonrpc":"2.0"}' not.localhost/api  | jq
    ```
  * Try to add a user from a another host
  * If the query return `0` as result it works.
