### PR TITLE
Clean up determination of config file default path

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -78,6 +78,7 @@ share/locale/nb/LC_MESSAGES/Zonemaster-Backend.mo
 share/locale/sv/LC_MESSAGES/Zonemaster-Backend.mo
 share/Makefile
 share/GNUmakefile
+t/00-load.t
 t/config.t
 t/db.t
 t/parameters_validation.t

--- a/MANIFEST
+++ b/MANIFEST
@@ -17,6 +17,7 @@ docs/upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
 inc/Module/Install.pm
 inc/Module/Install/Base.pm
 inc/Module/Install/Can.pm
+inc/Module/Install/External.pm
 inc/Module/Install/Fetch.pm
 inc/Module/Install/Makefile.pm
 inc/Module/Install/Metadata.pm
@@ -24,7 +25,6 @@ inc/Module/Install/Scripts.pm
 inc/Module/Install/Share.pm
 inc/Module/Install/Win32.pm
 inc/Module/Install/WriteAll.pm
-inc/Module/Install/External.pm
 lib/Zonemaster/Backend.pm
 lib/Zonemaster/Backend/Config.pm
 lib/Zonemaster/Backend/Config/DCPlugin.pm
@@ -53,7 +53,14 @@ share/cleanup-mysql.sql
 share/cleanup-postgres.sql
 share/create_db.pl
 share/freebsd-pwd.conf
-share/patch/README.txt
+share/GNUmakefile
+share/locale/da/LC_MESSAGES/Zonemaster-Backend.mo
+share/locale/es/LC_MESSAGES/Zonemaster-Backend.mo
+share/locale/fi/LC_MESSAGES/Zonemaster-Backend.mo
+share/locale/fr/LC_MESSAGES/Zonemaster-Backend.mo
+share/locale/nb/LC_MESSAGES/Zonemaster-Backend.mo
+share/locale/sv/LC_MESSAGES/Zonemaster-Backend.mo
+share/Makefile
 share/patch/patch_mysql_db_zonemaster_backend_ver_1.0.3.pl
 share/patch/patch_mysql_db_zonemaster_backend_ver_5.0.0.pl
 share/patch/patch_mysql_db_zonemaster_backend_ver_5.0.2.pl
@@ -62,6 +69,7 @@ share/patch/patch_postgresql_db_zonemaster_backend_ver_1.0.3.pl
 share/patch/patch_postgresql_db_zonemaster_backend_ver_5.0.0.pl
 share/patch/patch_postgresql_db_zonemaster_backend_ver_8.0.0.pl
 share/patch/patch_sqlite_db_zonemaster_backend_ver_8.0.0.pl
+share/patch/README.txt
 share/tmpfiles.conf
 share/travis_mysql_backend_config.ini
 share/travis_postgresql_backend_config.ini
@@ -70,14 +78,6 @@ share/zm-rpcapi.lsb
 share/zm-testagent.lsb
 share/zm_rpcapi-bsd
 share/zm_testagent-bsd
-share/locale/da/LC_MESSAGES/Zonemaster-Backend.mo
-share/locale/es/LC_MESSAGES/Zonemaster-Backend.mo
-share/locale/fi/LC_MESSAGES/Zonemaster-Backend.mo
-share/locale/fr/LC_MESSAGES/Zonemaster-Backend.mo
-share/locale/nb/LC_MESSAGES/Zonemaster-Backend.mo
-share/locale/sv/LC_MESSAGES/Zonemaster-Backend.mo
-share/Makefile
-share/GNUmakefile
 t/00-load.t
 t/config.t
 t/db.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -32,7 +32,7 @@
 
 # Avoid Makemaker generated and utility files.
 \bMANIFEST\.bak
-\bMakefile$
+^Makefile$
 \bblib/
 \bMakeMaker-\d
 \bpm_to_blib\.ts$

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -26,8 +26,8 @@ A list of values and locations are checked and the first match is returned.
 If all places are checked and no file is found, an exception is thrown.
 
 This procedure is idempotent - i.e. if you call this procedure multiple times
-the same value is returned no matter if environmental circumstances have
-changed.
+the same value is returned no matter if environment variables or the file system
+have changed.
 
 The following checks are made in order:
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -26,7 +26,8 @@ A list of values and locations are checked and the first match is returned.
 If all places are checked and no file is found, an exception is thrown.
 
 This procedure is idempotent - i.e. if you call this procedure multiple times
-the same value is returned no matter if envirnmental circumstances have changed.
+the same value is returned no matter if environmental circumstances have
+changed.
 
 The following checks are made in order:
 

--- a/t/00-load.t
+++ b/t/00-load.t
@@ -1,0 +1,12 @@
+use 5.014002;
+use strict;
+use warnings FATAL => 'all';
+use Test::More;
+
+plan tests => 1;
+
+BEGIN {
+    use_ok( 'Zonemaster::Backend::Config' ) || print "Bail out!\n";
+}
+
+done_testing;


### PR DESCRIPTION
## Purpose

This is mainly a code quality improvement. It also avoids locating the default backend_config.ini if it isn't needed.

## Context

N/A

## Changes

* It avoids executing some code at load time.
* It replaces a global variable (`$Zonemaster::Backend::Config::path`) with a procedure (`Zonemaster::Backend::Config::get_default_path()`).
* It adds code documentation about where the default backend_config.ini file is sought.
* It simplifies the code to determine the config file path.

## How to test this PR

This should not change the behavior of Backend in production context.

A unit test has been added to make sure the Zonemaster::Backend::Config module can be loaded without it being able to locate a backend_config.ini file at load time.