### PR TITLE
Add custom error handling

### DIFF
--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -213,7 +213,7 @@ sub get_test_params {
 
     eval { $result = decode_json( encode_utf8( $params_json ) ); };
 
-    die Zonemaster::Backend::Error::Internal->new( reason => "$@", data => { test_id => $test_id } ) if $@;
+    die Zonemaster::Backend::Error::JsonError->new( reason => "$@", data => { test_id => $test_id } ) if $@;
 
     return $result;
 }
@@ -227,12 +227,9 @@ sub test_results {
       if ( $results );
 
     my $result;
-    eval {
-        my ( $hrefs ) = $dbh->selectall_hashref( "SELECT id, hash_id, creation_time at time zone current_setting('TIMEZONE') at time zone 'UTC' as creation_time, params, results FROM test_results WHERE hash_id=?", 'hash_id', undef, $test_id );
-        $result = $hrefs->{$test_id};
-    };
+    my ( $hrefs ) = $dbh->selectall_hashref( "SELECT id, hash_id, creation_time at time zone current_setting('TIMEZONE') at time zone 'UTC' as creation_time, params, results FROM test_results WHERE hash_id=?", 'hash_id', undef, $test_id );
+    $result = $hrefs->{$test_id};
 
-    die Zonemaster::Backend::Error::Internal->new( reason => "$@", data => { test_id => $test_id } ) if $@;
     die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } ) unless defined $result;
 
     eval {
@@ -257,7 +254,7 @@ sub test_results {
         }
     };
 
-    die Zonemaster::Backend::Error::Internal->new( reason => "$@", data => { test_id => $test_id }) if $@;
+    die Zonemaster::Backend::Error::JsonError->new( reason => "$@", data => { test_id => $test_id }) if $@;
 
     return $result;
 }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -11,6 +11,8 @@ use Digest::MD5 qw(md5_hex);
 use JSON::PP;
 use Log::Any qw( $log );
 
+use Zonemaster::Backend::Errors;
+
 with 'Zonemaster::Backend::DB';
 
 has 'dbh' => (
@@ -244,12 +246,14 @@ sub get_test_params {
 
     my ( $params_json ) = $self->dbh->selectrow_array( "SELECT params FROM test_results WHERE hash_id=?", undef, $test_id );
 
+    die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } ) unless defined $params_json;
+
     my $result;
     eval {
         $result = decode_json( $params_json );
     };
 
-    $log->warn( "decoding of params_json failed (test_id: [$test_id]):".Dumper($params_json) ) if $@;
+    die Zonemaster::Backend::Error::JsonError->new( reason => "$@", data => { test_id => $test_id } ) if $@;
 
     return $result;
 }
