### PR TITLE
fix shared db handler

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -31,6 +31,30 @@ requires qw(
   get_relative_start_time
 );
 
+has 'data_source_name' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has 'user' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has 'password' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has 'dbhandle' => (
+    is       => 'rw',
+    isa      => 'DBI::db',
+    required => 1,
+);
+
 =head2 get_db_class
 
 Get the database adapter class for the given database type.
@@ -48,6 +72,22 @@ sub get_db_class {
     $db_class->import();
 
     return $db_class;
+}
+
+sub dbh {
+    my ( $self ) = @_;
+
+    if ( !$self->dbhandle->ping ) {
+        my $dbh = $self->_new_dbh(    #
+            $self->data_source_name,
+            $self->user,
+            $self->password,
+        );
+
+        $self->dbhandle( $dbh );
+    }
+
+    return $self->dbhandle;
 }
 
 sub user_exists {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -14,30 +14,6 @@ use Zonemaster::Backend::Errors;
 
 with 'Zonemaster::Backend::DB';
 
-has 'data_source_name' => (
-    is       => 'ro',
-    isa      => 'Str',
-    required => 1,
-);
-
-has 'user' => (
-    is       => 'ro',
-    isa      => 'Str',
-    required => 1,
-);
-
-has 'password' => (
-    is       => 'ro',
-    isa      => 'Str',
-    required => 1,
-);
-
-has 'dbhandle' => (
-    is       => 'rw',
-    isa      => 'DBI::db',
-    required => 1,
-);
-
 =head1 CLASS METHODS
 
 =head2 from_config
@@ -79,21 +55,6 @@ sub from_config {
     );
 }
 
-sub dbh {
-    my ( $self ) = @_;
-
-    if ( !$self->dbhandle->ping ) {
-        my $dbh = $self->_new_dbh(    #
-            $self->data_source_name,
-            $self->user,
-            $self->password,
-        );
-
-        $self->dbhandle( $dbh );
-    }
-
-    return $self->dbhandle;
-}
 
 sub create_db {
     my ( $self ) = @_;

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -14,30 +14,6 @@ use Zonemaster::Backend::Errors;
 
 with 'Zonemaster::Backend::DB';
 
-has 'data_source_name' => (
-    is       => 'ro',
-    isa      => 'Str',
-    required => 1,
-);
-
-has 'user' => (
-    is       => 'ro',
-    isa      => 'Str',
-    required => 1,
-);
-
-has 'password' => (
-    is       => 'ro',
-    isa      => 'Str',
-    required => 1,
-);
-
-has 'dbhandle' => (
-    is       => 'rw',
-    isa      => 'DBI::db',
-    required => 1,
-);
-
 =head1 CLASS METHODS
 
 =head2 from_config
@@ -73,22 +49,6 @@ sub from_config {
             dbhandle         => $dbh,
         }
     );
-}
-
-sub dbh {
-    my ( $self ) = @_;
-
-    if ( !$self->dbhandle->ping ) {
-        my $dbh = $self->_new_dbh(    #
-            $self->data_source_name,
-            $self->user,
-            $self->password,
-        );
-
-        $self->dbhandle( $dbh );
-    }
-
-    return $self->dbhandle;
 }
 
 sub create_db {

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -46,7 +46,7 @@ sub from_config {
 
 sub DEMOLISH {
     my ( $self ) = @_;
-    $self->dbh->disconnect() if $self->dbh;
+    $self->dbh->disconnect() if defined $self->dbhandle && $self->dbhandle->ping;
 }
 
 sub create_db {

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -15,11 +15,6 @@ use Zonemaster::Backend::Errors;
 
 with 'Zonemaster::Backend::DB';
 
-has 'dbh' => (
-    is  => 'rw',
-    isa => 'DBI::db',
-);
-
 =head1 CLASS METHODS
 
 =head2 from_config
@@ -41,7 +36,10 @@ sub from_config {
 
     return $class->new(
         {
-            dbh => $dbh,
+            data_source_name => $data_source_name,
+            user             => '',
+            password         => '',
+            dbhandle         => $dbh,
         }
     );
 }

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -132,6 +132,8 @@ sub main {
     local $SIG{TERM} = $catch_sigterm;
 
     my $agent = Zonemaster::Backend::TestAgent->new( { config => $self->config } );
+    # Disconnect from database in parent to avoid sharing the connection between children
+    $agent->{_db}->dbh->disconnect;
 
     while ( !$caught_sigterm ) {
         $self->pm->reap_finished_children();    # Reaps terminated child processes


### PR DESCRIPTION
## Purpose

Do not reuse initial database connection in child processes.

## Context

After commit https://github.com/zonemaster/zonemaster-backend/commit/dc5b1cdad08fd19dfc0985285f6e0ddaa79508c4 the `TestAgent` class creates a database handler on the parent process of the test agent (as opposed to before when it was lazy-loaded in the child). This handler will then be reuse by the child processes. While it seems that some environment the database object will reconnect to the database because of a failing ping result, in my environment the ping was working correctly. This caused all child processes to share a unique database handler which lead to a number of concurrency error.

Example of such error include (for postgres):

```
2021-09-07T10:46:17Z [84688] WARNING - DBD::Pg::db do warning:  at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB/PostgreSQL.pm line 131.
2021-09-07T10:46:17Z [84688] ERROR - Test died: fd7d3a2187b0bb86: DBD::Pg::db selectrow_array failed: no statement executing at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB/PostgreSQL.pm line 138.

2021-09-07T10:46:24Z [84713] WARNING - DBD::Pg::db do failed: synchronisation perdue avec le serveur : a re�u le type de message � 1 �, longueur 909194544 at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB/PostgreSQL.pm line 131.
2021-09-07T10:46:24Z [84713] ERROR - Test died: bb1d7cec5adea48d: DBD::Pg::db do failed: synchronisation perdue avec le serveur : a re�u le type de message � 1 �,
longueur 909194544 at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB/PostgreSQL.pm line 131.

2021-09-07T10:57:00Z [86056] ERROR - Test died: 169890693b1d69ea: DBD::Pg::db selectall_hashref failed: Field 'hash_id' does not exist (not one of ) at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB/PostgreSQL.pm line 231.

2021-09-07T10:56:57Z [86054] WARNING - DBD::Pg::db selectrow_array warning:  at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB/PostgreSQL.pm line 212.
2021-09-07T10:56:57Z [86054] ERROR - Test died: 7129c73974a3361a: malformed JSON string, neither array, object, number, string or atom, at character offset 0 (before "(end of string)") at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB/PostgreSQL.pm line 213.

2021-09-07T10:56:43Z [85996] ERROR - Test died: 61899d176109b9c3: Can't use string ("1") as a HASH ref while "strict refs" in use at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/TestAgent.pm line 83.
```

## Changes

This PR simply close the connection to the database for the database object of the TestAgent thus forcing the a lazy reconnection in the child processes.

## How to test this PR

* Configure backend to use postgresql or mysql
* Create a batch job with  enough domains to test

If there is no error then it is good (in some cases it works correctly without this patch, I haven't found why)

