### PR TITLE
Update zmtest

### DIFF
--- a/script/zmtest
+++ b/script/zmtest
@@ -8,7 +8,7 @@ JQ="$(which jq)"
 usage () {
     status="$1"
     message="$2"
-    printf "%s" "${message}" >&2
+    printf "%s\n" "${message}" >&2
     echo "Usage: zmtest [OPTIONS] DOMAIN" >&2
     echo >&2
     echo "This interface is unstable and may change in a future release." >&2


### PR DESCRIPTION
Print a newline after the error message, without which the "Usage..." string appears on the same line, squashed with the error message.

## Purpose

This PR...

## Context

(e.g. Fixes #9999, Follow-up to #9999, etc.)

## Changes

...

## How to test this PR

Before this PR:

```
$ zmtest
No domain specifiedUsage: zmtest [OPTIONS] DOMAIN

This interface is unstable and may change in a future release.

(...)
```
After this PR:
```
$ zmtest
No domain specified
Usage: zmtest [OPTIONS] DOMAIN

This interface is unstable and may change in a future release.

(...)
```