### PR TITLE
Rename init files on FreeBSD

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -66,8 +66,8 @@ share/travis_postgresql_backend_config.ini
 share/travis_sqlite_backend_config.ini
 share/zm-rpcapi.lsb
 share/zm-testagent.lsb
-share/zm_rpcapi-bsd
-share/zm_testagent-bsd
+share/zm-rpcapi.bsd
+share/zm-testagent.bsd
 t/config.t
 t/db.t
 t/parameters_validation.t

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -361,8 +361,8 @@ install -v -m 755 -d /usr/local/etc/zonemaster
 install -v -m 640 -g zonemaster ./backend_config.ini /usr/local/etc/zonemaster/
 install -v -m 775 -g zonemaster -d /var/log/zonemaster
 install -v -m 775 -g zonemaster -d /var/run/zonemaster
-install -v -m 755 ./zm_rpcapi-bsd /usr/local/etc/rc.d/zm_rpcapi
-install -v -m 755 ./zm_testagent-bsd /usr/local/etc/rc.d/zm_testagent
+install -v -m 755 ./zm-rpcapi.bsd /usr/local/etc/rc.d/zm-rpcapi
+install -v -m 755 ./zm-testagent.bsd /usr/local/etc/rc.d/zm-testagent
 ```
 
 ### 5.2 Database engine installation (FreeBSD)
@@ -412,10 +412,10 @@ su -m zonemaster -c "`perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir(
 Enable services at startup and start service:
 
 ```sh
-sysrc zm_rpcapi_enable="YES"
-sysrc zm_testagent_enable="YES"
-service zm_rpcapi start
-service zm_testagent start
+sysrc zm-rpcapi_enable="YES"
+sysrc zm-testagent_enable="YES"
+service zm-rpcapi start
+service zm-testagent start
 ```
 
 ### 5.5 Post-installation (FreeBSD)
@@ -423,8 +423,8 @@ service zm_testagent start
 To check that the running daemons run:
 
 ```sh
-service zm_rpcapi status
-service zm_testagent status
+service zm-rpcapi status
+service zm-testagent status
 ```
 
 See the [post-installation] section for post-installation matters.

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -21,12 +21,14 @@ within the [Zonemaster::Engine installation] document.
 
 To upgrade Zonemaster::Backend perform the following tasks:
 
-  1. stop the `zm-rpcapi` and `zm-testagent` daemons (`zm_rpcapi` and
-     `zm_testagent` on FreeBSD)
+  1. stop the `zm-rpcapi` and `zm-testagent` daemons
   2. install any new dependencies (see corresponding upgrade document)
   3. install the latest version from CPAN with `cpanm Zonemaster::Backend`
   4. apply any remaining instructions specific to this new release
   5. start the `zm-rpcapi` and `zm-testagent` daemons
+
+> On FreeBSD the daemons are named `zm_rpcapi` and `zm_testagent` in versions
+> v7.0.0 and earlier.
 
 
 ### Specific upgrade instructions

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -26,8 +26,7 @@ To upgrade Zonemaster::Backend perform the following tasks:
   2. install any new dependencies (see corresponding upgrade document)
   3. install the latest version from CPAN with `cpanm Zonemaster::Backend`
   4. apply any remaining instructions specific to this new release
-  5. start the `zm-rpcapi` and `zm-testagent` daemons (`zm_rpcapi` and
-     `zm_testagent` on FreeBSD)
+  5. start the `zm-rpcapi` and `zm-testagent` daemons
 
 
 ### Specific upgrade instructions

--- a/docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
+++ b/docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
@@ -46,8 +46,8 @@ enable_add_api_user = yes
 
 ## Upgrading init scripts
 
-The `zm-rpcapi` (`zm_rpcapi` on FreeBSD) init script has been updated. It needs
-to be reinstalled.
+The `zm-rpcapi` init script has been updated. It needs to be reinstalled. On
+FreeBSD the scripts have also been renamed with `-` instead of `_`.
 
 ### CentOS
 
@@ -66,8 +66,11 @@ sudo install -v -m 755 ./zm-rpcapi.lsb /etc/init.d/zm-rpcapi
 ### FreeBSD
 
 ```
+rm -f /usr/local/etc/rc.d/zm_rpcapi
+rm -f /usr/local/etc/rc.d/zm_testagent
 cd `perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")'`
-install -v -m 755 ./zm_rpcapi-bsd /usr/local/etc/rc.d/zm_rpcapi
+install -v -m 755 ./zm-rpcapi.bsd /usr/local/etc/rc.d/zm-rpcapi
+install -v -m 755 ./zm-testagent.bsd /usr/local/etc/rc.d/zm-testagent
 ```
 
 

--- a/docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
+++ b/docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
@@ -86,7 +86,6 @@ than v8.0.0, and not upgraded, use the following instructions.
 
 ### SQLite
 
-Run
 ```sh
 cd $(perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')
 perl patch_sqlite_db_zonemaster_backend_ver_8.0.0.pl
@@ -94,7 +93,6 @@ perl patch_sqlite_db_zonemaster_backend_ver_8.0.0.pl
 
 ### MySQL (or MariaDB)
 
-Run
 ```sh
 cd $(perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')
 perl patch/patch_mysql_db_zonemaster_backend_ver_8.0.0.pl
@@ -102,7 +100,6 @@ perl patch/patch_mysql_db_zonemaster_backend_ver_8.0.0.pl
 
 ### PostgreSQL
 
-Run
 ```sh
 cd $(perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')
 perl patch/patch_postgresql_db_zonemaster_backend_ver_8.0.0.pl

--- a/share/zm-rpcapi.bsd
+++ b/share/zm-rpcapi.bsd
@@ -1,12 +1,12 @@
 #!/bin/sh
 
-# PROVIDE: zm_rpcapi
+# PROVIDE: zm-rpcapi
 # REQUIRE: NETWORKING mysql postgresql
 # KEYWORD: shutdown
 
 . /etc/rc.subr
 
-name="zm_rpcapi"
+name="zm-rpcapi"
 rcvar="${name}_enable"
 
 load_rc_config $name

--- a/share/zm-testagent.bsd
+++ b/share/zm-testagent.bsd
@@ -6,7 +6,7 @@
 
 . /etc/rc.subr
 
-name="zm_testagent"
+name="zm-testagent"
 rcvar="${name}_enable"
 
 load_rc_config $name


### PR DESCRIPTION
## Purpose

Harmonize file names.

## Context

See https://github.com/zonemaster/zonemaster-backend/pull/879#discussion_r719229720

## Breaking changes

Rename files:
* `share/zm_rpcapi-bsd` -> `share/zm-rpcapi.bsd`
* `share/zm-testagent-bsd` -> `share/zm-testagent.bsd`

Rename daemons as well using an hyphen.

## How to test this PR

Install the Backend on FreeBSD and try starting/stoping the daemons using there new names (with hyphen).
