### PR TITLE
Fix internationalized testing failure with error: "malformed UTF-8 character in JSON string"

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -260,9 +260,11 @@ sub get_test_params {
 
     my $result;
     eval {
-        # TODO: do we use "encode_utf8" as this was the case in PostgreSQL
-        #       (see commit diff)
-        $result = decode_json( $params_json );
+        if ( utf8::is_utf8( $params_json ) ) {
+            $result = decode_json( encode_utf8( $params_json ) );
+        } else {
+            $result = decode_json( $params_json );
+        }
     };
 
     die Zonemaster::Backend::Error::JsonError->new( reason => "$@", data => { test_id => $test_id } )


### PR DESCRIPTION
## Purpose

The different database drivers do not retrieve the data with the same Perl's internal representation. Therefore it is required to check this representation before calling "decode_json" that "expects an UTF-8 (binary) string" (https://metacpan.org/pod/JSON::PP#decode_json).

## Context

Fixes #931
Also see #570

## Changes

Fix the `get_test_params` method in `DB.pm`.

## How to test this PR

Check that internationalized and non-internationalized domains works properly for all database engines.
