### PR TITLE
process dead tests quickly

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -10,6 +10,7 @@ use JSON::PP;
 use Digest::MD5 qw(md5_hex);
 use Encode;
 use Log::Any qw( $log );
+use Time::HiRes qw[time];
 
 use Zonemaster::Engine::Profile
 
@@ -137,22 +138,37 @@ sub process_unfinished_tests {
             $self->schedule_for_retry($h->{hash_id});
         }
         else {
-            my $result;
-            if ( defined $h->{results} && $h->{results} =~ /^\[/ ) {
-                $result = decode_json( $h->{results} );
-            }
-            else {
-                $result = [];
-            }
-            push @$result,
-              {
-                "level"     => "CRITICAL",
-                "module"    => "BACKEND_TEST_AGENT",
-                "tag"       => "UNABLE_TO_FINISH_TEST",
-                "timestamp" => $test_run_timeout,
-              };
-            $self->process_unfinished_tests_give_up($result, $h->{hash_id});
+            $self->force_end_test($h->{hash_id}, $h->{results}, $test_run_timeout);
         }
+    }
+}
+
+sub force_end_test {
+    my ( $self, $hash_id, $results, $timestamp ) = @_;
+    my $result;
+    if ( defined $results && $results =~ /^\[/ ) {
+        $result = decode_json( $results );
+    }
+    else {
+        $result = [];
+    }
+    push @$result,
+        {
+        "level"     => "CRITICAL",
+        "module"    => "BACKEND_TEST_AGENT",
+        "tag"       => "UNABLE_TO_FINISH_TEST",
+        "timestamp" => $timestamp,
+        };
+    $self->process_unfinished_tests_give_up($result, $hash_id);
+}
+
+sub process_dead_test {
+    my ( $self, $hash_id, $test_run_max_retries ) = @_;
+    my ( $nb_retries, $results ) = $self->dbh->selectrow_array("SELECT nb_retries, results FROM test_results WHERE hash_id = ?", undef, $hash_id);
+    if ( $nb_retries < $test_run_max_retries) {
+        $self->schedule_for_retry($hash_id);
+    } else {
+        $self->force_end_test($hash_id, $results, $self->get_timestamp($hash_id));
     }
 }
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -27,6 +27,7 @@ requires qw(
   test_results
   user_authorized
   user_exists_in_db
+  get_relative_start_time
 );
 
 =head2 get_db_class
@@ -167,7 +168,7 @@ sub process_dead_test {
     if ( $nb_retries < $test_run_max_retries) {
         $self->schedule_for_retry($hash_id);
     } else {
-        $self->force_end_test($hash_id, $results, $self->get_timestamp($hash_id));
+        $self->force_end_test($hash_id, $results, $self->get_relative_start_time($hash_id));
     }
 }
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -10,7 +10,6 @@ use JSON::PP;
 use Digest::MD5 qw(md5_hex);
 use Encode;
 use Log::Any qw( $log );
-use Time::HiRes qw[time];
 
 use Zonemaster::Engine::Profile
 

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -423,7 +423,7 @@ sub schedule_for_retry {
     $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NOW() WHERE hash_id=?", undef, $hash_id);
 }
 
-sub get_timestamp {
+sub get_relative_start_time {
     my ( $self, $hash_id ) = @_;
 
     return $self->dbh->selectrow_array("SELECT now() - test_start_time FROM test_results WHERE hash_id=?", undef, $hash_id);

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -423,6 +423,12 @@ sub schedule_for_retry {
     $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NOW() WHERE hash_id=?", undef, $hash_id);
 }
 
+sub get_timestamp {
+    my ( $self, $hash_id ) = @_;
+
+    return $self->dbh->selectrow_array("SELECT now() - test_start_time FROM test_results WHERE hash_id=?", undef, $hash_id);
+}
+
 
 no Moose;
 __PACKAGE__->meta()->make_immutable();

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -395,7 +395,7 @@ sub schedule_for_retry {
     $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NOW() WHERE hash_id=?", undef, $hash_id);
 }
 
-sub get_timestamp {
+sub get_relative_start_time {
     my ( $self, $hash_id ) = @_;
 
     return $self->dbh->selectrow_array("SELECT EXTRACT(EPOCH FROM now() - test_start_time) FROM test_results WHERE hash_id=?", undef, $hash_id);

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -395,6 +395,12 @@ sub schedule_for_retry {
     $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = NOW() WHERE hash_id=?", undef, $hash_id);
 }
 
+sub get_timestamp {
+    my ( $self, $hash_id ) = @_;
+
+    return $self->dbh->selectrow_array("SELECT EXTRACT(EPOCH FROM now() - test_start_time) FROM test_results WHERE hash_id=?", undef, $hash_id);
+}
+
 no Moose;
 __PACKAGE__->meta()->make_immutable();
 

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -416,6 +416,12 @@ sub schedule_for_retry {
     $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = DATETIME('now') WHERE hash_id=?", undef, $hash_id);
 }
 
+sub get_timestamp {
+    my ( $self, $hash_id ) = @_;
+
+    return $self->dbh->selectrow_array("SELECT (julianday('now') - julianday(test_start_time)) * 3600 * 24 FROM test_results WHERE hash_id=?", undef, $hash_id);
+}
+
 no Moose;
 __PACKAGE__->meta()->make_immutable();
 

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -416,7 +416,7 @@ sub schedule_for_retry {
     $self->dbh->do("UPDATE test_results SET nb_retries = nb_retries + 1, progress = 0, test_start_time = DATETIME('now') WHERE hash_id=?", undef, $hash_id);
 }
 
-sub get_timestamp {
+sub get_relative_start_time {
     my ( $self, $hash_id ) = @_;
 
     return $self->dbh->selectrow_array("SELECT (julianday('now') - julianday(test_start_time)) * 3600 * 24 FROM test_results WHERE hash_id=?", undef, $hash_id);

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -145,6 +145,7 @@ sub main {
                 if ( $@ ) {
                     chomp $@;
                     $log->error( "Test died: $id: $@" );
+                    $self->db->process_dead_test( $id, $self->config->ZONEMASTER_maximal_number_of_retries )
                 }
                 else {
                     $log->info( "Test completed: $id" );


### PR DESCRIPTION
## Purpose

Terminate dead tests as soon as they die to not have the user to wait `max_zonemaster_execution_time` to see the error.

## Changes

* Add a few new methods in DB
  * `process_dead_test` terminate the test or schedule retry
  * `force_end_test` mark the test as failed, method reused in `process_unfinished_tests`
  * `get_timestamp` return the number of second since the test started
* When a test dies, process the termination of the test right away by calling `process_dead_test`

## How to test this PR

Test a domain that causes a failure, the test results should show up as soon as the test dies.
```
time ./script/zmtest kamglass.com.pl
```
