### PR TITLE
Fix inconsistency in SQLite test's age

### DIFF
--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -128,7 +128,7 @@ sub recent_test_hash_id {
 
     my $dbh = $self->dbh;
     my ( $recent_hash_id ) = $dbh->selectrow_array(
-        "SELECT hash_id FROM test_results WHERE fingerprint = ? AND test_start_time > DATETIME('now', ?)",
+        "SELECT hash_id FROM test_results WHERE fingerprint = ? AND creation_time > DATETIME('now', ?)",
         undef, $fingerprint, "-$age_reuse_previous_test seconds"
     );
 


### PR DESCRIPTION
## Purpose

Fix inconsistency in SQLite test's age.

## Context

#841 did not update SQLite to use `creation_time` instead of `test_start_time` when looking for test to reuse, which is inconsistent with MySQL and PostgreSQL.
In fact #841 made the change (a8a4cee) and removed it in a later commit (5df15c0).

Addresses #840.

## Changes

Update method `recent_test_hash_id` in `DB/SQLite.pm`.

## How to test this PR

With SQLite configured, start two tests for the same domain. Before, this fix, the test ID is different. With this fix, the test ID should be the same (until `age_reuse_previous_test` seconds are passed).
```
curl -sH "Content-Type: application/json" --data '{"method":"start_domain_test","params":{"domain":"domain.example"},"id":1,"jsonrpc":"2.0"}' localhost:5000/api | jq
```