@@ -265,8 +269,20 @@ sub test_results {
     my $result;
     my ( $hrefs ) = $self->dbh->selectall_hashref( "SELECT id, hash_id, creation_time, params, results FROM test_results WHERE hash_id=?", 'hash_id', undef, $test_id );
     $result            = $hrefs->{$test_id};
-    $result->{params}  = decode_json( $result->{params} );
-    $result->{results} = decode_json( $result->{results} );
+
+    die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } ) unless defined $result;
+
+    eval {
+        $result->{params}  = decode_json( $result->{params} );
+
+        if (defined $result->{results}) {
+            $result->{results} = decode_json( $result->{results} );
+        } else {
+            $result->{results} = [];
+        }
+    };
+
+    die Zonemaster::Backend::Error::JsonError->new( reason => "$@", data => { test_id => $test_id } ) if $@;
 
     return $result;
 }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -270,7 +270,7 @@ sub test_results {
     my ( $hrefs ) = $self->dbh->selectall_hashref( "SELECT id, hash_id, creation_time, params, results FROM test_results WHERE hash_id=?", 'hash_id', undef, $test_id );
     $result            = $hrefs->{$test_id};
 
-    die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } ) unless defined $result;
+    #die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } ) unless defined $result;
 
     eval {
         $result->{params}  = decode_json( $result->{params} );

--- a/lib/Zonemaster/Backend/Errors.pm
+++ b/lib/Zonemaster/Backend/Errors.pm
@@ -1,0 +1,141 @@
+package Zonemaster::Backend::Error;
+use Moose;
+use Data::Dumper;
+
+
+has 'message' => (
+    is => 'rw',
+    isa => 'Str',
+    required => 1,
+);
+
+has 'code' => (
+    is => 'rw',
+    isa => 'Int',
+    required => 1,
+);
+
+has 'data' => (
+    is => 'rw',
+    isa => 'Any',
+    default => undef,
+);
+
+sub as_hash {
+    my $self = shift;
+    my $error = {
+        code => $self->code,
+        message => $self->message
+    };
+    $error->{data} = $self->data if defined $self->data;
+    return $error;
+}
+
+sub as_string {
+    my $self = shift;
+    my $str = sprintf "%s (code %d)", $self->message, $self->code;
+    if (defined $self->data) {
+        $str .= sprintf "; Context: %s", $self->_data_dump;
+    }
+    return $str;
+}
+
+sub _data_dump {
+    my $self = shift;
+    local $Data::Dumper::Indent = 0;
+    local $Data::Dumper::Terse = 1;
+    my $data = Dumper($self->data);
+    $data =~ s/[\n\r]/ /g;
+    return $data ;
+}
+
+package Zonemaster::Backend::Error::Internal;
+use Moose;
+
+extends 'Zonemaster::Backend::Error';
+
+has '+message' => (
+    default => 'Internal server error'
+);
+
+has '+code' => (
+    default => -32603
+);
+
+has 'reason' => (
+    isa => 'Str',
+    is => 'rw',
+    initializer => 'reason',
+);
+
+has 'method' => (
+    is => 'rw',
+    isa => 'Str',
+    builder => '_build_method'
+);
+
+has 'id' => (
+    is => 'rw',
+    isa => 'Int',
+    default => 0,
+);
+
+sub _build_method {
+    my $s = 0;
+    while (my @c = caller($s)) {
+        $s ++;
+        last if $c[3] eq 'Moose::Object::new';
+    }
+    my @c = caller($s);
+    if ($c[3] =~ /^(.*)::handle_exception$/ ) {
+        @c = caller(++$s);
+    }
+
+    return $c[3];
+}
+
+around 'reason' => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    my ( $value, $setter, $attr ) = @_;
+
+    # reader
+    return $self->$orig if not $value;
+
+    # trim new lines
+    $value =~ s/\n/ /g;
+    $value =~ s/^\s+|\s+$//g;
+
+    # initializer
+    return $setter->($value) if $setter;
+
+    # writer
+    $self->$orig($value);
+};
+
+
+sub as_string {
+    my $self = shift;
+    my $str = sprintf "Internal error %0.3d: Unexpected error in the `%s` method: [%s]", $self->id, $self->method, $self->reason;
+    if (defined $self->data) {
+        $str .= sprintf "; Context: %s", $self->_data_dump;
+    }
+    return $str;
+}
+
+
+package Zonemaster::Backend::Error::ResourceNotFound;
+use Moose;
+
+extends 'Zonemaster::Backend::Error';
+
+has '+message' => (
+    default => 'Resource not found'
+);
+
+has '+code' => (
+    default => -32000
+);
+
+1;

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -85,7 +85,7 @@ sub handle_exception {
     if ( $exception->isa('Zonemaster::Backend::Error::Internal') ) {
         $log->error($exception->as_string);
     } else {
-        $log->notice($exception->as_string);
+        $log->info($exception->as_string);
     }
 
     die $exception->as_hash;

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -26,6 +26,7 @@ use Zonemaster::Backend;
 use Zonemaster::Backend::Config;
 use Zonemaster::Backend::Translator;
 use Zonemaster::Backend::Validator;
+use Log::Any qw( $log );
 
 my $zm_validator = Zonemaster::Backend::Validator->new;
 my %json_schemas;
@@ -77,7 +78,7 @@ sub handle_exception {
 
     $exception =~ s/\n/ /g;
     $exception =~ s/^\s+|\s+$//g;
-    warn "Internal error $exception_id: Unexpected error in the $method API call: [$exception] \n";
+    $log->error("Internal error $exception_id: Unexpected error in the $method API call: [$exception]");
     die "Internal error $exception_id \n";
 }
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -68,8 +68,9 @@ sub _init_db {
         my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
         $self->{db} = $dbclass->from_config( $self->{config} );
     };
-        handle_exception('_init_db', "Failed to initialize the [$dbtype] database backend module: [$@]", '002');
+
     if ($@) {
+        handle_exception('_init_db', "Failed to initialize the [$dbtype] database backend module: [$@]", '002');
     }
 }
 

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -45,14 +45,19 @@ Log::Any::Adapter->set(
                 'Screen',
                 min_level => get_loglevel(),
                 stderr    => 1,
+                newline   => 1,
                 callbacks => sub {
                     my %args = @_;
-                    $args{message} = sprintf "%s [%d] %s - %s\n", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
+                    $args{message} = sprintf "%s [%d] %s - %s", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
                 },
             ],
         ]
     ),
 );
+
+$SIG{__WARN__} = sub {
+    $log->warning(map { my $m = $_; $m =~ s/\n/ /g; $m =~ s/^\s+|\s+$//g; $m } @_);
+};
 
 my $config = Zonemaster::Backend::Config->load_config();
 

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -78,9 +78,10 @@ sub log_dispatcher_dup_stdout {
                 'Handle',
                 handle    => $handle,
                 min_level => $min_level,
+                newline   => 1,
                 callbacks => sub {
                     my %args = @_;
-                    $args{message} = sprintf "%s: %s\n", uc $args{level}, $args{message};
+                    $args{message} = sprintf "%s [%d] %s - %s", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
                 },
             ],
         ]
@@ -99,14 +100,19 @@ sub log_dispatcher_file {
                 filename  => $log_file,
                 mode      => '>>',
                 min_level => $min_level,
+                newline   => 1,
                 callbacks => sub {
                     my %args = @_;
-                    $args{message} = sprintf "%s [%d] %s - %s\n", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
+                    $args{message} = sprintf "%s [%d] %s - %s", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
                 },
             ],
         ]
     );
 }
