### PR TITLE
add custom error message in json schema

### DIFF
--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -136,7 +136,7 @@ sub ds_info {
         properties => {
             digest => {
                 type => 'string',
-                regex => $DIGEST_RE,
+                pattern => $DIGEST_RE,
                 'x-error-message' => 'Invalid digest format'
             },
             algorithm => {
@@ -192,7 +192,7 @@ sub test_id {
 sub language_tag {
     return {
         type => 'string',
-        regex => $LANGUAGE_RE,
+        pattern => $LANGUAGE_RE,
         'x-error-message' => 'Invalid language tag format'
     };
 }

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -122,24 +122,60 @@ sub client_version {
     return joi->string->regex( $CLIENT_VERSION_RE );
 }
 sub domain_name {
-    return joi->string->regex( $RELAXED_DOMAIN_NAME_RE );
+    return {
+        type => 'string',
+        pattern => $RELAXED_DOMAIN_NAME_RE,
+        'x-error-message' => 'The domain name contains a character or characters not supported'
+    };
 }
 sub ds_info {
-    return joi->object->strict->props(
-        digest => joi->string->regex($DIGEST_RE)->required,
-        algorithm => joi->integer->min(0)->required,
-        digtype => joi->integer->min(0)->required,
-        keytag => joi->integer->min(0)->required,
-    );
+    return {
+        type => 'object',
+        additionalProperties => 0,
+        required => [ 'digest', 'algorithm', 'digtype', 'keytag' ],
+        properties => {
+            digest => {
+                type => 'string',
+                regex => $DIGEST_RE,
+                'x-error-message' => 'Invalid digest format'
+            },
+            algorithm => {
+                type => 'number',
+                minimum => 0,
+                'x-error-message' => 'Algorithm must be a positive integer'
+            },
+            digtype => {
+                type => 'number',
+                minimum => 0,
+                'x-error-message' => 'Digest type must be a positive integer'
+            },
+            keytag => {
+                type => 'number',
+                minimum => 0,
+                'x-error-message' => 'Keytag must be a positive integer'
+            }
+        }
+    };
 }
 sub ip_address {
-    return joi->string->regex( $IPADDR_RE );
+    return {
+        type => 'string',
+        pattern => $IPADDR_RE,
+        'x-error-message' => 'Invalid IP address',
+    };
 }
 sub nameserver {
-    return joi->object->strict->props(
-            ns => joi->string->required,
-            ip => ip_address()
-    );
+    return {
+        type => 'object',
+        required => [ 'ns' ],
+        additionalProperties => 0,
+        properties => {
+            ns => {
+                type => 'string'
+            },
+            ip => ip_address
+        }
+    };
 }
 sub priority {
     return joi->integer;
@@ -154,7 +190,11 @@ sub test_id {
     return joi->string->regex( $TEST_ID_RE );
 }
 sub language_tag {
-    return joi->string->regex( $LANGUAGE_RE );
+    return {
+        type => 'string',
+        regex => $LANGUAGE_RE,
+        'x-error-message' => 'Invalid language tag format'
+    };
 }
 sub username {
     return joi->string->regex( $USERNAME_RE );


### PR DESCRIPTION
## Purpose

Provide more human friendly error messages than the ones generated by the JSON validator.

## Context

* Addresses issue #789 
* Replaces  #821 

## Changes

> TODO

I still need to test a bit more but this PR uses a custom attribute in the schema (`x-message-error`) to defined custom messages error directly in the schema. The exception being that when a required field is missing this custom message is ignored.

To make that possible I had to walk away from the Joi DSL, even the `description` field is not available with Joi. Not all schema have been replaced with raw JSON schema, only the necessary parts. I can replace the remaining bits later if needed.

## How to test this PR

`curl -sH "Content-Type: application/json" --data '{"method":"start_domain_test","params":{"domain":"toto.com", "nameservers":[{"ip":"a"}], "ds_info":[{"algorithm":-1,"digest":"abc","digtype":-1,"keytag":"abc"}]},"id":1,"jsonrpc":"2.0"}' localhost:5000/api  | jq`
```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "error": {
    "code": "-32602",
    "data": [
      {
        "message": "Algorithm must be a positive integer",
        "path": "/ds_info/0/algorithm"
      },
      {
        "path": "/ds_info/0/digest",
        "message": "Invalid digest format"
      },
      {
        "path": "/ds_info/0/digtype",
        "message": "Digest type must be a positive integer"
      },
      {
        "path": "/ds_info/0/keytag",
        "message": "Keytag must be a positive integer"
      },
      {
        "path": "/nameservers/0/ns",
        "message": "Missing property"
      },
      {
        "path": "/nameservers/0/ip",
        "message": "Invalid IP address"
      },
      {
        "message": "Domain name required",
        "path": "/nameservers/0/ns"
      },
      {
        "message": "Invalid IP address",
        "path": "/nameservers/0/ip"
      }
    ],
    "message": "Invalid method parameter(s)."
  }
}
```
