### PR TITLE
Update documentation to use SQLite by default

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -9,22 +9,21 @@
   * [3.2 Database engine installation and configuration (CentOS)](#32-database-engine-installation-and-configuration-centos)
   * [3.3 Service configuration and startup (CentOS)](#33-service-configuration-and-startup-centos)
   * [3.4 Post-installation (CentOS)](#34-post-installation-centos)
-* [4. Installation on Debian](#4-installation-on-debian)
-  * [4.1 Install Zonemaster::Backend and related dependencies (Debian)](#41-install-zonemasterbackend-and-related-dependencies-debian)
-  * [4.2 Database engine installation and configuration (Debian)](#42-database-engine-installation-and-configuration-debian)
-  * [4.3 Service configuration and startup (Debian)](#43-service-configuration-and-startup-debian)
-  * [4.4 Post-installation (Debian)](#44-post-installation-debian)
+* [4. Installation on Debian (and Ubuntu)](#4-installation-on-debian-and-ubuntu)
+  * [4.1 Install Zonemaster::Backend and related dependencies (Debian/Ubuntu)](#41-install-zonemasterbackend-and-related-dependencies-debian-and-ubuntu)
+  * [4.2 Database engine installation and configuration (Debian/Ubuntu)](#42-database-engine-installation-and-configuration-debian-and-ubuntu)
+  * [4.3 Service configuration and startup (Debian/Ubuntu)](#43-service-configuration-and-startup-debian-and-ubuntu)
+  * [4.4 Post-installation (Debian/Ubuntu)](#44-post-installation-debian-and-ubuntu)
 * [5. Installation on FreeBSD](#5-installation-on-freebsd)
   * [5.1 Install Zonemaster::Backend and related dependencies (FreeBSD)](#51-install-zonemasterbackend-and-related-dependencies-freebsd)
   * [5.2 Database engine installation and configuration (FreeBSD)](#52-database-engine-installation-and-configuration-freebsd)
   * [5.3 Service startup (FreeBSD)](#53-service-startup-freebsd)
   * [5.4 Post-installation (FreeBSD)](#54-post-installation-freebsd)
-* [6. Installation on Ubuntu](#6-installation-on-ubuntu)
-* [7. Post-installation](#7-post-installation)
-  * [7.1 Smoke test](#71-smoke-test)
-  * [7.2 What to do next?](#72-what-to-do-next)
-  * [7.3 Cleaning up the database](#73-cleaning-up-the-database)
-  * [7.4 Upgrade Zonemaster database](#74-upgrade-zonemaster-database)
+* [6. Post-installation](#6-post-installation)
+  * [6.1 Smoke test](#61-smoke-test)
+  * [6.2 What to do next?](#62-what-to-do-next)
+  * [6.3 Cleaning up the database](#63-cleaning-up-the-database)
+  * [6.4 Upgrade Zonemaster database](#64-upgrade-zonemaster-database)
 
 ## 1. Overview
 
@@ -241,9 +240,9 @@ sudo systemctl start zm-testagent
 See the [post-installation] section for post-installation matters.
 
 
-## 4. Installation on Debian
+## 4. Installation on Debian and Ubuntu
 
-### 4.1 Install Zonemaster::Backend and related dependencies (Debian)
+### 4.1 Install Zonemaster::Backend and related dependencies (Debian and Ubuntu)
 
 > **Note:** Zonemaster::LDNS and Zonemaster::Engine are not listed here as they
 > are dealt with in the [prerequisites](#prerequisites) section.
@@ -311,7 +310,7 @@ sudo install -v -m 755 ./tmpfiles.conf /usr/lib/tmpfiles.d/zonemaster.conf
 > `/etc/init.d/zm-backend.sh` (script from previous version of Zonemaster-Backend).
 
 
-### 4.2 Database engine installation and configuration (Debian)
+### 4.2 Database engine installation and configuration (Debian and Ubuntu)
 
 Check the [declaration of prerequisites] to make sure your preferred combination
 of operating system version and database engine version is supported.
@@ -326,7 +325,7 @@ If you keep the database, skip the initialization of the Zonemaster database,
 but if you have removed the old Zonemaster database, then do the initialization.
 
 
-#### 4.2.1 Instructions for MariaDB (Debian)
+#### 4.2.1 Instructions for MariaDB (Debian and Ubuntu)
 
 Install the database engine and its dependencies:
 
@@ -353,7 +352,7 @@ sudo mysql < $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backe
 > file). This user has just enough permissions to run the backend software.
 
 
-#### 4.2.2 Instructions for PostgreSQL (Debian)
+#### 4.2.2 Instructions for PostgreSQL (Debian and Ubuntu)
 
 Install database engine and Perl bindings:
 
@@ -380,7 +379,7 @@ sudo -u postgres psql -f $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zone
 > This user has just enough permissions to run the backend software.
 
 
-#### 4.2.3 Instructions for SQLite (Debian)
+#### 4.2.3 Instructions for SQLite (Debian and Ubuntu)
 
 > **Note:** Zonemaster with SQLite is not meant for an installation with heavy
 > load.
@@ -408,7 +407,7 @@ sudo chown zonemaster:zonemaster /var/lib/zonemaster/db.sqlite
 > **Note:** See the [backend configuration] documentation for details.
 
 
-### 4.3 Service configuration and startup (Debian)
+### 4.3 Service configuration and startup (Debian and Ubuntu)
 
 Make sure our tmpfiles configuration takes effect:
 
@@ -426,7 +425,7 @@ sudo systemctl start zm-testagent
 ```
 
 
-### 4.4 Post-installation (Debian)
+### 4.4 Post-installation (Debian and Ubuntu)
 
 See the [post-installation] section for post-installation matters.
 
@@ -636,14 +635,9 @@ service zm_testagent status
 See the [post-installation] section for post-installation matters.
 
 
-## 6. Installation on Ubuntu
+## 6. Post-installation
 
-Use the procedure for installation on [Debian](#4-installation-on-debian).
-
-
-## 7. Post-installation
-
-### 7.1 Smoke test
+### 6.1 Smoke test
 
 If you have followed the installation instructions for Zonemaster::Backend above,
 you should be able to use the API on localhost port 5000 as below.
@@ -657,14 +651,14 @@ followed by a percentage ticking up from 0% to 100%.
 Once the number reaches 100% a JSON object is printed and zmtest terminates.
 
 
-### 7.2. What to do next?
+### 6.2. What to do next?
 
 * For a web interface, follow the [Zonemaster::GUI installation] instructions.
 * For a command line interface, follow the [Zonemaster::CLI installation] instruction.
 * For a JSON-RPC API, see the Zonemaster::Backend [JSON-RPC API] documentation.
 
 
-### 7.3. Cleaning up the database
+### 6.3. Cleaning up the database
 
 If, at some point, you want to delete all traces of Zonemaster in the database,
 you can run the file `cleanup-mysql.sql` or file `cleanup-postgres.sql`
@@ -672,25 +666,25 @@ as a database administrator. Commands
 for locating and running the file are below. It removes the user and drops the
 database (obviously taking all data with it).
 
-#### 7.3.1 MySQL
+#### 6.3.1 MySQL
 
 ```sh
 cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
 mysql --user=root --password < ./cleanup-mysql.sql
 ```
 
-#### 7.3.2 PostgreSQL
+#### 6.3.2 PostgreSQL
 
 ```sh
 cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
 sudo -u postgres psql -f ./cleanup-postgres.sql # MUST BE VERIFIED!
 ```
 
-#### 7.3.3 SQLite
+#### 6.3.3 SQLite
 
 Remove the database file and recreate it following the installation instructions above.
 
-### 7.4 Upgrade Zonemaster database
+### 6.4 Upgrade Zonemaster database
 
 If you upgrade your Zonemaster installation with a newer version of
 Zonemaster-Backend and keep the database, then you might have to upgrade the

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -126,7 +126,7 @@ but if you have removed the old Zonemaster database, then do the initialization.
 > **Note:** Zonemaster with SQLite is not meant for an installation with heavy
 > load.
 
-Create database directory, set correct ownership and create database:
+Create database directory, database and set correct ownership:
 
 ```sh
 cd `perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")'`
@@ -134,8 +134,6 @@ sudo install -v -m 755 -o zonemaster -g zonemaster -d /var/lib/zonemaster
 sudo perl create_db_sqlite.pl
 sudo chown zonemaster:zonemaster /var/lib/zonemaster/db.sqlite
 ```
-
-> **Note:** See the [backend configuration] documentation for details.
 
 
 #### 3.2.2 Instructions for other engines (CentOS)
@@ -256,9 +254,7 @@ but if you have removed the old Zonemaster database, then do the initialization.
 > **Note:** Zonemaster with SQLite is not meant for an installation with heavy
 > load.
 
-> All binaries and Perl bindings are already installed.
-
-Create database directory, set correct ownership and create database:
+Create database directory, database and set correct ownership:
 
 ```sh
 cd `perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")'`
@@ -266,10 +262,6 @@ sudo install -v -m 755 -o zonemaster -g zonemaster -d /var/lib/zonemaster
 sudo perl create_db_sqlite.pl
 sudo chown zonemaster:zonemaster /var/lib/zonemaster/db.sqlite
 ```
-
-> SQLite will not run as a daemon and does not need to be started.
-
-> **Note:** See the [backend configuration] documentation for details.
 
 
 #### 4.2.2 Instructions for other engines (Debian/Ubuntu)
@@ -369,25 +361,21 @@ but if you have removed the old Zonemaster database, then do the initialization.
 > **Note:** Zonemaster with SQLite is not meant for an installation with heavy
 > load.
 
-> All binaries and Perl bindings are already installed.
-
 Configure Zonemaster::Backend to use the correct database path:
 
 ```sh
 sed -i '' '/[[:<:]]database_file[[:>:]]/ s:=.*:= /var/db/zonemaster/db.sqlite:' /usr/local/etc/zonemaster/backend_config.ini
 ```
 
-Create database directory, set correct ownership and create database:
+> **Note:** See the [backend configuration] documentation for details.
+
+Create database directory and database with correct ownership:
 
 ```sh
 cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
 install -v -m 755 -o zonemaster -g zonemaster -d /var/db/zonemaster
 env ZONEMASTER_BACKEND_CONFIG_FILE=/usr/local/etc/zonemaster/backend_config.ini su -m zonemaster -c "perl create_db_sqlite.pl"
 ```
-
-> SQLite will not run as a daemon and does not need to be started.
-
-> **Note:** See the [backend configuration] documentation for details.
 
 #### 5.2.2 Instructions for other engines (FreeBSD)
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -135,6 +135,9 @@ sudo perl create_db_sqlite.pl
 sudo chown zonemaster:zonemaster /var/lib/zonemaster/db.sqlite
 ```
 
+> Some parameters can be changed, see the [backend configuration] documentation
+> for details.
+
 
 #### 3.2.2 Instructions for other engines (CentOS)
 
@@ -263,6 +266,9 @@ sudo perl create_db_sqlite.pl
 sudo chown zonemaster:zonemaster /var/lib/zonemaster/db.sqlite
 ```
 
+> Some parameters can be changed, see the [backend configuration] documentation
+> for details.
+
 
 #### 4.2.2 Instructions for other engines (Debian/Ubuntu)
 
@@ -367,8 +373,6 @@ Configure Zonemaster::Backend to use the correct database path:
 sed -i '' '/[[:<:]]database_file[[:>:]]/ s:=.*:= /var/db/zonemaster/db.sqlite:' /usr/local/etc/zonemaster/backend_config.ini
 ```
 
-> **Note:** See the [backend configuration] documentation for details.
-
 Create database directory and database with correct ownership:
 
 ```sh
@@ -376,6 +380,9 @@ cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backen
 install -v -m 755 -o zonemaster -g zonemaster -d /var/db/zonemaster
 env ZONEMASTER_BACKEND_CONFIG_FILE=/usr/local/etc/zonemaster/backend_config.ini su -m zonemaster -c "perl create_db_sqlite.pl"
 ```
+
+> Some parameters can be changed, see the [backend configuration] documentation
+> for details.
 
 #### 5.2.2 Instructions for other engines (FreeBSD)
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -469,8 +469,6 @@ Zonemaster-Backend and keep the database, then you might have to upgrade the
 database to use it with the new version of Zonemaster-Backend. Please see the
 [upgrade][README.md-upgrade] information.
 
-For SQLite database upgrading is not needed as of now.
-
 
 
 ## Appendices

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -126,13 +126,6 @@ but if you have removed the old Zonemaster database, then do the initialization.
 > **Note:** Zonemaster with SQLite is not meant for an installation with heavy
 > load.
 
-Configure Zonemaster::Backend to use the correct database engine and database
-path:
-
-```sh
-sudo sed -i '/\bengine\b/ s/=.*/= SQLite/' /etc/zonemaster/backend_config.ini
-```
-
 Create database directory, set correct ownership and create database:
 
 ```sh
@@ -265,13 +258,6 @@ but if you have removed the old Zonemaster database, then do the initialization.
 
 > All binaries and Perl bindings are already installed.
 
-Configure Zonemaster::Backend to use the correct database engine and database
-path:
-
-```sh
-sudo sed -i '/\bengine\b/ s/=.*/= SQLite/' /etc/zonemaster/backend_config.ini
-```
-
 Create database directory, set correct ownership and create database:
 
 ```sh
@@ -385,11 +371,9 @@ but if you have removed the old Zonemaster database, then do the initialization.
 
 > All binaries and Perl bindings are already installed.
 
-Configure Zonemaster::Backend to use the correct database engine and database
-path:
+Configure Zonemaster::Backend to use the correct database path:
 
 ```sh
-sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= SQLite/' /usr/local/etc/zonemaster/backend_config.ini
 sed -i '' '/[[:<:]]database_file[[:>:]]/ s:=.*:= /var/db/zonemaster/db.sqlite:' /usr/local/etc/zonemaster/backend_config.ini
 ```
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -22,8 +22,11 @@
 * [6. Post-installation](#6-post-installation)
   * [6.1 Smoke test](#61-smoke-test)
   * [6.2 What to do next?](#62-what-to-do-next)
-  * [6.3 Cleaning up the database](#63-cleaning-up-the-database)
-  * [6.4 Upgrade Zonemaster database](#64-upgrade-zonemaster-database)
+* [7. Upgrade Zonemaster database](#7-upgrade-zonemaster-database)
+* [Appendices](#appendices)
+  * [A. Installation with MariaDB](#a-installation-with-mariadb)
+  * [B. Installation with PostgreSQL](#b-installation-with-postgresql)
+  * [C. Cleaning up the database](#c-cleaning-up-the-database)
 
 ## 1. Overview
 
@@ -110,90 +113,15 @@ Check the [declaration of prerequisites] to make sure your preferred combination
 of operating system version and database engine version is supported.
 
 The installation instructions below assumes that this is a new installation.
-If you upgrade and want to keep the database, go to section
-[7.4](#74-upgrade-zonemaster-database) first. If you instead want to start
-from afresh, then go to section [7.3](#73-cleaning-up-the-database) and remove
-the old database first.
+If you upgrade and want to keep the database, go to [section 7][Upgrade
+database] first. If you instead want to start from afresh, then go to [appendix
+C][Cleaning database] and remove the old database first.
 
 If you keep the database, skip the initialization of the Zonemaster database,
 but if you have removed the old Zonemaster database, then do the initialization.
 
 
-#### 3.2.1 Instructions for MariaDB (CentOS)
-
-Configure Zonemaster::Backend to use the correct database engine:
-
-```sh
-sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
-```
-
-> **Note:** See the [backend configuration] documentation for details.
-
-Install, configure and start database engine:
-
-```sh
-sudo yum -y install mariadb-server
-sudo systemctl enable mariadb
-sudo systemctl start mariadb
-```
-
-Initialize the database (unless you keep an old database):
-
-```sh
-sudo mysql < $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/initial-mysql.sql
-```
-
-> **Note:** This creates a database called `zonemaster`, as well as a user
-> called "zonemaster" with the password "zonemaster" (as stated in the config
-> file). This user has just enough permissions to run the backend software.
-
-
-#### 3.2.2 Instructions for PostgreSQL (CentOS)
-
-Configure Zonemaster::Backend to use the correct database engine:
-
-```sh
-sudo sed -i '/\bengine\b/ s/=.*/= PostgreSQL/' /etc/zonemaster/backend_config.ini
-```
-
-> **Note:** See the [backend configuration] documentation for details.
-
-
-Install, configure and start database engine:
-
-* On CentOS 7:
-
-  ```sh
-  sudo rpm -iUvh https://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/pgdg-centos93-9.3-3.noarch.rpm
-  sudo yum -y install postgresql93-server perl-DBD-Pg
-  sudo /usr/pgsql-9.3/bin/postgresql93-setup initdb
-  sudo sed -i '/^[^#]/ s/ident$/md5/' /var/lib/pgsql/9.3/data/pg_hba.conf
-  sudo systemctl enable postgresql-9.3
-  sudo systemctl start postgresql-9.3
-  ```
-
-* On CentOS 8:
-
-  ```sh
-  sudo yum -y install postgresql-server perl-DBD-Pg
-  sudo postgresql-setup --initdb --unit postgresql
-  sudo sed -i '/^[^#]/ s/ident$/md5/' /var/lib/pgsql/data/pg_hba.conf
-  sudo systemctl enable postgresql
-  sudo systemctl start postgresql
-  ```
-
-Initialize Zonemaster database (unless you keep an old database):
-
-```sh
-sudo -u postgres psql -f $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/initial-postgres.sql
-```
-
-> **Note:** This creates a database called `zonemaster`, as well as a user called
-> "zonemaster" with the password "zonemaster" (as stated in the config file).
-> This user has just enough permissions to run the backend software.
-
-
-#### 3.2.3 Instructions for SQLite (CentOS)
+#### 3.2.1 Instructions for SQLite (CentOS)
 
 > **Note:** Zonemaster with SQLite is not meant for an installation with heavy
 > load.
@@ -215,6 +143,12 @@ sudo chown zonemaster:zonemaster /var/lib/zonemaster/db.sqlite
 ```
 
 > **Note:** See the [backend configuration] documentation for details.
+
+
+#### 3.2.2 Instructions for other engines (CentOS)
+
+See appendices for [MariaDB][MariaDB instructions for CentOS] and
+[PostgreSQL][PostgreSQL instructions for CentOS].
 
 
 ### 3.3 Service configuration and startup (CentOS)
@@ -316,70 +250,15 @@ Check the [declaration of prerequisites] to make sure your preferred combination
 of operating system version and database engine version is supported.
 
 The installation instructions below assumes that this is a new installation.
-If you upgrade and want to keep the database, go to section
-[7.4](#74-upgrade-zonemaster-database) first. If you instead want to start
-from afresh, then go to section [7.3](#73-cleaning-up-the-database) and remove
-the old database first.
+If you upgrade and want to keep the database, go to [section 7][Upgrade
+database] first. If you instead want to start from afresh, then go to [appendix
+C][Cleaning database] and remove the old database first.
 
 If you keep the database, skip the initialization of the Zonemaster database,
 but if you have removed the old Zonemaster database, then do the initialization.
 
 
-#### 4.2.1 Instructions for MariaDB (Debian and Ubuntu)
-
-Install the database engine and its dependencies:
-
-```sh
-sudo apt install mariadb-server libdbd-mysql-perl
-```
-
-Configure Zonemaster::Backend to use the correct database engine:
-
-```sh
-sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
-```
-
-> **Note:** See the [backend configuration] documentation for details.
-
-Initialize Zonemaster database (unless you keep an old database):
-
-```sh
-sudo mysql < $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/initial-mysql.sql
-```
-
-> **Note:** This creates a database called `zonemaster`, as well as a user
-> called "zonemaster" with the password "zonemaster" (as stated in the config
-> file). This user has just enough permissions to run the backend software.
-
-
-#### 4.2.2 Instructions for PostgreSQL (Debian and Ubuntu)
-
-Install database engine and Perl bindings:
-
-```sh
-sudo apt install postgresql libdbd-pg-perl
-```
-
-Configure Zonemaster::Backend to use the correct database engine:
-
-```sh
-sudo sed -i '/\bengine\b/ s/=.*/= PostgreSQL/' /etc/zonemaster/backend_config.ini
-```
-
-> **Note:** See the [backend configuration] documentation for details.
-
-Initialize Zonemaster database (unless you keep an old database):
-
-```sh
-sudo -u postgres psql -f $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/initial-postgres.sql
-```
-
-> **Note:** This creates a database called `zonemaster`, as well as a user called
-> "zonemaster" with the password "zonemaster" (as stated in the config file).
-> This user has just enough permissions to run the backend software.
-
-
-#### 4.2.3 Instructions for SQLite (Debian and Ubuntu)
+#### 4.2.1 Instructions for SQLite (Debian and Ubuntu)
 
 > **Note:** Zonemaster with SQLite is not meant for an installation with heavy
 > load.
@@ -405,6 +284,12 @@ sudo chown zonemaster:zonemaster /var/lib/zonemaster/db.sqlite
 > SQLite will not run as a daemon and does not need to be started.
 
 > **Note:** See the [backend configuration] documentation for details.
+
+
+#### 4.2.2 Instructions for other engines (Debian and Ubuntu)
+
+See appendices for [MariaDB][MariaDB instructions for Debian] and
+[PostgreSQL][PostgreSQL instructions for Debian].
 
 
 ### 4.3 Service configuration and startup (Debian and Ubuntu)
@@ -486,95 +371,14 @@ Check the [declaration of prerequisites] to make sure your preferred combination
 of operating system version and database engine version is supported.
 
 The installation instructions below assumes that this is a new installation.
-If you upgrade and want to keep the database, go to section
-[7.4](#74-upgrade-zonemaster-database) first. If you instead want to start
-from afresh, then go to section [7.3](#73-cleaning-up-the-database) and remove
-the old database first.
+If you upgrade and want to keep the database, go to [section 7][Upgrade
+database] first. If you instead want to start from afresh, then go to [appendix
+C][Cleaning database] and remove the old database first.
 
 If you keep the database, skip the initialization of the Zonemaster database,
 but if you have removed the old Zonemaster database, then do the initialization.
 
-#### 5.2.1 Instructions for MySQL (FreeBSD)
-
-Configure Zonemaster::Backend to use the correct database engine:
-
-```sh
-sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= MySQL/' /usr/local/etc/zonemaster/backend_config.ini
-```
-> **Note:** See the [backend configuration] documentation for details.
-
-Install, configure and start database engine (and Perl bindings):
-
-```sh
-pkg install mysql57-server p5-DBD-mysql
-sysrc mysql_enable="YES"
-service mysql-server start
-```
-
-Read the current root password for MySQL:
-
-```sh
-cat /root/.mysql_secret
-```
-
-Connect to MySQL interactively:
-
-```sh
-mysql -u root -h localhost -p
-```
-
-Reset root password in MySQL (required by MySQL). Replace
-`<selected root password>` with the password from the file above
-(or another one of your choice):
-
-```sql
-ALTER USER 'root'@'localhost' IDENTIFIED BY '<selected root password>';
-```
-
-Logout from database:
-
-```sql
-exit;
-```
-
-Unless you keep an old database, initialize the database (and give the
-root password when prompted):
-
-```sh
-cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
-mysql -u root -p < ./initial-mysql.sql
-```
-
-> **Note:** This creates a database called `zonemaster`, as well as a user
-> called "zonemaster" with the password "zonemaster" (as stated in the config
-> file). This user has just enough permissions to run the backend software.
-
-#### 5.2.2 Instructions for PostgreSQL (FreeBSD)
-
-Configure Zonemaster::Backend to use the correct database engine:
-
-```sh
-sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= PostgreSQL/' /usr/local/etc/zonemaster/backend_config.ini
-```
-> **Note:** See the [backend configuration] documentation for details.
-
-Install, configure and start database engine (and Perl bindings):
-
-```sh
-pkg install postgresql12-server p5-DBD-Pg
-sysrc postgresql_enable="YES"
-service postgresql initdb
-service postgresql start
-```
-
-Initialize Zonemaster database (unless you keep an old database):
-
-```sh
-cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
-psql -U postgres -f ./initial-postgres.sql
-```
-
-#### 5.2.3 Instructions for SQLite (FreeBSD)
+#### 5.2.1 Instructions for SQLite (FreeBSD)
 
 > **Note:** Zonemaster with SQLite is not meant for an installation with heavy
 > load.
@@ -600,6 +404,12 @@ env ZONEMASTER_BACKEND_CONFIG_FILE=/usr/local/etc/zonemaster/backend_config.ini 
 > SQLite will not run as a daemon and does not need to be started.
 
 > **Note:** See the [backend configuration] documentation for details.
+
+#### 5.2.2 Instructions for other engines (FreeBSD)
+
+See appendices for [MariaDB][MariaDB instructions for FreeBSD] and
+[PostgreSQL][PostgreSQL instructions for FreeBSD].
+
 
 ### 5.3 Service startup (FreeBSD)
 
@@ -658,33 +468,7 @@ Once the number reaches 100% a JSON object is printed and zmtest terminates.
 * For a JSON-RPC API, see the Zonemaster::Backend [JSON-RPC API] documentation.
 
 
-### 6.3. Cleaning up the database
-
-If, at some point, you want to delete all traces of Zonemaster in the database,
-you can run the file `cleanup-mysql.sql` or file `cleanup-postgres.sql`
-as a database administrator. Commands
-for locating and running the file are below. It removes the user and drops the
-database (obviously taking all data with it).
-
-#### 6.3.1 MySQL
-
-```sh
-cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
-mysql --user=root --password < ./cleanup-mysql.sql
-```
-
-#### 6.3.2 PostgreSQL
-
-```sh
-cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
-sudo -u postgres psql -f ./cleanup-postgres.sql # MUST BE VERIFIED!
-```
-
-#### 6.3.3 SQLite
-
-Remove the database file and recreate it following the installation instructions above.
-
-### 6.4 Upgrade Zonemaster database
+## 7. Upgrade Zonemaster database
 
 If you upgrade your Zonemaster installation with a newer version of
 Zonemaster-Backend and keep the database, then you might have to upgrade the
@@ -693,14 +477,277 @@ database to use it with the new version of Zonemaster-Backend. Please see the
 
 For SQLite database upgrading is not needed as of now.
 
+
+
+# Appendices
+
+
+## A. Installation with MariaDB
+
+* [CentOS](#a1-mariadb-installation-for-centos)
+* [Debian/Ubuntu](#a2-mariadb-installation-for-debian-and-ubuntu)
+* [FreeBSD](#a3-mysql-installation-for-freebsd)
+
+### A.1. MariaDB installation for CentOS
+
+Configure Zonemaster::Backend to use the correct database engine:
+
+```sh
+sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
+```
+
+> **Note:** See the [backend configuration] documentation for details.
+
+Install, configure and start database engine:
+
+```sh
+sudo yum -y install mariadb-server
+sudo systemctl enable mariadb
+sudo systemctl start mariadb
+```
+
+Initialize the database (unless you keep an old database):
+
+```sh
+sudo mysql < $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/initial-mysql.sql
+```
+
+> **Note:** This creates a database called `zonemaster`, as well as a user
+> called "zonemaster" with the password "zonemaster" (as stated in the config
+> file). This user has just enough permissions to run the backend software.
+
+
+### A.2. MariaDB installation for Debian and Ubuntu
+
+Install the database engine and its dependencies:
+
+```sh
+sudo apt install mariadb-server libdbd-mysql-perl
+```
+
+Configure Zonemaster::Backend to use the correct database engine:
+
+```sh
+sudo sed -i '/\bengine\b/ s/=.*/= MySQL/' /etc/zonemaster/backend_config.ini
+```
+
+> **Note:** See the [backend configuration] documentation for details.
+
+Initialize Zonemaster database (unless you keep an old database):
+
+```sh
+sudo mysql < $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/initial-mysql.sql
+```
+
+> **Note:** This creates a database called `zonemaster`, as well as a user
+> called "zonemaster" with the password "zonemaster" (as stated in the config
+> file). This user has just enough permissions to run the backend software.
+
+
+### A.3. MySQL installation for FreeBSD
+
+> MySQL is used on FreeBSD
+
+Configure Zonemaster::Backend to use the correct database engine:
+
+```sh
+sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= MySQL/' /usr/local/etc/zonemaster/backend_config.ini
+```
+> **Note:** See the [backend configuration] documentation for details.
+
+Install, configure and start database engine (and Perl bindings):
+
+```sh
+pkg install mysql57-server p5-DBD-mysql
+sysrc mysql_enable="YES"
+service mysql-server start
+```
+
+Read the current root password for MySQL:
+
+```sh
+cat /root/.mysql_secret
+```
+
+Connect to MySQL interactively:
+
+```sh
+mysql -u root -h localhost -p
+```
+
+Reset root password in MySQL (required by MySQL). Replace
+`<selected root password>` with the password from the file above
+(or another one of your choice):
+
+```sql
+ALTER USER 'root'@'localhost' IDENTIFIED BY '<selected root password>';
+```
+
+Logout from database:
+
+```sql
+exit;
+```
+
+Unless you keep an old database, initialize the database (and give the
+root password when prompted):
+
+```sh
+cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
+mysql -u root -p < ./initial-mysql.sql
+```
+
+> **Note:** This creates a database called `zonemaster`, as well as a user
+> called "zonemaster" with the password "zonemaster" (as stated in the config
+> file). This user has just enough permissions to run the backend software.
+
+
+## B. Installation with PostgreSQL
+
+* [CentOS](#b1-postgresql-installation-for-centos)
+* [Debian/Ubuntu](#b2-postgresql-installation-for-debian-and-ubuntu)
+* [FreeBSD](#b3-postgresql-installation-for-freebsd)
+
+
+### B.1. PostgreSQL installation for CentOS
+
+Configure Zonemaster::Backend to use the correct database engine:
+
+```sh
+sudo sed -i '/\bengine\b/ s/=.*/= PostgreSQL/' /etc/zonemaster/backend_config.ini
+```
+
+> **Note:** See the [backend configuration] documentation for details.
+
+Install, configure and start database engine:
+
+* On CentOS 7:
+
+  ```sh
+  sudo rpm -iUvh https://yum.postgresql.org/9.3/redhat/rhel-7-x86_64/pgdg-centos93-9.3-3.noarch.rpm
+  sudo yum -y install postgresql93-server perl-DBD-Pg
+  sudo /usr/pgsql-9.3/bin/postgresql93-setup initdb
+  sudo sed -i '/^[^#]/ s/ident$/md5/' /var/lib/pgsql/9.3/data/pg_hba.conf
+  sudo systemctl enable postgresql-9.3
+  sudo systemctl start postgresql-9.3
+  ```
+
+* On CentOS 8:
+
+  ```sh
+  sudo yum -y install postgresql-server perl-DBD-Pg
+  sudo postgresql-setup --initdb --unit postgresql
+  sudo sed -i '/^[^#]/ s/ident$/md5/' /var/lib/pgsql/data/pg_hba.conf
+  sudo systemctl enable postgresql
+  sudo systemctl start postgresql
+  ```
+
+Initialize Zonemaster database (unless you keep an old database):
+
+```sh
+sudo -u postgres psql -f $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/initial-postgres.sql
+```
+
+> **Note:** This creates a database called `zonemaster`, as well as a user called
+> "zonemaster" with the password "zonemaster" (as stated in the config file).
+> This user has just enough permissions to run the backend software.
+
+
+### B.2. PostgreSQL installation for Debian and Ubuntu
+
+Configure Zonemaster::Backend to use the correct database engine:
+
+```sh
+sudo sed -i '/\bengine\b/ s/=.*/= PostgreSQL/' /etc/zonemaster/backend_config.ini
+```
+
+Install the database engine and Perl bindings:
+
+```sh
+sudo apt install postgresql libdbd-pg-perl
+```
+
+> **Note:** See the [backend configuration] documentation for details.
+
+Initialize Zonemaster database (unless you keep an old database):
+
+```sh
+sudo -u postgres psql -f $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/initial-postgres.sql
+```
+
+> **Note:** This creates a database called `zonemaster`, as well as a user called
+> "zonemaster" with the password "zonemaster" (as stated in the config file).
+> This user has just enough permissions to run the backend software.
+
+
+### B.3. PostgreSQL installation for FreeBSD
+
+Configure Zonemaster::Backend to use the correct database engine:
+
+```sh
+sed -i '' '/[[:<:]]engine[[:>:]]/ s/=.*/= PostgreSQL/' /usr/local/etc/zonemaster/backend_config.ini
+```
+> **Note:** See the [backend configuration] documentation for details.
+
+Install, configure and start database engine (and Perl bindings):
+
+```sh
+pkg install postgresql12-server p5-DBD-Pg
+sysrc postgresql_enable="YES"
+service postgresql initdb
+service postgresql start
+```
+
+Initialize Zonemaster database (unless you keep an old database):
+
+```sh
+cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
+psql -U postgres -f ./initial-postgres.sql
+```
+
+
+## C. Cleaning up the database
+
+If, at some point, you want to delete all traces of Zonemaster in the database,
+you can run the file `cleanup-mysql.sql` or file `cleanup-postgres.sql`
+as a database administrator. Commands
+for locating and running the file are below. It removes the user and drops the
+database (obviously taking all data with it).
+
+### C.1. MySQL
+
+```sh
+cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
+mysql --user=root --password < ./cleanup-mysql.sql
+```
+
+### C.2. PostgreSQL
+
+```sh
+cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
+sudo -u postgres psql -f ./cleanup-postgres.sql # MUST BE VERIFIED!
+```
+
+### C.3. SQLite
+
+Remove the database file and recreate it following the installation instructions above.
+
 -------
 
 [Backend configuration]: Configuration.md
+[Cleaning database]: #c-cleaning-up-the-database
 [Declaration of prerequisites]: https://github.com/zonemaster/zonemaster#prerequisites
 [JSON-RPC API]: API.md
 [Main Zonemaster repository]: https://github.com/zonemaster/zonemaster/blob/master/README.md
-[Post-installation]: #7-post-installation
+[MariaDB instructions for CentOS]: #a1-mariadb-installation-for-centos
+[MariaDB instructions for Debian]: #a2-mariadb-installation-for-debian-and-ubuntu
+[MariaDB instructions for FreeBSD]: #a3-mysql-installation-for-freebsd
+[PostgreSQL instructions for CentOS]: #b1-postgresql-installation-for-centos
+[PostgreSQL instructions for Debian]: #b2-postgresql-installation-for-debian-and-ubuntu
+[PostgreSQL instructions for FreeBSD]: #b3-postgresql-installation-for-freebsd
+[Post-installation]: #6-post-installation
 [README.md-upgrade]: /README.md#upgrade
+[Upgrade database]: #7-upgrade-zonemaster-database
 [Zonemaster::CLI installation]: https://github.com/zonemaster/zonemaster-cli/blob/master/docs/Installation.md
 [Zonemaster::GUI installation]: https://github.com/zonemaster/zonemaster-gui/blob/master/docs/Installation.md
 [Zonemaster::Engine installation]: https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -9,11 +9,11 @@
   * [3.2 Database engine installation and configuration (CentOS)](#32-database-engine-installation-and-configuration-centos)
   * [3.3 Service configuration and startup (CentOS)](#33-service-configuration-and-startup-centos)
   * [3.4 Post-installation (CentOS)](#34-post-installation-centos)
-* [4. Installation on Debian (and Ubuntu)](#4-installation-on-debian-and-ubuntu)
-  * [4.1 Install Zonemaster::Backend and related dependencies (Debian/Ubuntu)](#41-install-zonemasterbackend-and-related-dependencies-debian-and-ubuntu)
-  * [4.2 Database engine installation and configuration (Debian/Ubuntu)](#42-database-engine-installation-and-configuration-debian-and-ubuntu)
-  * [4.3 Service configuration and startup (Debian/Ubuntu)](#43-service-configuration-and-startup-debian-and-ubuntu)
-  * [4.4 Post-installation (Debian/Ubuntu)](#44-post-installation-debian-and-ubuntu)
+* [4. Installation on Debian and Ubuntu](#4-installation-on-debian-and-ubuntu)
+  * [4.1 Install Zonemaster::Backend and related dependencies (Debian/Ubuntu)](#41-install-zonemasterbackend-and-related-dependencies-debianubuntu)
+  * [4.2 Database engine installation and configuration (Debian/Ubuntu)](#42-database-engine-installation-and-configuration-debianubuntu)
+  * [4.3 Service configuration and startup (Debian/Ubuntu)](#43-service-configuration-and-startup-debianubuntu)
+  * [4.4 Post-installation (Debian/Ubuntu)](#44-post-installation-debianubuntu)
 * [5. Installation on FreeBSD](#5-installation-on-freebsd)
   * [5.1 Install Zonemaster::Backend and related dependencies (FreeBSD)](#51-install-zonemasterbackend-and-related-dependencies-freebsd)
   * [5.2 Database engine installation and configuration (FreeBSD)](#52-database-engine-installation-and-configuration-freebsd)
@@ -176,7 +176,7 @@ See the [post-installation] section for post-installation matters.
 
 ## 4. Installation on Debian and Ubuntu
 
-### 4.1 Install Zonemaster::Backend and related dependencies (Debian and Ubuntu)
+### 4.1 Install Zonemaster::Backend and related dependencies (Debian/Ubuntu)
 
 > **Note:** Zonemaster::LDNS and Zonemaster::Engine are not listed here as they
 > are dealt with in the [prerequisites](#prerequisites) section.
@@ -244,7 +244,7 @@ sudo install -v -m 755 ./tmpfiles.conf /usr/lib/tmpfiles.d/zonemaster.conf
 > `/etc/init.d/zm-backend.sh` (script from previous version of Zonemaster-Backend).
 
 
-### 4.2 Database engine installation and configuration (Debian and Ubuntu)
+### 4.2 Database engine installation and configuration (Debian/Ubuntu)
 
 Check the [declaration of prerequisites] to make sure your preferred combination
 of operating system version and database engine version is supported.
@@ -258,7 +258,7 @@ If you keep the database, skip the initialization of the Zonemaster database,
 but if you have removed the old Zonemaster database, then do the initialization.
 
 
-#### 4.2.1 Instructions for SQLite (Debian and Ubuntu)
+#### 4.2.1 Instructions for SQLite (Debian/Ubuntu)
 
 > **Note:** Zonemaster with SQLite is not meant for an installation with heavy
 > load.
@@ -286,13 +286,13 @@ sudo chown zonemaster:zonemaster /var/lib/zonemaster/db.sqlite
 > **Note:** See the [backend configuration] documentation for details.
 
 
-#### 4.2.2 Instructions for other engines (Debian and Ubuntu)
+#### 4.2.2 Instructions for other engines (Debian/Ubuntu)
 
 See appendices for [MariaDB][MariaDB instructions for Debian] and
 [PostgreSQL][PostgreSQL instructions for Debian].
 
 
-### 4.3 Service configuration and startup (Debian and Ubuntu)
+### 4.3 Service configuration and startup (Debian/Ubuntu)
 
 Make sure our tmpfiles configuration takes effect:
 
@@ -310,7 +310,7 @@ sudo systemctl start zm-testagent
 ```
 
 
-### 4.4 Post-installation (Debian and Ubuntu)
+### 4.4 Post-installation (Debian/Ubuntu)
 
 See the [post-installation] section for post-installation matters.
 
@@ -432,12 +432,6 @@ service zm_testagent start
 To check the running daemons run:
 
 ```sh
-service mysql-server status      # If mysql-server is installed
-```
-```sh
-service postgresql status        # If postgresql is installed
-```
-```sh
 service zm_rpcapi status
 service zm_testagent status
 ```
@@ -479,16 +473,16 @@ For SQLite database upgrading is not needed as of now.
 
 
 
-# Appendices
+## Appendices
 
 
-## A. Installation with MariaDB
+### A. Installation with MariaDB
 
-* [CentOS](#a1-mariadb-installation-for-centos)
-* [Debian/Ubuntu](#a2-mariadb-installation-for-debian-and-ubuntu)
-* [FreeBSD](#a3-mysql-installation-for-freebsd)
+* [CentOS](#a1-mariadb-installation-on-centos)
+* [Debian/Ubuntu](#a2-mariadb-installation-on-debian-and-ubuntu)
+* [FreeBSD](#a3-mysql-installation-on-freebsd)
 
-### A.1. MariaDB installation for CentOS
+#### A.1. MariaDB installation on CentOS
 
 Configure Zonemaster::Backend to use the correct database engine:
 
@@ -517,7 +511,7 @@ sudo mysql < $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backe
 > file). This user has just enough permissions to run the backend software.
 
 
-### A.2. MariaDB installation for Debian and Ubuntu
+#### A.2. MariaDB installation on Debian and Ubuntu
 
 Install the database engine and its dependencies:
 
@@ -544,7 +538,7 @@ sudo mysql < $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backe
 > file). This user has just enough permissions to run the backend software.
 
 
-### A.3. MySQL installation for FreeBSD
+#### A.3. MySQL installation on FreeBSD
 
 > MySQL is used on FreeBSD
 
@@ -602,14 +596,14 @@ mysql -u root -p < ./initial-mysql.sql
 > file). This user has just enough permissions to run the backend software.
 
 
-## B. Installation with PostgreSQL
+### B. Installation with PostgreSQL
 
-* [CentOS](#b1-postgresql-installation-for-centos)
-* [Debian/Ubuntu](#b2-postgresql-installation-for-debian-and-ubuntu)
-* [FreeBSD](#b3-postgresql-installation-for-freebsd)
+* [CentOS](#b1-postgresql-installation-on-centos)
+* [Debian/Ubuntu](#b2-postgresql-installation-on-debian-and-ubuntu)
+* [FreeBSD](#b3-postgresql-installation-on-freebsd)
 
 
-### B.1. PostgreSQL installation for CentOS
+#### B.1. PostgreSQL installation on CentOS
 
 Configure Zonemaster::Backend to use the correct database engine:
 
@@ -653,7 +647,7 @@ sudo -u postgres psql -f $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zone
 > This user has just enough permissions to run the backend software.
 
 
-### B.2. PostgreSQL installation for Debian and Ubuntu
+#### B.2. PostgreSQL installation on Debian and Ubuntu
 
 Configure Zonemaster::Backend to use the correct database engine:
 
@@ -680,7 +674,7 @@ sudo -u postgres psql -f $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zone
 > This user has just enough permissions to run the backend software.
 
 
-### B.3. PostgreSQL installation for FreeBSD
+#### B.3. PostgreSQL installation on FreeBSD
 
 Configure Zonemaster::Backend to use the correct database engine:
 
@@ -706,7 +700,7 @@ psql -U postgres -f ./initial-postgres.sql
 ```
 
 
-## C. Cleaning up the database
+### C. Cleaning up the database
 
 If, at some point, you want to delete all traces of Zonemaster in the database,
 you can run the file `cleanup-mysql.sql` or file `cleanup-postgres.sql`
@@ -714,21 +708,21 @@ as a database administrator. Commands
 for locating and running the file are below. It removes the user and drops the
 database (obviously taking all data with it).
 
-### C.1. MySQL
+#### C.1. MySQL
 
 ```sh
 cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
 mysql --user=root --password < ./cleanup-mysql.sql
 ```
 
-### C.2. PostgreSQL
+#### C.2. PostgreSQL
 
 ```sh
 cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
 sudo -u postgres psql -f ./cleanup-postgres.sql # MUST BE VERIFIED!
 ```
 
-### C.3. SQLite
+#### C.3. SQLite
 
 Remove the database file and recreate it following the installation instructions above.
 

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -2,7 +2,7 @@
 # https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md
 
 [DB]
-engine            = MySQL
+engine            = SQLite
 polling_interval  = 0.5
 
 [MYSQL]


### PR DESCRIPTION
## Purpose

Try to remove some overhead in the installation process by moving the parts on installing MariaDB/MySQL and PostgreSQL engines to the end of the document.

## Context

N/A

## Changes

* Remove the Ubuntu section, merge it with the Debian section

* Update the "doc/Installation.md" with a new "Appendices" section.

* Move all references to MariaDB/MySQL or PostgreSQL to the appendices.

* Move the cleaning instructions to an appendix.

* Update the `backend_config.ini` file to use SQLite database engine by default

## How to test this PR

N/A (documentation only).
