### PR TITLE
remove the retry column in db

### DIFF
--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -79,8 +79,7 @@ sub create_db {
             fingerprint character varying(32),
             params blob NOT NULL,
             results mediumblob DEFAULT NULL,
-            undelegated integer NOT NULL DEFAULT 0,
-            nb_retries integer NOT NULL DEFAULT 0
+            undelegated integer NOT NULL DEFAULT 0
         ) ENGINE=InnoDB
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'test_results' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -75,8 +75,7 @@ sub create_db {
                 fingerprint varchar(32),
                 params json NOT NULL,
                 undelegated integer NOT NULL DEFAULT 0,
-                results json,
-                nb_retries integer NOT NULL DEFAULT 0
+                results json
             )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'test_results' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -70,8 +70,7 @@ sub create_db {
                  fingerprint character varying(32),
                  params text NOT NULL,
                  results text DEFAULT NULL,
-                 undelegated boolean NOT NULL DEFAULT false,
-                 nb_retries integer NOT NULL DEFAULT 0
+                 undelegated boolean NOT NULL DEFAULT false
            )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'test_results' table", data => $dbh->errstr() );

--- a/share/patch/patch_mysql_db_zonemaster_backend_ver_8.0.0.pl
+++ b/share/patch/patch_mysql_db_zonemaster_backend_ver_8.0.0.pl
@@ -65,6 +65,12 @@ sub patch_db {
         $dbh->do( "ALTER TABLE users DROP COLUMN user_info" );
     };
     print( "Error while dropping the column:  " . $@ ) if ($@);
+
+    # remove the "nb_retries" column from the "test_results" table
+    eval {
+        $dbh->do( "ALTER TABLE test_results DROP COLUMN nb_retries" );
+    };
+    print( "Error while dropping the column:  " . $@ ) if ($@);
 }
 
 patch_db();

--- a/share/patch/patch_postgresql_db_zonemaster_backend_ver_8.0.0.pl
+++ b/share/patch/patch_postgresql_db_zonemaster_backend_ver_8.0.0.pl
@@ -94,10 +94,16 @@ sub patch_db {
     print( "Error while changing DB schema:  " . $@ ) if ($@);
 
     # update the columns
-    $dbh->do( "UPDATE users SET username = (user_info->>'username'), api_key = (user_info->>'api_key')" );
+    eval {
+        $dbh->do( "UPDATE users SET username = (user_info->>'username'), api_key = (user_info->>'api_key')" );
+    };
+    print( "Error while updating the users table:  " . $@ ) if ($@);
 
     # remove the "user_info" column from the "users" table
     $dbh->do( "ALTER TABLE users DROP COLUMN IF EXISTS user_info" );
+
+    # remove the "nb_retries" column from the "test_results" table
+    $dbh->do( "ALTER TABLE test_results DROP COLUMN IF EXISTS nb_retries" );
 }
 
 patch_db();

--- a/share/patch/patch_sqlite_db_zonemaster_backend_ver_8.0.0.pl
+++ b/share/patch/patch_sqlite_db_zonemaster_backend_ver_8.0.0.pl
@@ -31,7 +31,26 @@ sub patch_db {
         $db->create_db();
 
         # populate it
-        $dbh->do('INSERT INTO test_results SELECT * FROM test_results_old');
+        # - nb_retries is omitted as we remove this column
+        # - params_deterministic_hash is renamed to fingerprint
+        $dbh->do('
+            INSERT INTO test_results
+            SELECT id,
+                   hash_id,
+                   domain,
+                   batch_id,
+                   creation_time,
+                   test_start_time,
+                   test_end_time,
+                   priority,
+                   queue,
+                   progress,
+                   params_deterministic_hash,
+                   params,
+                   results,
+                   undelegated
+            FROM test_results_old
+        ');
 
         $dbh->do('DROP TABLE test_results_old');
 


### PR DESCRIPTION
## Purpose

Remove the `nb_retries` column from the database.

## Context

Second step of  #881.


## Changes

* Updates the database creation scripts
* Update the patch scripts to remove the column

## How to test this PR

* Run the patch scripts on a existing database with the `nb_retries` column (some error messages can be ignored if the database was already partially migrated)
* Create new databases