### PR TITLE
Wrapper around "decode_json" to properly encode the string

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -316,7 +316,7 @@ sub force_end_test {
     my ( $self, $hash_id, $results, $timestamp ) = @_;
     my $result;
     if ( defined $results && $results =~ /^\[/ ) {
-        $result = decode_json( $results );
+        $result = _decode_json_sanitize( $results );
     }
     else {
         $result = [];

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -260,11 +260,7 @@ sub get_test_params {
 
     my $result;
     eval {
-        if ( utf8::is_utf8( $params_json ) ) {
-            $result = decode_json( encode_utf8( $params_json ) );
-        } else {
-            $result = decode_json( $params_json );
-        }
+        $result = _decode_json_sanitize( $params_json );
     };
 
     die Zonemaster::Backend::Error::JsonError->new( reason => "$@", data => { test_id => $test_id } )
@@ -366,6 +362,21 @@ sub _new_dbh {
     $dbh->{AutoInactiveDestroy} = 1;
 
     return $dbh;
+}
+
+# A wrapper around JSON::PP->decode_json to be sure to pass a string in the
+# expected format
+sub _decode_json_sanitize {
+    my ( $input ) = @_;
+    my $output;
+
+    if ( utf8::is_utf8( $input ) ) {
+        $output = decode_json( encode_utf8( $input ) );
+    } else {
+        $output = decode_json( $input );
+    }
+
+    return $output;
 }
 
 sub _project_params {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -255,8 +255,8 @@ sub get_test_history {
     }
 
     while ( my $h = $sth->fetchrow_hashref ) {
-        $h->{results} = decode_json($h->{results}) if $h->{results};
-        $h->{params} = decode_json($h->{params}) if $h->{params};
+        $h->{results} = _decode_json_sanitize($h->{results}) if $h->{results};
+        $h->{params} = _decode_json_sanitize($h->{params}) if $h->{params};
         my $critical = ( grep { $_->{level} eq 'CRITICAL' } @{ $h->{results} } );
         my $error    = ( grep { $_->{level} eq 'ERROR' } @{ $h->{results} } );
         my $warning  = ( grep { $_->{level} eq 'WARNING' } @{ $h->{results} } );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -189,10 +189,10 @@ sub test_results {
         unless defined $result;
 
     eval {
-        $result->{params}  = decode_json( $result->{params} );
+        $result->{params}  = _decode_json_sanitize( $result->{params} );
 
         if (defined $result->{results}) {
-            $result->{results} = decode_json( $result->{results} );
+            $result->{results} = _decode_json_sanitize( $result->{results} );
         } else {
             $result->{results} = [];
         }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -175,22 +175,10 @@ sub test_results {
         unless defined $result;
 
     eval {
-        # This workaround is needed to properly handle all versions of perl and the DBD::Pg module
-        # More details in the zonemaster backend issue #570
-        if (utf8::is_utf8($result->{params}) ) {
-            $result->{params}  = decode_json( encode_utf8($result->{params}) );
-        }
-        else {
-            $result->{params}  = decode_json( $result->{params} );
-        }
+        $result->{params} = _decode_json_sanitize( $result->{params} );
 
         if (defined $result->{results} ) {
-            if (utf8::is_utf8($result->{results} ) ) {
-                $result->{results}  = decode_json( encode_utf8($result->{results}) );
-            }
-            else {
-                $result->{results}  = decode_json( $result->{results} );
-            }
+            $result->{results} = _decode_json_sanitize( $result->{results} );
         } else {
             $result->{results} = [];
         }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -214,7 +214,7 @@ sub get_test_history {
     my $sth1 = $self->dbh->prepare( $query );
     $sth1->execute;
     while ( my $h = $sth1->fetchrow_hashref ) {
-        $h->{results} = decode_json($h->{results}) if $h->{results};
+        $h->{results} = _decode_json_sanitize($h->{results}) if $h->{results};
         my $critical = ( grep { $_->{level} eq 'CRITICAL' } @{ $h->{results} } );
         my $error    = ( grep { $_->{level} eq 'ERROR' } @{ $h->{results} } );
         my $warning  = ( grep { $_->{level} eq 'WARNING' } @{ $h->{results} } );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -169,10 +169,10 @@ sub test_results {
         unless defined $result;
 
     eval {
-        $result->{params}  = decode_json( $result->{params} );
+        $result->{params}  = _decode_json_sanitize( $result->{params} );
 
         if (defined $result->{results}) {
-            $result->{results} = decode_json( $result->{results} );
+            $result->{results} = _decode_json_sanitize( $result->{results} );
         } else {
             $result->{results} = [];
         }

--- a/share/patch/patch_mysql_db_zonemaster_backend_ver_8.0.0.pl
+++ b/share/patch/patch_mysql_db_zonemaster_backend_ver_8.0.0.pl
@@ -50,7 +50,7 @@ sub patch_db {
     $sth1->execute;
     while ( my $row = $sth1->fetchrow_hashref ) {
         my $id = $row->{id};
-        my $raw_params = decode_json($row->{params});
+        my $raw_params = _decode_json_sanitize($row->{params});
         my $ds_info_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{ds_info}};
         my $nameservers_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{nameservers}};
         my $undelegated = $ds_info_values > 0 || $nameservers_values > 0 || 0;

--- a/share/patch/patch_postgresql_db_zonemaster_backend_ver_8.0.0.pl
+++ b/share/patch/patch_postgresql_db_zonemaster_backend_ver_8.0.0.pl
@@ -71,14 +71,7 @@ sub patch_db {
     $sth1->execute;
     while ( my $row = $sth1->fetchrow_hashref ) {
         my $id = $row->{id};
-        my $raw_params;
-
-        if (utf8::is_utf8($row->{params}) ) {
-            $raw_params = decode_json( encode_utf8 ( $row->{params} ) );
-        } else {
-            $raw_params = decode_json( $row->{params} );
-        }
-
+        my $raw_params = _decode_json_sanitize($row->{params});
         my $ds_info_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{ds_info}};
         my $nameservers_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{nameservers}};
         my $undelegated = $ds_info_values > 0 || $nameservers_values > 0 || 0;

--- a/share/patch/patch_sqlite_db_zonemaster_backend_ver_8.0.0.pl
+++ b/share/patch/patch_sqlite_db_zonemaster_backend_ver_8.0.0.pl
@@ -64,7 +64,7 @@ sub patch_db {
     $sth1->execute;
     while ( my $row = $sth1->fetchrow_hashref ) {
         my $id = $row->{id};
-        my $raw_params = decode_json($row->{params});
+        my $raw_params = _decode_json_sanitize($row->{params});
         my $ds_info_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{ds_info}};
         my $nameservers_values = scalar grep !/^$/, map { values %$_ } @{$raw_params->{nameservers}};
         my $undelegated = $ds_info_values > 0 || $nameservers_values > 0 || 0;


### PR DESCRIPTION
## Purpose

Create a wrapper around `decode_json` in order to properly encode the data in the expected format.

> expects an UTF-8 (binary) string
https://metacpan.org/pod/JSON::PP#decode_json

## Context

Refactor code added in #932 and #571.

## Changes

New wrapper used in different places.

## How to test this PR

This is mostly a refactoring. So nothing should break.