### PR TITLE
Remove the retry feature

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -32,7 +32,6 @@
 * [PUBLIC PROFILES and PRIVATE PROFILES sections](#PUBLIC-PROFILES-and-PRIVATE-PROFILES-sections)
 * [ZONEMASTER section](#ZONEMASTER-section)
   * [max_zonemaster_execution_time](#max_zonemaster_execution_time)
-  * [maximal_number_of_retries](#maximal_number_of_retries)
   * [number_of_processes_for_frontend_testing](#number_of_processes_for_frontend_testing)
   * [number_of_processes_for_batch_testing](#number_of_processes_for_batch_testing)
   * [lock_on_queue](#lock_on_queue)
@@ -347,7 +346,6 @@ The ZONEMASTER section has several keys :
 * number_of_processes_for_frontend_testing
 * number_of_processes_for_batch_testing
 * lock_on_queue
-* maximal_number_of_retries
 * age_reuse_previous_test
 
 ### max_zonemaster_execution_time
@@ -356,17 +354,6 @@ A strictly positive integer. Max length 5 digits.
 
 Time in seconds before reporting an unfinished test as failed.
 Default value: `600`.
-
-### maximal_number_of_retries
-
-A non-negative integer. Max length 5 digits.
-
-Number of time a test is allowed to be run again if unfinished after
-`max_zonemaster_execution_time`.
-Default value: `0`.
-
-This option is experimental and all edge cases are not fully tested.
-Do not use it (keep the default value "0"), or use it with care.
 
 ### number_of_processes_for_frontend_testing
 

--- a/docs/internal-documentation/maintenance/Garbage-Collection-Testing.md
+++ b/docs/internal-documentation/maintenance/Garbage-Collection-Testing.md
@@ -5,31 +5,8 @@ The purpose of this instruction is to serve as a notice for manual testing of th
 
 ## Testing the unfinished tests garbage collection feature
 
-1. Ensure that the database has the required additionnal columns for this feature:
-     ```
-     SELECT nb_retries FROM test_results LIMIT 0;
-     ```
-     Should return:
 
-     ```
-     nb_retries 
-     ------------
-     (0 rows)
-     ```
-     _Remark: for MySQL use `SHOW COLUMNS FROM test_results` and ensure the `nb_retries` column is present in the list._
-
-2. Check that your `/etc/zonemaster/backend_config.ini` (or, in FreeBSD, `/usr/local/etc/zonemaster/backend_config.ini`) has the proper parameter set
-
-     Either disabled:
-     ```
-     #maximal_number_of_retries=3
-     ```
-     or set to 0:
-     ```
-     maximal_number_of_retries=0
-     ```
-
-3. Start a test and wait for it to be finished
+1. Start a test and wait for it to be finished
 
      ```
      SELECT hash_id, progress FROM test_results LIMIT 1;
@@ -43,12 +20,12 @@ The purpose of this instruction is to serve as a notice for manual testing of th
      (1 row)
      ```
 
-4. Simulate a crashed test
+2. Simulate a crashed test
      ```
      UPDATE test_results SET progress = 50, test_start_time = '2020-01-01' WHERE hash_id = '3f7a604683efaf93';
      ```
 
-5. Check that the backend finishes the test with a result stating it was unfinished
+3. Check that the backend finishes the test with a result stating it was unfinished
 
      ```
      SELECT hash_id, progress FROM test_results WHERE hash_id = '3f7a604683efaf93';
@@ -61,7 +38,7 @@ The purpose of this instruction is to serve as a notice for manual testing of th
      (1 row)
      ```
 
-6. Ensure the test result contains the backend generated critical message:
+4. Ensure the test result contains the backend generated critical message:
      ```
      {"tag":"UNABLE_TO_FINISH_TEST","level":"CRITICAL","timestamp":"300","module":"BACKEND_TEST_AGENT"}
      ```
@@ -80,50 +57,3 @@ The purpose of this instruction is to serve as a notice for manual testing of th
 
      ```
 
-## Testing the unfinished tests garbage collection feature with a number of retries set to allow finishing tests without a critical error
-
-1. Set the maximal_number_of_retries parameter to a value greater than 0 in the backend_config.ini config file 
-     ```
-     maximal_number_of_retries=1
-     ```
-
-2. Restart the test agent in order for the parameter to be taken into account
-     ```
-     zonemaster_backend_testagent restart
-     ```
-     _Remark: Update accordingly to the OS where the tests are done (ex use init script for FreeBSD, etc.)_
-
-3. Simulate a crashed test
-     ```
-     UPDATE test_results SET progress = 50, test_start_time = '2020-01-01' WHERE hash_id = '3f7a604683efaf93';
-     ```
-
-4. Check that the backend finishes the test WITHOUT a result stating it was unfinished
-
-     ```
-     SELECT hash_id, progress FROM test_results WHERE hash_id = '3f7a604683efaf93';
-     ```
-     Should return a finished result:
-     ```
-          hash_id      | progress 
-     ------------------+----------
-     3f7a604683efaf93 |      100
-     (1 row)
-     ```
-
-5. Ensure the test result does NOT contain the backend generated critical message:
-     ```
-     {"tag":"UNABLE_TO_FINISH_TEST","level":"CRITICAL","timestamp":"300","module":"BACKEND_TEST_AGENT"}
-     ```
-
-     ```
-     SELECT hash_id, progress FROM test_results WHERE hash_id = '3f7a604683efaf93' AND results::text like '%UNABLE_TO_FINISH_TEST%';
-     ```
-     _Remark: for MySQL queries remove the `::text` from all queries_
-     Should return:
-     ```
-     hash_id | progress 
-     ---------+----------
-     (0 rows)
-
-     ```

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -140,7 +140,6 @@ sub parse {
     $obj->_set_MYSQL_port( '3306' );
     $obj->_set_POSTGRESQL_port( '5432' );
     $obj->_set_ZONEMASTER_max_zonemaster_execution_time( '600' );
-    $obj->_set_ZONEMASTER_maximal_number_of_retries( '0' );
     $obj->_set_ZONEMASTER_number_of_processes_for_frontend_testing( '20' );
     $obj->_set_ZONEMASTER_number_of_processes_for_batch_testing( '20' );
     $obj->_set_ZONEMASTER_lock_on_queue( '0' );
@@ -261,9 +260,6 @@ sub parse {
     }
     if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'max_zonemaster_execution_time' ) ) ) {
         $obj->_set_ZONEMASTER_max_zonemaster_execution_time( $value );
-    }
-    if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'maximal_number_of_retries' ) ) ) {
-        $obj->_set_ZONEMASTER_maximal_number_of_retries( $value );
     }
     if ( defined( my $value = $get_and_clear->( 'ZONEMASTER', 'number_of_processes_for_frontend_testing' ) ) ) {
         $obj->_set_ZONEMASTER_number_of_processes_for_frontend_testing( $value );
@@ -558,14 +554,6 @@ L<ZONEMASTER.lock_on_queue|https://github.com/zonemaster/zonemaster-backend/blob
 Returns a number.
 
 
-=head2 ZONEMASTER_maximal_number_of_retries
-
-Get the value of
-L<ZONEMASTER.maximal_number_of_retries|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#maximal_number_of_retries>.
-
-Returns a number.
-
-
 =head2 ZONEMASTER_age_reuse_previous_test
 
 Get the value of
@@ -610,7 +598,6 @@ sub LANGUAGE_locale                                     { return %{ $_[0]->{_LAN
 sub PUBLIC_PROFILES                                     { return %{ $_[0]->{_public_profiles} }; }
 sub PRIVATE_PROFILES                                    { return %{ $_[0]->{_private_profiles} }; }
 sub ZONEMASTER_max_zonemaster_execution_time            { return $_[0]->{_ZONEMASTER_max_zonemaster_execution_time}; }
-sub ZONEMASTER_maximal_number_of_retries                { return $_[0]->{_ZONEMASTER_maximal_number_of_retries}; }
 sub ZONEMASTER_lock_on_queue                            { return $_[0]->{_ZONEMASTER_lock_on_queue}; }
 sub ZONEMASTER_number_of_processes_for_frontend_testing { return $_[0]->{_ZONEMASTER_number_of_processes_for_frontend_testing}; }
 sub ZONEMASTER_number_of_processes_for_batch_testing    { return $_[0]->{_ZONEMASTER_number_of_processes_for_batch_testing}; }
@@ -633,7 +620,6 @@ UNITCHECK {
     _create_setter( '_set_POSTGRESQL_database',                                 '_POSTGRESQL_database',                                 \&untaint_postgresql_ident );
     _create_setter( '_set_SQLITE_database_file',                                '_SQLITE_database_file',                                \&untaint_abs_path );
     _create_setter( '_set_ZONEMASTER_max_zonemaster_execution_time',            '_ZONEMASTER_max_zonemaster_execution_time',            \&untaint_strictly_positive_int );
-    _create_setter( '_set_ZONEMASTER_maximal_number_of_retries',                '_ZONEMASTER_maximal_number_of_retries',                \&untaint_non_negative_int );
     _create_setter( '_set_ZONEMASTER_lock_on_queue',                            '_ZONEMASTER_lock_on_queue',                            \&untaint_non_negative_int );
     _create_setter( '_set_ZONEMASTER_number_of_processes_for_frontend_testing', '_ZONEMASTER_number_of_processes_for_frontend_testing', \&untaint_strictly_positive_int );
     _create_setter( '_set_ZONEMASTER_number_of_processes_for_batch_testing',    '_ZONEMASTER_number_of_processes_for_batch_testing',    \&untaint_non_negative_int );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -330,35 +330,31 @@ sub add_batch_job {
 }
 
 sub select_unfinished_tests {
-    my ( $self, $queue_label, $test_run_timeout, $test_run_max_retries ) = @_;
+    my ( $self, $queue_label, $test_run_timeout ) = @_;
 
     if ( $queue_label ) {
         my $sth = $self->dbh->prepare( "
-            SELECT hash_id, results, nb_retries
+            SELECT hash_id, results
             FROM test_results
             WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ? SECOND)
-            AND nb_retries <= ?
             AND progress > 0
             AND progress < 100
             AND queue = ?" );
         $sth->execute(    #
             $test_run_timeout,
-            $test_run_max_retries,
             $queue_label,
         );
         return $sth;
     }
     else {
         my $sth = $self->dbh->prepare( "
-            SELECT hash_id, results, nb_retries
+            SELECT hash_id, results
             FROM test_results
             WHERE test_start_time < DATE_SUB(NOW(), INTERVAL ? SECOND)
-            AND nb_retries <= ?
             AND progress > 0
             AND progress < 100" );
         $sth->execute(    #
             $test_run_timeout,
-            $test_run_max_retries,
         );
         return $sth;
     }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -318,35 +318,31 @@ sub add_batch_job {
 }
 
 sub select_unfinished_tests {
-    my ( $self, $queue_label, $test_run_timeout, $test_run_max_retries ) = @_;
+    my ( $self, $queue_label, $test_run_timeout ) = @_;
 
     if ( $queue_label ) {
         my $sth = $self->dbh->prepare( "
-            SELECT hash_id, results, nb_retries
+            SELECT hash_id, results
             FROM test_results
             WHERE test_start_time < NOW() - ?::interval
-            AND nb_retries <= ?
             AND progress > 0
             AND progress < 100
             AND queue = ?" );
         $sth->execute(    #
             sprintf( "%d seconds", $test_run_timeout ),
-            $test_run_max_retries,
             $queue_label,
         );
         return $sth;
     }
     else {
         my $sth = $self->dbh->prepare( "
-            SELECT hash_id, results, nb_retries
+            SELECT hash_id, results
             FROM test_results
             WHERE test_start_time < NOW() - ?::interval
-            AND nb_retries <= ?
             AND progress > 0
             AND progress < 100" );
         $sth->execute(    #
             sprintf( "%d seconds", $test_run_timeout ),
-            $test_run_max_retries,
         );
         return $sth;
     }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -287,35 +287,31 @@ sub add_batch_job {
 }
 
 sub select_unfinished_tests {
-    my ( $self, $queue_label, $test_run_timeout, $test_run_max_retries ) = @_;
+    my ( $self, $queue_label, $test_run_timeout ) = @_;
 
     if ( $queue_label ) {
         my $sth = $self->dbh->prepare( "
-            SELECT hash_id, results, nb_retries
+            SELECT hash_id, results
             FROM test_results
             WHERE test_start_time < DATETIME('now', ?)
-            AND nb_retries <= ?
             AND progress > 0
             AND progress < 100
             AND queue = ?" );
         $sth->execute(    #
             sprintf( "-%d seconds", $test_run_timeout ),
-            $test_run_max_retries,
             $queue_label,
         );
         return $sth;
     }
     else {
         my $sth = $self->dbh->prepare( "
-            SELECT hash_id, results, nb_retries
+            SELECT hash_id, results
             FROM test_results
             WHERE test_start_time < DATETIME('now', ?)
-            AND nb_retries <= ?
             AND progress > 0
             AND progress < 100" );
         $sth->execute(    #
             sprintf( "-%d seconds", $test_run_timeout ),
-            $test_run_max_retries,
         );
         return $sth;
     }

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -143,7 +143,6 @@ sub main {
         $self->db->process_unfinished_tests(
             $self->config->ZONEMASTER_lock_on_queue,
             $self->config->ZONEMASTER_max_zonemaster_execution_time,
-            $self->config->ZONEMASTER_maximal_number_of_retries,
         );
         if ( $id ) {
             $log->info( "Test found: $id" );
@@ -153,7 +152,7 @@ sub main {
                 if ( $@ ) {
                     chomp $@;
                     $log->error( "Test died: $id: $@" );
-                    $self->db->process_dead_test( $id, $self->config->ZONEMASTER_maximal_number_of_retries )
+                    $self->db->process_dead_test( $id )
                 }
                 else {
                     $log->info( "Test completed: $id" );

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -26,11 +26,6 @@ database_file = /var/lib/zonemaster/db.sqlite
 #number_of_processes_for_batch_testing    = 20
 #age_reuse_previous_test                  = 600
 
-# WARNING: The following option is experimental and all edge cases are not fully tested.
-# Do not use it (keep the default value "0"), or use it with care.
-#
-#maximal_number_of_retries=3
-
 [RPCAPI]
 
 # Uncomment to enable API method "add_api_user"

--- a/t/config.t
+++ b/t/config.t
@@ -56,7 +56,6 @@ subtest 'Everything but NoWarnings' => sub {
             number_of_processes_for_frontend_testing = 30
             number_of_processes_for_batch_testing    = 40
             lock_on_queue                            = 1
-            maximal_number_of_retries                = 2
             age_reuse_previous_test                  = 800
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
@@ -86,7 +85,6 @@ subtest 'Everything but NoWarnings' => sub {
           },
           'set: PRIVATE PROFILES';
         is $config->ZONEMASTER_max_zonemaster_execution_time,            1200, 'set: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->ZONEMASTER_maximal_number_of_retries,                2,    'set: ZONEMASTER.maximal_number_of_retries';
         is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 30,   'set: ZONEMASTER.number_of_processes_for_frontend_testing';
         is $config->ZONEMASTER_number_of_processes_for_batch_testing,    40,   'set: ZONEMASTER.number_of_processes_for_batch_testing';
         is $config->ZONEMASTER_lock_on_queue,                            1,    'set: ZONEMASTER.lock_on_queue';
@@ -109,7 +107,6 @@ subtest 'Everything but NoWarnings' => sub {
         eq_or_diff { $config->PUBLIC_PROFILES }, { default => undef }, 'default: PUBLIC_PROFILES';
         eq_or_diff { $config->PRIVATE_PROFILES }, {}, 'default: PRIVATE_PROFILES';
         is $config->ZONEMASTER_max_zonemaster_execution_time,            600, 'default: ZONEMASTER.max_zonemaster_execution_time';
-        is $config->ZONEMASTER_maximal_number_of_retries,                0,   'default: ZONEMASTER.maximal_number_of_retries';
         is $config->ZONEMASTER_number_of_processes_for_frontend_testing, 20,  'default: ZONEMASTER.number_of_processes_for_frontend_testing';
         is $config->ZONEMASTER_number_of_processes_for_batch_testing,    20,  'default: ZONEMASTER.number_of_processes_for_batch_testing';
         is $config->ZONEMASTER_lock_on_queue,                            0,   'default: ZONEMASTER.lock_on_queue';
@@ -415,18 +412,6 @@ subtest 'Everything but NoWarnings' => sub {
         Zonemaster::Backend::Config->parse( $text );
     }
     qr{ZONEMASTER\.max_zonemaster_execution_time.*0}, 'die: Invalid ZONEMASTER.max_zonemaster_execution_time value';
-
-    throws_ok {
-        my $text = q{
-            [DB]
-            engine = SQLite
-
-            [ZONEMASTER]
-            maximal_number_of_retries = -1
-        };
-        Zonemaster::Backend::Config->parse( $text );
-    }
-    qr{ZONEMASTER\.maximal_number_of_retries.*-1}, 'die: Invalid ZONEMASTER.maximal_number_of_retries value';
 
     throws_ok {
         my $text = q{


### PR DESCRIPTION
## Purpose

The retry feature that depends on the `maximal_number_of_retries` key is removed by this PR. In the normal case a removal of a feature should start with deprecation. In this case the feature is documented as "experimental". From `Configuration.md`:

> This option is experimental and all edge cases are not fully tested. Do not use it (keep the default value "0"), or use it with care.

From default `backend_config.ini`:

```
# WARNING: The following option is experimental and all edge cases are not fully tested.
# Do not use it (keep the default value "0"), or use it with care.
#
#maximal_number_of_retries=3
```

There are no clear use cases for the feature. Instead for setting retries to 1 (permit running twice) the `max_zonemaster_execution_time` could be doubled with similar result.

The purpose here is to remove complexity not needed.

## Changes

The following files have been updated:

* docs/Configuration.md
* docs/internal-documentation/maintenance/Garbage-Collection-Testing.md
* lib/Zonemaster/Backend/Config.pm
* lib/Zonemaster/Backend/DB.pm
* lib/Zonemaster/Backend/DB/MySQL.pm
* lib/Zonemaster/Backend/DB/PostgreSQL.pm
* lib/Zonemaster/Backend/DB/SQLite.pm
* script/zonemaster_backend_testagent
* share/backend_config.ini
* t/config.t

The databases has a column `nb_retries` that is not removed by this PR. It should be taken in a second step.

## How to test this PR

1. Set `maximal_number_of_retries = 1` in the configuration file, and the daemon should not start.
2. Run various test and nothing should break unless expected to brea,
3. Create timeout by following `Garbage-Collection-Testing.md` and it should work as expected
