### PR TITLE
use logger instead of warn

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -26,6 +26,7 @@ use Zonemaster::Backend;
 use Zonemaster::Backend::Config;
 use Zonemaster::Backend::Translator;
 use Zonemaster::Backend::Validator;
+use Log::Any qw( $log );
 
 my $zm_validator = Zonemaster::Backend::Validator->new;
 my %json_schemas;
@@ -77,7 +78,7 @@ sub handle_exception {
 
     $exception =~ s/\n/ /g;
     $exception =~ s/^\s+|\s+$//g;
-    warn "Internal error $exception_id: Unexpected error in the $method API call: [$exception] \n";
+    $log->error("Internal error $exception_id: Unexpected error in the $method API call: [$exception]");
     die "Internal error $exception_id \n";
 }
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -26,7 +26,6 @@ use Zonemaster::Backend;
 use Zonemaster::Backend::Config;
 use Zonemaster::Backend::Translator;
 use Zonemaster::Backend::Validator;
-use Log::Any qw( $log );
 
 my $zm_validator = Zonemaster::Backend::Validator->new;
 my %json_schemas;

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -45,14 +45,19 @@ Log::Any::Adapter->set(
                 'Screen',
                 min_level => get_loglevel(),
                 stderr    => 1,
+                newline   => 1,
                 callbacks => sub {
                     my %args = @_;
-                    $args{message} = sprintf "%s [%d] %s - %s\n", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
+                    $args{message} = sprintf "%s [%d] %s - %s", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
                 },
             ],
         ]
     ),
 );
+
+$SIG{__WARN__} = sub {
+    $log->warning(map { my $m = $_; $m =~ s/\n/ /g; $m =~ s/^\s+|\s+$//g; $m } @_);
+};
 
 my $config = Zonemaster::Backend::Config->load_config();
 

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -56,7 +56,7 @@ Log::Any::Adapter->set(
 );
 
 $SIG{__WARN__} = sub {
-    $log->warning(map { my $m = $_; $m =~ s/\n/ /g; $m =~ s/^\s+|\s+$//g; $m } @_);
+    $log->warning(map s/^\s+|\s+$//gr, map s/\n/ /gr, @_);
 };
 
 my $config = Zonemaster::Backend::Config->load_config();

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -111,7 +111,7 @@ sub log_dispatcher_file {
 }
 
 $SIG{__WARN__} = sub {
-    $log->warning(map { my $m = $_; $m =~ s/\n/ /g; $m =~ s/^\s+|\s+$//g; $m } @_);
+    $log->warning(map s/^\s+|\s+$//gr, map s/\n/ /gr, @_);
 };
 
 ###

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -78,9 +78,10 @@ sub log_dispatcher_dup_stdout {
                 'Handle',
                 handle    => $handle,
                 min_level => $min_level,
+                newline   => 1,
                 callbacks => sub {
                     my %args = @_;
-                    $args{message} = sprintf "%s: %s\n", uc $args{level}, $args{message};
+                    $args{message} = sprintf "%s [%d] %s - %s", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
                 },
             ],
         ]
@@ -99,14 +100,19 @@ sub log_dispatcher_file {
                 filename  => $log_file,
                 mode      => '>>',
                 min_level => $min_level,
+                newline   => 1,
                 callbacks => sub {
                     my %args = @_;
-                    $args{message} = sprintf "%s [%d] %s - %s\n", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
+                    $args{message} = sprintf "%s [%d] %s - %s", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
                 },
             ],
         ]
     );
 }
+
+$SIG{__WARN__} = sub {
+    $log->warning(map { my $m = $_; $m =~ s/\n/ /g; $m =~ s/^\s+|\s+$//g; $m } @_);
+};
 
 ###
 ### Actual functionality


### PR DESCRIPTION
## Purpose

Get better log files.

## Changes

Use logger instead of warn.

## How to test this PR

```
./script/zmb get_test_results --test-id 123456789abcdef0 --lang fr
```
This trigger an exception (it should not but that for another PR), check that the message is correctly formatted:
```
2021-08-11T10:31:23Z [63992] ERROR - Internal error 012: Unexpected error in the get_test_results API call: [malformed JSON string, neither array, object, number, string or atom, at character offset 0 (before "(end of string)") at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB/PostgreSQL.pm line 235.]
```