### PR TITLE
Clean old files when upgrading

### DIFF
--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -23,10 +23,11 @@ To upgrade Zonemaster::Backend perform the following tasks:
 
   1. stop the `zm-rpcapi` and `zm-testagent` daemons (`zm_rpcapi` and
      `zm_testagent` on FreeBSD)
-  2. install any new dependencies (see corresponding upgrade document)
-  3. install the latest version from CPAN with `cpanm Zonemaster::Backend`
-  4. apply any remaining instructions specific to this new release
-  5. start the `zm-rpcapi` and `zm-testagent` daemons (`zm_rpcapi` and
+  2. remove old files with `cpanm --uninstall Zonemaster::Backend`
+  3. install any new dependencies (see corresponding upgrade document)
+  4. install the latest version from CPAN with `cpanm Zonemaster::Backend`
+  5. apply any remaining instructions specific to this new release
+  6. start the `zm-rpcapi` and `zm-testagent` daemons (`zm_rpcapi` and
      `zm_testagent` on FreeBSD)
 
 

--- a/docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
+++ b/docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
@@ -81,18 +81,6 @@ install -v -m 755 ./zm_rpcapi-bsd /usr/local/etc/rc.d/zm_rpcapi
 ```
 
 
-## Cleaning old files
-
-### Linux
-```sh
-sudo rm `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')`/patch_*.pl
-```
-
-### FreeBSD
-```sh
-rm `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")')`/patch_*.pl
-```
-
 ## Upgrading the database
 
 If your Zonemaster database was created by a Zonemaster-Backend version smaller


### PR DESCRIPTION
## Purpose

Some old files are not cleaned when following the upgrade instructions.
Instead of manually listing and removing each deprecated files, `cpanm --uninstall` will do the cleaning for us.

## Context

Follow #907

## Changes

Instructions to run `cpanm --uninstall Zonemaster::Backend` when upgrading the module.

## How to test this PR

Install the previous version of Backend and follow the instructions from the "Clean old file section" of the upgrade document.