### PR TITLE
Harmonize databases

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -216,6 +216,19 @@ sub process_dead_test {
     }
 }
 
+=head2 schedule_for_retry
+
+For the test with the given "hash_id" increments its number of retries by 1,
+resets its progress to 0 and its start time to NULL.
+
+=cut
+
+sub schedule_for_retry {
+    my ( $self, $hash_id ) = @_;
+
+    $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NULL WHERE hash_id=?", undef, $hash_id);
+}
+
 # A thin wrapper around DBI->connect to ensure similar behavior across database
 # engines.
 sub _new_dbh {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -14,7 +14,6 @@ use Log::Any qw( $log );
 use Zonemaster::Engine::Profile;
 
 requires qw(
-  add_api_user_to_db
   add_batch_job
   create_db
   create_new_batch_job
@@ -26,8 +25,6 @@ requires qw(
   select_unfinished_tests
   test_progress
   test_results
-  user_authorized
-  user_exists_in_db
   get_relative_start_time
 );
 
@@ -114,6 +111,50 @@ sub add_api_user {
         unless ( $result );
 
     return $result;
+}
+
+# Standard SQL, can be here
+sub user_exists_in_db {
+    my ( $self, $user ) = @_;
+
+    my $dbh = $self->dbh;
+    my ( $id ) = $dbh->selectrow_array(
+        "SELECT id FROM users WHERE username = ?",
+        undef,
+        $user
+    );
+
+    return $id;
+}
+
+# Standard SQL, can be here
+sub add_api_user_to_db {
+    my ( $self, $user_name, $api_key  ) = @_;
+
+    my $dbh = $self->dbh;
+    my $nb_inserted = $dbh->do(
+        "INSERT INTO users (username, api_key) VALUES (?,?)",
+        undef,
+        $user_name,
+        $api_key,
+    );
+
+    return $nb_inserted;
+}
+
+# Standard SQL, can be here
+sub user_authorized {
+    my ( $self, $user, $api_key ) = @_;
+
+    my $dbh = $self->dbh;
+    my ( $id ) = $dbh->selectrow_array(
+        "SELECT id FROM users WHERE username = ? AND api_key = ?",
+        undef,
+        $user,
+        $api_key
+    );
+
+    return $id;
 }
 
 # Standard SQL, can be here

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -6,22 +6,22 @@ use Moose::Role;
 
 use 5.14.2;
 
-use JSON::PP;
 use Digest::MD5 qw(md5_hex);
 use Encode;
+use JSON::PP;
 use Log::Any qw( $log );
 
 use Zonemaster::Engine::Profile;
+use Zonemaster::Backend::Errors;
 
 requires qw(
   add_batch_job
   create_db
-  create_new_batch_job
   create_new_test
   from_config
   get_test_history
-  get_test_params
   process_unfinished_tests_give_up
+  recent_test_hash_id
   select_unfinished_tests
   test_progress
   test_results
@@ -114,6 +114,34 @@ sub add_api_user {
 }
 
 # Standard SQL, can be here
+sub create_new_batch_job {
+    my ( $self, $username ) = @_;
+
+    my $dbh = $self->dbh;
+    my ( $batch_id, $creation_time ) = $dbh->selectrow_array( "
+            SELECT
+                batch_id,
+                batch_jobs.creation_time AS batch_creation_time
+            FROM
+                test_results
+            JOIN batch_jobs
+                ON batch_id = batch_jobs.id
+                AND username = ?
+            WHERE
+                test_results.progress <> 100
+            LIMIT 1
+            ", undef, $username );
+
+    die Zonemaster::Backend::Error::Conflict->new( message => 'Batch job still running', data => { batch_id => $batch_id, creation_time => $creation_time } )
+        if ( $batch_id );
+
+    $dbh->do( "INSERT INTO batch_jobs (username) VALUES (?)", undef, $username );
+    my $new_batch_id = $dbh->last_insert_id( undef, undef, "batch_jobs", undef );
+
+    return $new_batch_id;
+}
+
+# Standard SQL, can be here
 sub user_exists_in_db {
     my ( $self, $user ) = @_;
 
@@ -177,6 +205,29 @@ sub get_test_request {
         $result_id = $hash_id;
     }
     return $result_id;
+}
+
+# Standard SQL, can be here
+sub get_test_params {
+    my ( $self, $test_id ) = @_;
+
+    my $dbh = $self->dbh;
+    my ( $params_json ) = $dbh->selectrow_array( "SELECT params FROM test_results WHERE hash_id = ?", undef, $test_id );
+
+    die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } )
+        unless defined $params_json;
+
+    my $result;
+    eval {
+        # TODO: do we use "encode_utf8" as this was the case in PostgreSQL
+        #       (see commit diff)
+        $result = decode_json( $params_json );
+    };
+
+    die Zonemaster::Backend::Error::JsonError->new( reason => "$@", data => { test_id => $test_id } )
+        if $@;
+
+    return $result;
 }
 
 # Standatd SQL, can be here

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -255,7 +255,7 @@ sub create_new_test {
         else {
             $dbh->do(
                 q[
-                INSERT INTO test_results (batch_id, priority, queue, fingerprint, params, domain, test_start_time, undelegated) VALUES (?, ?,?,?,?,?, NOW(),?)
+                INSERT INTO test_results (batch_id, priority, queue, fingerprint, params, domain, undelegated) VALUES (?,?,?,?,?,?,?)
                 ],
                 undef,
                 $batch_id,
@@ -513,7 +513,7 @@ sub process_unfinished_tests_give_up {
 sub schedule_for_retry {
     my ( $self, $hash_id ) = @_;
 
-    $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NOW() WHERE hash_id=?", undef, $hash_id);
+    $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NULL WHERE hash_id=?", undef, $hash_id);
 }
 
 sub get_relative_start_time {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -159,42 +159,10 @@ sub create_db {
         'CREATE TABLE IF NOT EXISTS users (
             id integer AUTO_INCREMENT primary key,
             username varchar(128),
-            api_key varchar(512),
-            user_info blob DEFAULT NULL
+            api_key varchar(512)
         ) ENGINE=InnoDB;
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'users' table", data => $dbh->errstr() );
-}
-
-sub user_exists_in_db {
-    my ( $self, $user ) = @_;
-
-    my ( $id ) = $self->dbh->selectrow_array( "SELECT id FROM users WHERE username = ?", undef, $user );
-
-    return $id;
-}
-
-sub add_api_user_to_db {
-    my ( $self, $user_name, $api_key  ) = @_;
-
-    my $nb_inserted = $self->dbh->do(
-        "INSERT INTO users (user_info, username, api_key) VALUES (?,?,?)",
-        undef,
-        'NULL',
-        $user_name,
-        $api_key,
-    );
-
-    return $nb_inserted;
-}
-
-sub user_authorized {
-    my ( $self, $user, $api_key ) = @_;
-
-    my ( $id ) =
-      $self->dbh->selectrow_array( q[SELECT id FROM users WHERE username = ? AND api_key = ?], undef, $user, $api_key );
-
-    return $id;
 }
 
 sub create_new_batch_job {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -510,12 +510,6 @@ sub process_unfinished_tests_give_up {
     $self->dbh->do("UPDATE test_results SET progress = 100, test_end_time = NOW(), results = ? WHERE hash_id=?", undef, encode_json($result), $hash_id);
 }
 
-sub schedule_for_retry {
-    my ( $self, $hash_id ) = @_;
-
-    $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NULL WHERE hash_id=?", undef, $hash_id);
-}
-
 sub get_relative_start_time {
     my ( $self, $hash_id ) = @_;
 

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -131,40 +131,12 @@ sub create_db {
     $dbh->do(
         'CREATE TABLE IF NOT EXISTS users (
                 id serial PRIMARY KEY,
-                user_info json
+                username VARCHAR(128),
+                api_key VARCHAR(512)
             )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'users' table", data => $dbh->errstr() );
 
-}
-
-sub user_exists_in_db {
-    my ( $self, $user ) = @_;
-
-    my $dbh = $self->dbh;
-    my ( $id ) = $dbh->selectrow_array( "SELECT id FROM users WHERE user_info->>'username'=?", undef, $user );
-
-    return $id;
-}
-
-sub add_api_user_to_db {
-    my ( $self, $user_name, $api_key ) = @_;
-
-    my $dbh = $self->dbh;
-    my $nb_inserted = $dbh->do( "INSERT INTO users (user_info) VALUES (?)", undef, encode_json( { username => $user_name, api_key => $api_key } ) );
-
-    return $nb_inserted;
-}
-
-sub user_authorized {
-    my ( $self, $user, $api_key ) = @_;
-
-    my $dbh = $self->dbh;
-    my $id =
-      $dbh->selectrow_array( "SELECT id FROM users WHERE user_info->>'username'=? AND user_info->>'api_key'=?",
-        undef, $user, $api_key );
-
-    return $id;
 }
 
 sub test_progress {

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -106,7 +106,7 @@ sub create_db {
     }
     if ( not exists($indexes->{test_results__domain_undelegated}) ) {
         $dbh->do(
-            "CREATE INDEX test_results__domain_undelegated ON test_results ((params->>'domain'), (params->>'undelegated'))"
+            "CREATE INDEX test_results__domain_undelegated ON test_results ((params->>'domain'), undelegated)"
         );
     }
 
@@ -401,7 +401,7 @@ sub add_batch_job {
         $dbh->do( "CREATE INDEX test_results__fingerprint ON test_results (fingerprint)" );
         $dbh->do( "CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)" );
         $dbh->do( "CREATE INDEX test_results__progress ON test_results (progress)" );
-        $dbh->do( "CREATE INDEX test_results__domain_undelegated ON test_results ((params->>'domain'), (params->>'undelegated'))" );
+        $dbh->do( "CREATE INDEX test_results__domain_undelegated ON test_results ((params->>'domain'), undelegated)" );
 
         $dbh->commit();
     }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -453,12 +453,6 @@ sub process_unfinished_tests_give_up {
     $self->dbh->do("UPDATE test_results SET progress = 100, test_end_time = NOW(), results = ? WHERE hash_id=?", undef, encode_json($result), $hash_id);
 }
 
-sub schedule_for_retry {
-    my ( $self, $hash_id ) = @_;
-
-    $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NULL WHERE hash_id=?", undef, $hash_id);
-}
-
 sub get_relative_start_time {
     my ( $self, $hash_id ) = @_;
 

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -65,8 +65,8 @@ sub create_db {
                 hash_id VARCHAR(16) DEFAULT substring(md5(random()::text || clock_timestamp()::text) from 1 for 16) NOT NULL,
                 batch_id integer,
                 creation_time timestamp without time zone DEFAULT NOW() NOT NULL,
-                test_start_time timestamp without time zone,
-                test_end_time timestamp without time zone,
+                test_start_time timestamp without time zone DEFAULT NULL,
+                test_end_time timestamp without time zone DEFAULT NULL,
                 priority integer DEFAULT 10,
                 queue integer DEFAULT 0,
                 progress integer DEFAULT 0,
@@ -456,7 +456,7 @@ sub process_unfinished_tests_give_up {
 sub schedule_for_retry {
     my ( $self, $hash_id ) = @_;
 
-    $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NOW() WHERE hash_id=?", undef, $hash_id);
+    $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NULL WHERE hash_id=?", undef, $hash_id);
 }
 
 sub get_relative_start_time {

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -52,11 +52,13 @@ sub DEMOLISH {
 sub create_db {
     my ( $self ) = @_;
 
+    my $dbh = $self->dbh;
+
     ####################################################################
     # TEST RESULTS
     ####################################################################
-    $self->dbh->do(
-        'CREATE TABLE test_results (
+    $dbh->do(
+        'CREATE TABLE IF NOT EXISTS test_results (
                  id integer PRIMARY KEY AUTOINCREMENT,
                  hash_id VARCHAR(16) DEFAULT NULL,
                  domain VARCHAR(255) NOT NULL,
@@ -74,50 +76,50 @@ sub create_db {
                  nb_retries integer NOT NULL DEFAULT 0
            )
         '
-    ) or die "SQLite Fatal error: " . $self->dbh->errstr() . "\n";
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'test_results' table", data => $dbh->errstr() );
 
-    $self->dbh->do(
-        'CREATE INDEX test_results__hash_id ON test_results (hash_id)'
+    $dbh->do(
+        'CREATE INDEX IF NOT EXISTS test_results__hash_id ON test_results (hash_id)'
     );
-    $self->dbh->do(
-        'CREATE INDEX test_results__fingerprint ON test_results (params_deterministic_hash)'
+    $dbh->do(
+        'CREATE INDEX IF NOT EXISTS test_results__fingerprint ON test_results (params_deterministic_hash)'
     );
-    $self->dbh->do(
-        'CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)'
+    $dbh->do(
+        'CREATE INDEX IF NOT EXISTS test_results__batch_id_progress ON test_results (batch_id, progress)'
     );
-    $self->dbh->do(
-        'CREATE INDEX test_results__progress ON test_results (progress)'
+    $dbh->do(
+        'CREATE INDEX IF NOT EXISTS test_results__progress ON test_results (progress)'
     );
-    $self->dbh->do(
-        'CREATE INDEX test_results__domain_undelegated ON test_results (domain, undelegated)'
+    $dbh->do(
+        'CREATE INDEX IF NOT EXISTS test_results__domain_undelegated ON test_results (domain, undelegated)'
     );
 
 
     ####################################################################
     # BATCH JOBS
     ####################################################################
-    $self->dbh->do(
-        'CREATE TABLE batch_jobs (
+    $dbh->do(
+        'CREATE TABLE IF NOT EXISTS batch_jobs (
                  id integer PRIMARY KEY,
                  username character varying(50) NOT NULL,
                  creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
            )
         '
-    ) or die "SQLite Fatal error: " . $self->dbh->errstr() . "\n";
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'batch_jobs' table", data => $dbh->errstr() );
 
 
     ####################################################################
     # USERS
     ####################################################################
-    $self->dbh->do(
-        'CREATE TABLE users (
+    $dbh->do(
+        'CREATE TABLE IF NOT EXISTS users (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 username varchar(128),
                 api_key varchar(512),
                 user_info json DEFAULT NULL
            )
         '
-    ) or die "SQLite Fatal error: " . $self->dbh->errstr() . "\n";
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'users' table", data => $dbh->errstr() );
 
     return 1;
 }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -444,12 +444,6 @@ sub process_unfinished_tests_give_up {
      $self->dbh->do("UPDATE test_results SET progress = 100, test_end_time = DATETIME('now'), results = ? WHERE hash_id=?", undef, encode_json($result), $hash_id);
 }
 
-sub schedule_for_retry {
-    my ( $self, $hash_id ) = @_;
-
-    $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NULL WHERE hash_id=?", undef, $hash_id);
-}
-
 sub get_relative_start_time {
     my ( $self, $hash_id ) = @_;
 

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -199,7 +199,7 @@ sub create_new_test {
     # Search for recent test result with the test same parameters, where "$seconds"
     # gives the time limit for how old test result that is accepted.
     my ( $recent_hash_id ) = $dbh->selectrow_array(
-        "SELECT hash_id FROM test_results WHERE fingerprint = ? AND test_start_time > DATETIME('now', ?)",
+        "SELECT hash_id FROM test_results WHERE fingerprint = ? AND creation_time > DATETIME('now', ?)",
         undef,
         $fingerprint,
         "-$seconds seconds"

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -115,44 +115,12 @@ sub create_db {
         'CREATE TABLE IF NOT EXISTS users (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 username varchar(128),
-                api_key varchar(512),
-                user_info json DEFAULT NULL
+                api_key varchar(512)
            )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'users' table", data => $dbh->errstr() );
 
     return 1;
-}
-
-sub user_exists_in_db {
-    my ( $self, $user ) = @_;
-
-    my ( $id ) = $self->dbh->selectrow_array( "SELECT id FROM users WHERE username = ?", undef, $user );
-
-    return $id;
-}
-
-sub add_api_user_to_db {
-    my ( $self, $user_name, $api_key  ) = @_;
-
-    my $nb_inserted = $self->dbh->do(
-        "INSERT INTO users (user_info, username, api_key) VALUES (?,?,?)",
-        undef,
-        'NULL',
-        $user_name,
-        $api_key,
-    );
-
-    return $nb_inserted;
-}
-
-sub user_authorized {
-    my ( $self, $user, $api_key ) = @_;
-
-    my ( $id ) =
-      $self->dbh->selectrow_array( q[SELECT id FROM users WHERE username = ? AND api_key = ?], undef, $user, $api_key );
-
-    return $id;
 }
 
 sub create_new_batch_job {

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -64,8 +64,8 @@ sub create_db {
                  domain VARCHAR(255) NOT NULL,
                  batch_id integer NULL,
                  creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                 test_start_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                 test_end_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                 test_start_time TIMESTAMP DEFAULT NULL,
+                 test_end_time TIMESTAMP DEFAULT NULL,
                  priority integer DEFAULT 10,
                  queue integer DEFAULT 0,
                  progress integer DEFAULT 0,
@@ -216,9 +216,9 @@ sub create_new_test {
         # cannot, however, be guaranteed. Same as with the other database engines.
         my $hash_id = substr(md5_hex(time().rand()), 0, 16);
 
-        my $fields = 'hash_id, batch_id, priority, queue, fingerprint, params, domain, test_start_time, undelegated';
+        my $fields = 'hash_id, batch_id, priority, queue, fingerprint, params, domain, undelegated';
         $dbh->do(
-            "INSERT INTO test_results ($fields) VALUES (?,?,?,?,?,?,?, datetime('now'),?)",
+            "INSERT INTO test_results ($fields) VALUES (?,?,?,?,?,?,?,?)",
             undef,
             $hash_id,
             $batch_id,
@@ -447,7 +447,7 @@ sub process_unfinished_tests_give_up {
 sub schedule_for_retry {
     my ( $self, $hash_id ) = @_;
 
-    $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = DATETIME('now') WHERE hash_id=?", undef, $hash_id);
+    $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NULL WHERE hash_id=?", undef, $hash_id);
 }
 
 sub get_relative_start_time {

--- a/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
@@ -16,6 +16,28 @@ my $dbh = $db->dbh;
 
 
 sub patch_db {
+
+    # Rename column "params_deterministic_hash" into "fingerprint"
+    # Since MariaDB 10.5.2 (2020-03-26) <https://mariadb.com/kb/en/mariadb-1052-release-notes/>
+    #   ALTER TABLE t1 RENAME COLUMN old_col TO new_col;
+    # Before that we need to use CHANGE COLUMN <https://mariadb.com/kb/en/alter-table/#change-column>
+    eval {
+        $dbh->do('ALTER TABLE test_results CHANGE COLUMN params_deterministic_hash fingerprint CHARACTER VARYING(32)');
+    };
+    print( "Error while changing DB schema:  " . $@ ) if ($@);
+
+    # Update index
+    eval {
+        # retrieve all indexes by key name
+        my $indexes = $dbh->selectall_hashref( 'SHOW INDEXES FROM test_results', 'Key_name' );
+        if ( exists($indexes->{test_results__params_deterministic_hash}) ) {
+            $dbh->do( "DROP INDEX test_results__params_deterministic_hash ON test_results" );
+        }
+        $dbh->do( "CREATE INDEX test_results__fingerprint ON test_results (fingerprint)" );
+    };
+    print( "Error while updating the index:  " . $@ ) if ($@);
+
+    # Update the "undelegated" column
     my $sth1 = $dbh->prepare('SELECT id, params from test_results', undef);
     $sth1->execute;
     while ( my $row = $sth1->fetchrow_hashref ) {

--- a/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
@@ -49,6 +49,14 @@ sub patch_db {
 
         $dbh->do('UPDATE test_results SET undelegated = ? where id = ?', undef, $undelegated, $id);
     }
+
+
+    # remove the "user_info" column from the "users" table
+    # the IF EXISTS clause is available with MariaDB but not MySQL
+    eval {
+        $dbh->do( "ALTER TABLE users DROP COLUMN user_info" );
+    };
+    print( "Error while dropping the column:  " . $@ ) if ($@);
 }
 
 patch_db();

--- a/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_mysql_db_zonemaster_backend_ver_7.0.0.pl
@@ -16,6 +16,14 @@ my $dbh = $db->dbh;
 
 
 sub patch_db {
+    # Remove the trigger
+    $dbh->do( 'DROP TRIGGER IF EXISTS before_insert_test_results' );
+
+    # Set the "hash_id" field to NOT NULL
+    eval {
+        $dbh->do( 'ALTER TABLE test_results MODIFY COLUMN hash_id VARCHAR(16) NOT NULL' );
+    };
+    print( "Error while changing DB schema:  " . $@ ) if ($@);
 
     # Rename column "params_deterministic_hash" into "fingerprint"
     # Since MariaDB 10.5.2 (2020-03-26) <https://mariadb.com/kb/en/mariadb-1052-release-notes/>

--- a/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
@@ -46,6 +46,14 @@ sub patch_db {
     };
     print( "Error while changing DB schema:  " . $@ ) if ($@);
 
+    # Update index
+    eval {
+        # clause IF EXISTS available since PostgreSQL >= 9.2
+        $dbh->do( "DROP INDEX IF EXISTS test_results__domain_undelegated" );
+        $dbh->do( "CREATE INDEX test_results__domain_undelegated ON test_results ((params->>'domain'), undelegated)" );
+    };
+    print( "Error while updating the index:  " . $@ ) if ($@);
+
     # Update the "undelegated" column
     my $sth1 = $dbh->prepare('SELECT id, params from test_results', undef);
     $sth1->execute;

--- a/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
@@ -79,6 +79,19 @@ sub patch_db {
 
         $dbh->do('UPDATE test_results SET undelegated = ? where id = ?', undef, $undelegated, $id);
     }
+
+    # add "username" and "api_key" columns to the "users" table
+    eval {
+        $dbh->do( 'ALTER TABLE users ADD COLUMN username VARCHAR(128)' );
+        $dbh->do( 'ALTER TABLE users ADD COLUMN api_key VARCHAR(512)' );
+    };
+    print( "Error while changing DB schema:  " . $@ ) if ($@);
+
+    # update the columns
+    $dbh->do( "UPDATE users SET username = (user_info->>'username'), api_key = (user_info->>'api_key')" );
+
+    # remove the "user_info" column from the "users" table
+    $dbh->do( "ALTER TABLE users DROP COLUMN IF EXISTS user_info" );
 }
 
 patch_db();

--- a/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
@@ -32,6 +32,14 @@ sub patch_db {
     };
     print( "Error while updating the index:  " . $@ ) if ($@);
 
+    # test_start_time and test_end_time default to NULL
+    eval {
+        $dbh->do('ALTER TABLE test_results ALTER COLUMN test_start_time SET DEFAULT NULL');
+        $dbh->do('ALTER TABLE test_results ALTER COLUMN test_end_time SET DEFAULT NULL');
+    };
+    print( "Error while changing DB schema:  " . $@ ) if ($@);
+
+
     # Add missing "undelegated" column
     eval {
         $dbh->do( 'ALTER TABLE test_results ADD COLUMN undelegated integer NOT NULL DEFAULT 0' );

--- a/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_postgresql_db_zonemaster_backend_ver_7.0.0.pl
@@ -17,6 +17,8 @@ my $dbh = $db->dbh;
 
 
 sub patch_db {
+    # Drop default value for the "hash_id" field
+    $dbh->do( 'ALTER TABLE test_results ALTER COLUMN hash_id DROP DEFAULT' );
 
     # Rename column "params_deterministic_hash" into "fingerprint"
     eval {

--- a/share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
+++ b/share/patch_sqlite_db_zonemaster_backend_ver_7.0.0.pl
@@ -52,6 +52,25 @@ sub patch_db {
 
         $dbh->do('UPDATE test_results SET undelegated = ? where id = ?', undef, $undelegated, $id);
     }
+
+
+    # in order to properly drop a column, the whole table needs to be recreated
+    #  1. rename the "users" table to "users_old"
+    #  2. create the new "users" table
+    #  3. populate it with the values from "users_old"
+    #  4. remove old table
+    eval {
+        $dbh->do('ALTER TABLE users RENAME TO users_old');
+
+        # create the table
+        $db->create_db();
+
+        # populate it
+        $dbh->do('INSERT INTO users SELECT id, username, api_key FROM users_old');
+
+        $dbh->do('DROP TABLE users_old');
+    };
+    print( "Error while updating the 'users' table schema:  " . $@ ) if ($@);
 }
 
 patch_db();

--- a/t/test01.t
+++ b/t/test01.t
@@ -75,13 +75,7 @@ if ( $db_backend eq 'SQLite' ) {
 # add test user
 is( $engine->add_api_user( { username => "zonemaster_test", api_key => "zonemaster_test's api key" } ), 1, 'API add_api_user success');
 
-my $user_check_query;
-if ( $db_backend eq 'PostgreSQL' ) {
-    $user_check_query = q/SELECT * FROM users WHERE user_info->>'username' = 'zonemaster_test'/;
-}
-elsif ( $db_backend eq 'MySQL' || $db_backend eq 'SQLite' ) {
-    $user_check_query = q/SELECT * FROM users WHERE username = 'zonemaster_test'/;
-}
+my $user_check_query = q/SELECT * FROM users WHERE username = 'zonemaster_test'/;
 is( scalar( $engine->{db}->dbh->selectrow_array( $user_check_query ) ), 1 ,'API add_api_user user created' );
 
 # add a new test to the db


### PR DESCRIPTION
## Purpose

This PR tries to improve and add consistency between database engines. There are PRs to update the database in a way that breaks things (new `undelegated` column in PosgreSQL for instance). It might be nice to take the opportunity of this new Backend release to improve and fix some behaviors in the databases.

A first part in this PR is to improve the `create_db()` routine in order to be able to call it at daemon startup (which will be handle in another PR #846 ).

## Context

Based on top of #833 and #834
Addresses #832, #840

## Changes

There are several changes. This PR can easily be split in smaller PRs.

* (1/11) Create indexes in SQLite -> #865

* (2/11) Always check that a table, index or trigger does not exists before creation. For some cases, the clause `IF NOT EXISTS` is sufficient, for others, we need workaround because it is not present in all supported versions of the database engine. (069732e) -> #866 

* (3/11) Rename column `params_deterministic_hash` into `fingerprint` (26c0511)

* (4/11) Correctly use `creation_time` in SQLite to check the age of a test (a8a4cee)

* (5/11) Set `test_start_time` to NULL by default and when the test is rescheduled (6aafdeb)

* (6/11) Move the `schedule_for_retry` routine to "DB.pm" (it now uses a SQL syntax that is valid for all database engines) (29e7eb2)

* (7/11) Fix a nonexistent index key field in PosgreSQL (7145d4f)

* (8/11) Add a new `domain` column in PostgreSQL to be consistent with other database engines (4e4d563)

* (9/11) Update the "users" table: (8563602)
   * new `username` and `api_key` columns for PostgreSQL
   * remove the `user_info` column for SQLite, MySQL and PostgreSQL

* (10/11) Made some refactoring: (576dc86)
    * New method `recent_test_hash_id' to search for pre-existing test
    * Move `create_new_batch_job' method to DB.pm
    * Move `get_test_params' method to DB.pm
    * Use generic DBI `last_insert_id'

* (11/11) Compute the `hash_id` before its insertion in database in order to use the same `create_new_test` method across database engines (60da83a)

* For all the changes that affect the database, each patch script has been updated accordingly
 
 

## How to test this PR

Do one of the following:
* upgrade an existing database with the corresponding patch script
* install and initialize the database with the instructions in the [installation document](https://github.com/zonemaster/zonemaster-backend/blob/develop/docs/Installation.md)

Then check for the following things:
* SQLite `test_results` table has indexes, `PRAGMA index_info(test_results)` should result in 5 indexes
* there is no `params_deterministic_hash` column, it should be named `fingerprint`
* there is no index `test_results__params_deterministic_hash`, it should be named `test_results__fingerprint`
* for PostgreSQL, a column `domain` should exist in the `test_results` table (if migrating, the field should be properly initialized)
* for PostgreSQL, the columns `username` and `api_key` should exist in the `users` table (if migrating, the fields should be properly initialized)
* the `hash_id` field can't be null and has no default value
* there should not be any `user_info` field in the `users` table anymore

Finally run some checks, you should be able to properly use the following methods:
* `start_domain_test` (and you should be able to reuse a pre-existing test)
* `add_api_user`
* `add_batch_job`
* `get_test_params`