### PR TITLE
Update dependencies

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,7 +21,7 @@ requires
   'HTML::Entities'              => 0,
   'JSON::PP'                    => 0,
   'JSON::RPC'                   => 1.01,
-  'JSON::Validator'             => 3.12,
+  'JSON::Validator'             => 4.00,
   'Log::Any'                    => 0,
   'Log::Any::Adapter::Dispatch' => 0,
   'Log::Dispatch'               => 0,

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,6 +26,7 @@ requires
   'Log::Any::Adapter::Dispatch' => 0,
   'Log::Dispatch'               => 0,
   'LWP::UserAgent'              => 0,
+  'Mojolicious'                 => 7.28,
   'Moose'                       => 2.04,
   'Parallel::ForkManager'       => 1.12,
   'Plack::Builder'              => 0,

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -209,9 +209,13 @@ Install dependencies available from binary packages:
 ```sh
 sudo apt install jq libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdaemon-control-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libio-stringy-perl libjson-pp-perl libjson-rpc-perl libjson-validator-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl libplack-middleware-reverseproxy-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtest-nowarnings-perl libtry-tiny-perl libintl-perl perl-doc starman
 ```
-
 > **Note**: libio-stringy-perl is listed here even though it's not a direct
 > dependency. It's an undeclared dependency of libconfig-inifiles-perl.
+
+* On Ubuntu, install the following dependency from CPAN:
+  ```
+  sudo cpanm JSON::Validator
+  ```
 
 Install Zonemaster::Backend:
 

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -79,7 +79,7 @@ for Zonemaster::Backend, see the [declaration of prerequisites].
 Install dependencies available from binary packages:
 
 ```sh
-sudo dnf -y install jq perl-Class-Method-Modifiers perl-Config-IniFiles perl-DBD-SQLite perl-DBI perl-HTML-Parser perl-JSON-RPC perl-libwww-perl perl-Log-Dispatch perl-Net-Server perl-Parallel-ForkManager perl-Plack perl-Plack-Test perl-Role-Tiny perl-Router-Simple perl-String-ShellQuote perl-Test-NoWarnings perl-Test-Warn perl-Try-Tiny perl-libintl redhat-lsb-core
+sudo dnf -y install jq perl-Class-Method-Modifiers perl-Config-IniFiles perl-DBD-SQLite perl-DBI perl-HTML-Parser perl-JSON-RPC perl-libwww-perl perl-Log-Dispatch perl-Mojolicious perl-Net-Server perl-Parallel-ForkManager perl-Plack perl-Plack-Test perl-Role-Tiny perl-Router-Simple perl-String-ShellQuote perl-Test-NoWarnings perl-Test-Warn perl-Try-Tiny perl-libintl redhat-lsb-core
 ```
 
 > **Note:** perl-Net-Server and perl-Test-Warn are listed here even though they
@@ -207,7 +207,7 @@ sv_SE.utf8
 Install dependencies available from binary packages:
 
 ```sh
-sudo apt install jq libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdaemon-control-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libio-stringy-perl libjson-pp-perl libjson-rpc-perl libjson-validator-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl libplack-middleware-reverseproxy-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtest-nowarnings-perl libtry-tiny-perl libintl-perl perl-doc starman
+sudo apt install jq libclass-method-modifiers-perl libconfig-inifiles-perl libdbd-sqlite3-perl libdaemon-control-perl libdbi-perl libfile-sharedir-perl libfile-slurp-perl libhtml-parser-perl libmojolicious-perl libio-stringy-perl libjson-pp-perl libjson-rpc-perl libjson-validator-perl liblog-any-adapter-dispatch-perl liblog-any-perl liblog-dispatch-perl libmoose-perl libparallel-forkmanager-perl libplack-perl libplack-middleware-debug-perl libplack-middleware-reverseproxy-perl librole-tiny-perl librouter-simple-perl libstring-shellquote-perl libtest-nowarnings-perl libtry-tiny-perl libintl-perl perl-doc starman
 ```
 > **Note**: libio-stringy-perl is listed here even though it's not a direct
 > dependency. It's an undeclared dependency of libconfig-inifiles-perl.
