### PR TITLE
Add MO files to manifest

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -70,7 +70,12 @@ share/zm-rpcapi.lsb
 share/zm-testagent.lsb
 share/zm_rpcapi-bsd
 share/zm_testagent-bsd
+share/locale/da/LC_MESSAGES/Zonemaster-Backend.mo
+share/locale/es/LC_MESSAGES/Zonemaster-Backend.mo
+share/locale/fi/LC_MESSAGES/Zonemaster-Backend.mo
 share/locale/fr/LC_MESSAGES/Zonemaster-Backend.mo
+share/locale/nb/LC_MESSAGES/Zonemaster-Backend.mo
+share/locale/sv/LC_MESSAGES/Zonemaster-Backend.mo
 share/Makefile
 share/GNUmakefile
 t/config.t


### PR DESCRIPTION
## Purpose

More MO files were indirectly added by PR #898 but it was not specified in the MANIFEST.

## How to test this PR

`make distcheck` should not complain about unknown MO files, and the MO files should be included in the distribution file.