### PR TITLE
Fix translation

### DIFF
--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -19,7 +19,10 @@ use Plack::Response;
 use Router::Simple::Declare;
 use Try::Tiny;
 
-BEGIN { $ENV{PERL_JSON_BACKEND} = 'JSON::PP' };
+BEGIN {
+    $ENV{PERL_JSON_BACKEND} = 'JSON::PP';
+    undef $ENV{LANGUAGE};
+};
 
 use Zonemaster::Backend::RPCAPI;
 use Zonemaster::Backend::Config;


### PR DESCRIPTION
## Purpose

Fix translation issue when the `LANGUAGE` env is set.

## Context

Follow-up on https://github.com/zonemaster/zonemaster-backend/pull/891#discussion_r742640234

## Changes

Unset the `LANGUAGE` env when the rpcapi start.

## How to test this PR

* Start the RCPAPI with `LANG=en_US.UTF-8 LANGUAGE=en_US:en ZM_BACKEND_RPCAPI_LOGLEVEL=debug starman --preload-app script/zonemaster_backend_rpcapi.psgi`
* Query a test result with a different language `./script/zmb get_test_results --test-id 95f2af2f841fc3ed --lang fr`, the result should be translated in the requested language.
