### PR TITLE
Fix MySQL cleanup

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -694,6 +694,8 @@ as a database administrator. Commands
 for locating and running the file are below. It removes the user and drops the
 database (obviously taking all data with it).
 
+> Each script uses default values, you may need to adapt them to your setup.
+
 ### 9.1. MariaDB and MySQL
 
 Rocky Linux, Debian and Ubuntu:

--- a/share/cleanup-mysql.sql
+++ b/share/cleanup-mysql.sql
@@ -1,4 +1,3 @@
 -- Remove Zonemaster data from database
 DROP DATABASE zonemaster;
 DROP USER 'zonemaster'@'localhost';
-DROP USER 'zonemaster'@'%';


### PR DESCRIPTION
## Purpose

Do not fail on cleanup.

## Context

Fixes #887 

## Changes

Update `cleanup-mysql.sql`.

## How to test this PR

Follow the instructions to install the MySQL database and then run the cleanup command. No errors should be emitted.
