### PR TITLE
Add a IF NOT EXISTS clause for all table/index/trigger creations

### DIFF
--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -137,21 +137,37 @@ sub create_db {
         '
     );
 
-    $dbh->do(
-        'CREATE INDEX test_results__hash_id ON test_results (hash_id)'
-    );
-    $dbh->do(
-        'CREATE INDEX test_results__params_deterministic_hash ON test_results (params_deterministic_hash)'
-    );
-    $dbh->do(
-        'CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)'
-    );
-    $dbh->do(
-        'CREATE INDEX test_results__progress ON test_results (progress)'
-    );
-    $dbh->do(
-        'CREATE INDEX test_results__domain_undelegated ON test_results (domain, undelegated)'
-    );
+    # Manually create the index if it does not exist
+    # the clause IF NOT EXISTS is not available for MySQL (used with FreeBSD)
+
+    # retrieve all indexes by key name
+    my $indexes = $dbh->selectall_hashref( 'SHOW INDEXES FROM test_results', 'Key_name' );
+
+    if ( not exists($indexes->{test_results__hash_id}) ) {
+        $dbh->do(
+            'CREATE INDEX test_results__hash_id ON test_results (hash_id)'
+        );
+    }
+    if ( not exists($indexes->{test_results__params_deterministic_hash}) ) {
+        $dbh->do(
+            'CREATE INDEX test_results__params_deterministic_hash ON test_results (params_deterministic_hash)'
+        );
+    }
+    if ( not exists($indexes->{test_results__batch_id_progress}) ) {
+        $dbh->do(
+            'CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)'
+        );
+    }
+    if ( not exists($indexes->{test_results__progress}) ) {
+        $dbh->do(
+            'CREATE INDEX test_results__progress ON test_results (progress)'
+        );
+    }
+    if ( not exists($indexes->{test_results__domain_undelegated}) ) {
+        $dbh->do(
+            'CREATE INDEX test_results__domain_undelegated ON test_results (domain, undelegated)'
+        );
+    }
 
 
     ####################################################################

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -104,7 +104,7 @@ sub create_db {
     # TEST RESULTS
     ####################################################################
     $dbh->do(
-        'CREATE TABLE test_results (
+        'CREATE TABLE IF NOT EXISTS test_results (
             id integer AUTO_INCREMENT PRIMARY KEY,
             hash_id VARCHAR(16) DEFAULT NULL,
             domain varchar(255) NOT NULL,
@@ -158,7 +158,7 @@ sub create_db {
     # BATCH JOBS
     ####################################################################
     $dbh->do(
-        'CREATE TABLE batch_jobs (
+        'CREATE TABLE IF NOT EXISTS batch_jobs (
             id integer AUTO_INCREMENT PRIMARY KEY,
             username character varying(50) NOT NULL,
             creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
@@ -171,7 +171,7 @@ sub create_db {
     # USERS
     ####################################################################
     $dbh->do(
-        'CREATE TABLE users (
+        'CREATE TABLE IF NOT EXISTS users (
             id integer AUTO_INCREMENT primary key,
             username varchar(128),
             api_key varchar(512),

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -122,7 +122,7 @@ sub create_db {
             nb_retries integer NOT NULL DEFAULT 0
         ) ENGINE=InnoDB
         '
-    );
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'test_results' table", data => $dbh->errstr() );
 
 
     # Manually create the trigger if it does not exist
@@ -188,7 +188,7 @@ sub create_db {
             creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
         ) ENGINE=InnoDB;
         '
-    );
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'batch_jobs' table", data => $dbh->errstr() );
 
 
     ####################################################################
@@ -202,7 +202,7 @@ sub create_db {
             user_info blob DEFAULT NULL
         ) ENGINE=InnoDB;
         '
-    );
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'users' table", data => $dbh->errstr() );
 }
 
 sub user_exists_in_db {

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -117,7 +117,7 @@ sub create_db {
                 nb_retries integer NOT NULL DEFAULT 0
             )
         '
-    );
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'test_results' table", data => $dbh->errstr() );
 
     # Manually create the index if it does not exist
     # the clause IF NOT EXISTS is not available for PostgreSQL < 9.5
@@ -161,7 +161,7 @@ sub create_db {
                 creation_time timestamp without time zone DEFAULT NOW() NOT NULL
             )
         '
-    );
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'batch_jobs' table", data => $dbh->errstr() );
 
 
     ####################################################################
@@ -173,7 +173,7 @@ sub create_db {
                 user_info json
             )
         '
-    );
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'users' table", data => $dbh->errstr() );
 
 }
 

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -100,7 +100,7 @@ sub create_db {
     # TEST RESULTS
     ####################################################################
     $dbh->do(
-        'CREATE TABLE test_results (
+        'CREATE TABLE IF NOT EXISTS test_results (
                 id serial PRIMARY KEY,
                 hash_id VARCHAR(16) DEFAULT substring(md5(random()::text || clock_timestamp()::text) from 1 for 16) NOT NULL,
                 batch_id integer,
@@ -140,7 +140,7 @@ sub create_db {
     # BATCH JOBS
     ####################################################################
     $dbh->do(
-        'CREATE TABLE batch_jobs (
+        'CREATE TABLE IF NOT EXISTS batch_jobs (
                 id serial PRIMARY KEY,
                 username varchar(50) NOT NULL,
                 creation_time timestamp without time zone DEFAULT NOW() NOT NULL
@@ -153,7 +153,7 @@ sub create_db {
     # USERS
     ####################################################################
     $dbh->do(
-        'CREATE TABLE users (
+        'CREATE TABLE IF NOT EXISTS users (
                 id serial PRIMARY KEY,
                 user_info json
             )

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -119,21 +119,36 @@ sub create_db {
         '
     );
 
-    $dbh->do(
-        'CREATE INDEX test_results__hash_id ON test_results (hash_id)'
-    );
-    $dbh->do(
-        'CREATE INDEX test_results__params_deterministic_hash ON test_results (params_deterministic_hash)'
-    );
-    $dbh->do(
-        'CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)'
-    );
-    $dbh->do(
-        'CREATE INDEX test_results__progress ON test_results (progress)'
-    );
-    $dbh->do(
-        "CREATE INDEX test_results__domain_undelegated ON test_results ((params->>'domain'), (params->>'undelegated'))"
-    );
+    # Manually create the index if it does not exist
+    # the clause IF NOT EXISTS is not available for PostgreSQL < 9.5
+
+    # retrieve all indexes by key name
+    my $indexes = $dbh->selectall_hashref( "SELECT indexname FROM pg_indexes WHERE tablename = 'test_results'", 'indexname' );
+    if ( not exists($indexes->{test_results__hash_id}) ) {
+        $dbh->do(
+            'CREATE INDEX test_results__hash_id ON test_results (hash_id)'
+        );
+    }
+    if ( not exists($indexes->{test_results__params_deterministic_hash}) ) {
+        $dbh->do(
+            'CREATE INDEX test_results__params_deterministic_hash ON test_results (params_deterministic_hash)'
+        );
+    }
+    if ( not exists($indexes->{test_results__batch_id_progress}) ) {
+        $dbh->do(
+            'CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)'
+        );
+    }
+    if ( not exists($indexes->{test_results__progress}) ) {
+        $dbh->do(
+            'CREATE INDEX test_results__progress ON test_results (progress)'
+        );
+    }
+    if ( not exists($indexes->{test_results__domain_undelegated}) ) {
+        $dbh->do(
+            "CREATE INDEX test_results__domain_undelegated ON test_results ((params->>'domain'), (params->>'undelegated'))"
+        );
+    }
 
 
     ####################################################################

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -79,19 +79,19 @@ sub create_db {
     ) or die "SQLite Fatal error: " . $self->dbh->errstr() . "\n";
 
     $self->dbh->do(
-        'CREATE INDEX test_results__hash_id ON test_results (hash_id)'
+        'CREATE INDEX IF NOT EXISTS test_results__hash_id ON test_results (hash_id)'
     );
     $self->dbh->do(
-        'CREATE INDEX test_results__fingerprint ON test_results (params_deterministic_hash)'
+        'CREATE INDEX IF NOT EXISTS test_results__fingerprint ON test_results (params_deterministic_hash)'
     );
     $self->dbh->do(
-        'CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)'
+        'CREATE INDEX IF NOT EXISTS test_results__batch_id_progress ON test_results (batch_id, progress)'
     );
     $self->dbh->do(
-        'CREATE INDEX test_results__progress ON test_results (progress)'
+        'CREATE INDEX IF NOT EXISTS test_results__progress ON test_results (progress)'
     );
     $self->dbh->do(
-        'CREATE INDEX test_results__domain_undelegated ON test_results (domain, undelegated)'
+        'CREATE INDEX IF NOT EXISTS test_results__domain_undelegated ON test_results (domain, undelegated)'
     );
 
 

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -54,10 +54,12 @@ sub DEMOLISH {
 sub create_db {
     my ( $self ) = @_;
 
+    my $dbh = $self->dbh;
+
     ####################################################################
     # TEST RESULTS
     ####################################################################
-    $self->dbh->do(
+    $dbh->do(
         'CREATE TABLE IF NOT EXISTS test_results (
                  id integer PRIMARY KEY AUTOINCREMENT,
                  hash_id VARCHAR(16) DEFAULT NULL,
@@ -76,21 +78,21 @@ sub create_db {
                  nb_retries integer NOT NULL DEFAULT 0
            )
         '
-    ) or die "SQLite Fatal error: " . $self->dbh->errstr() . "\n";
+    ) or die "SQLite Fatal error: " . $dbh->errstr() . "\n";
 
-    $self->dbh->do(
+    $dbh->do(
         'CREATE INDEX IF NOT EXISTS test_results__hash_id ON test_results (hash_id)'
     );
-    $self->dbh->do(
+    $dbh->do(
         'CREATE INDEX IF NOT EXISTS test_results__fingerprint ON test_results (params_deterministic_hash)'
     );
-    $self->dbh->do(
+    $dbh->do(
         'CREATE INDEX IF NOT EXISTS test_results__batch_id_progress ON test_results (batch_id, progress)'
     );
-    $self->dbh->do(
+    $dbh->do(
         'CREATE INDEX IF NOT EXISTS test_results__progress ON test_results (progress)'
     );
-    $self->dbh->do(
+    $dbh->do(
         'CREATE INDEX IF NOT EXISTS test_results__domain_undelegated ON test_results (domain, undelegated)'
     );
 
@@ -98,20 +100,20 @@ sub create_db {
     ####################################################################
     # BATCH JOBS
     ####################################################################
-    $self->dbh->do(
+    $dbh->do(
         'CREATE TABLE IF NOT EXISTS batch_jobs (
                  id integer PRIMARY KEY,
                  username character varying(50) NOT NULL,
                  creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
            )
         '
-    ) or die "SQLite Fatal error: " . $self->dbh->errstr() . "\n";
+    ) or die "SQLite Fatal error: " . $dbh->errstr() . "\n";
 
 
     ####################################################################
     # USERS
     ####################################################################
-    $self->dbh->do(
+    $dbh->do(
         'CREATE TABLE IF NOT EXISTS users (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 username varchar(128),
@@ -119,7 +121,7 @@ sub create_db {
                 user_info json DEFAULT NULL
            )
         '
-    ) or die "SQLite Fatal error: " . $self->dbh->errstr() . "\n";
+    ) or die "SQLite Fatal error: " . $dbh->errstr() . "\n";
 
     return 1;
 }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -78,7 +78,7 @@ sub create_db {
                  nb_retries integer NOT NULL DEFAULT 0
            )
         '
-    ) or die "SQLite Fatal error: " . $dbh->errstr() . "\n";
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'test_results' table", data => $dbh->errstr() );
 
     $dbh->do(
         'CREATE INDEX IF NOT EXISTS test_results__hash_id ON test_results (hash_id)'
@@ -107,7 +107,7 @@ sub create_db {
                  creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
            )
         '
-    ) or die "SQLite Fatal error: " . $dbh->errstr() . "\n";
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'batch_jobs' table", data => $dbh->errstr() );
 
 
     ####################################################################
@@ -121,7 +121,7 @@ sub create_db {
                 user_info json DEFAULT NULL
            )
         '
-    ) or die "SQLite Fatal error: " . $dbh->errstr() . "\n";
+    ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'users' table", data => $dbh->errstr() );
 
     return 1;
 }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -58,7 +58,7 @@ sub create_db {
     # TEST RESULTS
     ####################################################################
     $self->dbh->do(
-        'CREATE TABLE test_results (
+        'CREATE TABLE IF NOT EXISTS test_results (
                  id integer PRIMARY KEY AUTOINCREMENT,
                  hash_id VARCHAR(16) DEFAULT NULL,
                  domain VARCHAR(255) NOT NULL,
@@ -99,7 +99,7 @@ sub create_db {
     # BATCH JOBS
     ####################################################################
     $self->dbh->do(
-        'CREATE TABLE batch_jobs (
+        'CREATE TABLE IF NOT EXISTS batch_jobs (
                  id integer PRIMARY KEY,
                  username character varying(50) NOT NULL,
                  creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
@@ -112,7 +112,7 @@ sub create_db {
     # USERS
     ####################################################################
     $self->dbh->do(
-        'CREATE TABLE users (
+        'CREATE TABLE IF NOT EXISTS users (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 username varchar(128),
                 api_key varchar(512),


### PR DESCRIPTION
## Purpose

Allow running the `share/create_db.pl` script several times without raising any error or warning. This is a step toward automatically creating the database on startup.

## Context

This is part 2/11 from #841

## Changes

Always check that a table, index or trigger does not exists before creation. For some cases, the clause `IF NOT EXISTS` is sufficient, for others, we need workaround because it is not present in all supported versions of the database engine.

## How to test this PR

Calling several times the `share/create_db.pl` script should not raise any issue.