+
+$SIG{__WARN__} = sub {
+    $log->warning(map { my $m = $_; $m =~ s/\n/ /g; $m =~ s/^\s+|\s+$//g; $m } @_);
+};
 
 ###
 ### Actual functionality

--- a/script/zonemaster_db_exporter.psgi
+++ b/script/zonemaster_db_exporter.psgi
@@ -1,0 +1,35 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+
+use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB;
+use Net::Prometheus;
+
+my $client = Net::Prometheus->new;
+
+my $tests_gauge = $client->new_gauge(
+    name => 'zonemaster_tests_total',
+    help => 'Total number of tests',
+    labels => [ 'state' ],
+);
+
+my $config = Zonemaster::Backend::Config->load_config();
+my $dbtype = $config->DB_engine;
+my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
+my $db = $dbclass->from_config( $config );
+
+my $prom_app = $client->psgi_app;
+
+sub {
+    my $queued = $db->dbh->selectrow_hashref('SELECT count(*) from test_results WHERE progress = 0');
+    $tests_gauge->labels('queued')->set($queued->{count});
+
+    my $finished = $db->dbh->selectrow_hashref('SELECT count(*) from test_results WHERE progress = 100');
+    $tests_gauge->labels('finished')->set($finished->{count});
+
+    my $running = $db->dbh->selectrow_hashref('SELECT count(*) from test_results WHERE progress > 0 and progress < 100');
+    $tests_gauge->labels('running')->set($running->{count});
+
+    $prom_app->(@_);
+};


### PR DESCRIPTION
## Purpose

Make error management a bit more manageable. 

## Context

Partially addresses #819 (with limitations due to downstream dependencies; codes definition is not covered).

## Changes

Built on top of #843, planned to be integrated with #844 to provide server error counters.

Adds a base error type `Zonemaster::Backend::Error` extended to the following classes:
* `Zonemaster::Backend::Error::Internal` (covers code -32603, but subclassed to add more meaning when applicable)
  * `Zonemaster::Backend::Error::JsonError`
* `Zonemaster::Backend::Error::ResourceNotFound` (custom)

This type is used to differentiate *actual* unexpected server error and "normal" exceptions (a test that does not exist in the database should not result in a server error, even less in a json parsing error). Also I noticed that sometimes `null` is returned when a test is not found (like with `get_test_progress`) and sometimes an error is returned, what should be the correct behavior? Returning a custom error seems to be an accepted pattern from what I have seen in other implementations, it can also have some context about the error.

It also adds the possibility to add meaning and context to the error, both to the operator, in the logs, and to the user, in the response.

It theoretically adds the ability to set a custom error code but that is not yet usable due to a limitation of the [JSON::RPC](https://github.com/lestrrat-p5/JSON-RPC) module. I have made a [pull request](https://github.com/lestrrat-p5/JSON-RPC/pull/14) to address that matter but the maintainer of the repo that not seem active anymore (the package on cpan has been marked for adoption).

If / when custom code are available in the JSON RPC module, the parameter validation should be moved after the method routing, relying on the external module to parse and validate the method (what it is already doing).



## How to test this PR

```sh
% ./script/zmb get_test_params --test-id a260536b98076a81 | jq
{
  "jsonrpc": "2.0",
  "error": {
    "message": "Test not found",
    "data": {
      "test_id": "a260536b98076a81"
    },
    "code": -32603
  },
  "id": 1
}
# Should be converted to a application error
% ./script/zmb add_batch_job --domain example.com --username toto --api-key notsecret | jq
{
  "error": {
    "code": -32603,
    "data": null,
    "message": "Internal server error"
  },
  "id": 1,
  "jsonrpc": "2.0"
}
# Test result existence has been disable to show case a JsonError
% ./script/zmb get_test_results --test-id 123456789abcdef0 --lang fr | jq {
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": -32603,
    "data": {
      "test_id": "123456789abcdef0"
    },
    "message": "Internal server error"
  }
}
```
Generated logs:
```
2021-08-12T13:58:45Z [47491] ERROR - Internal error 015 (Zonemaster::Backend::Error::Internal): Unexpected error in the `Zonemaster::Backend::RPCAPI::add_batch_job` method: [User toto not authorized to use batch mode]
2021-08-12T13:58:49Z [47492] INFO - Test not found (code -32000); Context: {'test_id' => 'a260536b98076a81'}
2021-08-12T13:59:07Z [47493] ERROR - Internal error 000 (Zonemaster::Backend::Error::JsonError): Unexpected error in the `Zonemaster::Backend::DB::SQLite::test_results` method: [malformed JSON string, neither array, object, number, string or atom, at character offset 0 (before "(end of string)") at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB/SQLite.pm line 276.]; Context: {'test_id' => '123456789abcdef0'}
```