@@ -325,7 +325,7 @@ su -l
 Install dependencies available from binary packages:
 
 ```sh
-pkg install jq p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-JSON-PP p5-JSON-RPC p5-Moose p5-Parallel-ForkManager p5-Plack p5-Plack-Middleware-ReverseProxy p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote p5-DBD-SQLite p5-Log-Dispatch p5-Log-Any p5-Log-Any-Adapter-Dispatch p5-JSON-Validator p5-YAML-LibYAML p5-Test-NoWarnings p5-Locale-libintl gmake
+pkg install jq p5-Class-Method-Modifiers p5-Config-IniFiles p5-Daemon-Control p5-DBI p5-File-ShareDir p5-File-Slurp p5-HTML-Parser p5-JSON-PP p5-JSON-RPC p5-Mojolicious p5-Moose p5-Parallel-ForkManager p5-Plack p5-Plack-Middleware-ReverseProxy p5-Role-Tiny p5-Router-Simple p5-Starman p5-String-ShellQuote p5-DBD-SQLite p5-Log-Dispatch p5-Log-Any p5-Log-Any-Adapter-Dispatch p5-JSON-Validator p5-YAML-LibYAML p5-Test-NoWarnings p5-Locale-libintl gmake
 ```
 <!-- JSON::Validator requires YAML::PP, but p5-JSON-Validator currently lacks a dependency on p5-YAML-LibYAML -->
 

--- a/docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
+++ b/docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
@@ -27,6 +27,12 @@ sudo cpanm Plack::Middleware::ReverseProxy
 sudo apt-get install libplack-middleware-reverseproxy-perl libintl-perl libmojolicious-perl
 ```
 
+#### Specific to Ubuntu
+
+```sh
+sudo cpanm JSON::Validator
+```
+
 ### FreeBSD
 
 ```sh

--- a/docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
+++ b/docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
@@ -14,7 +14,7 @@ the corresponding command.
 ### Rocky Linux
 
 ```sh
-sudo dnf install perl-libintl
+sudo dnf install perl-libintl perl-Mojolicious
 ```
 
 ```sh
@@ -24,13 +24,13 @@ sudo cpanm Plack::Middleware::ReverseProxy
 ### Debian / Ubuntu
 
 ```sh
-sudo apt-get install libplack-middleware-reverseproxy-perl libintl-perl
+sudo apt-get install libplack-middleware-reverseproxy-perl libintl-perl libmojolicious-perl
 ```
 
 ### FreeBSD
 
 ```sh
-pkg install p5-Plack-Middleware-ReverseProxy p5-Locale-libintl
+pkg install p5-Plack-Middleware-ReverseProxy p5-Locale-libintl p5-Mojolicious
 ```
 
 


### PR DESCRIPTION
## Purpose

RPCAPI depends on the Draft7 schema:

https://github.com/zonemaster/zonemaster-backend/blob/46b164b1bf0f9b8f6563e980afdda95c118f9266/lib/Zonemaster/Backend/RPCAPI.pm#L18

used here for instance:

https://github.com/zonemaster/zonemaster-backend/blob/46b164b1bf0f9b8f6563e980afdda95c118f9266/lib/Zonemaster/Backend/RPCAPI.pm#L770

Add Mojolicious dependency. Reuse the [same minimum level as in JSON::Validator](https://github.com/jhthorsen/json-validator/blob/788fd4255899339d974d28141a5243f4409067d8/Makefile.PL#L35).

## Context

Closes #901
Closes #903

## Changes

Update minimum version in Makefile.PL.
Explicitely depend from Mojolicious.

## How to test this PR

Follow the installation document and check that you get a running Backend.
