### PR TITLE
Improve get_test_history

### DIFF
--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -5,7 +5,7 @@ our $VERSION = '1.1.0';
 use Moose;
 use 5.14.2;
 
-use DBI qw(:utils);
+use DBI qw(:utils :sql_types);
 use Digest::MD5 qw(md5_hex);
 use JSON::PP;
 
@@ -209,11 +209,11 @@ sub get_test_history {
 
     my $dbh = $self->dbh;
 
-    my $undelegated = "";
+    my $undelegated = undef;
     if ($p->{filter} eq "undelegated") {
-        $undelegated = "AND undelegated = 1";
+        $undelegated = 1;
     } elsif ($p->{filter} eq "delegated") {
-        $undelegated = "AND undelegated = 0";
+        $undelegated = 0;
     }
 
     my @results;
@@ -225,13 +225,20 @@ sub get_test_history {
             undelegated,
             results
         FROM test_results
-        WHERE progress = 100 AND domain = ? ] . $undelegated . q[
+        WHERE progress = 100 AND domain = ? AND ( ? IS NULL OR undelegated = ? )
         ORDER BY id DESC
         LIMIT ?
         OFFSET ?];
 
     my $sth = $dbh->prepare( $query );
-    $sth->execute( $p->{frontend_params}{domain}, $p->{limit}, $p->{offset} );
+
+    $sth->bind_param( 1, $p->{frontend_params}{domain} );
+    $sth->bind_param( 2, $undelegated, SQL_INTEGER );
+    $sth->bind_param( 3, $undelegated, SQL_INTEGER );
+    $sth->bind_param( 4, $p->{limit} );
+    $sth->bind_param( 5, $p->{offset} );
+
+    $sth->execute();
 
     while ( my $h = $sth->fetchrow_hashref ) {
         $h->{results} = decode_json($h->{results}) if $h->{results};

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -225,7 +225,7 @@ sub get_test_history {
             undelegated,
             results
         FROM test_results
-        WHERE domain = ? ] . $undelegated . q[
+        WHERE progress = 100 AND domain = ? ] . $undelegated . q[
         ORDER BY id DESC
         LIMIT ?
         OFFSET ?];

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -222,7 +222,6 @@ sub get_test_history {
             id,
             hash_id,
             CONVERT_TZ(`creation_time`, @@session.time_zone, '+00:00') AS creation_time,
-            params,
             undelegated,
             results
         FROM test_results
@@ -236,7 +235,6 @@ sub get_test_history {
 
     while ( my $h = $sth->fetchrow_hashref ) {
         $h->{results} = decode_json($h->{results}) if $h->{results};
-        $h->{params} = decode_json($h->{params}) if $h->{params};
         my $critical = ( grep { $_->{level} eq 'CRITICAL' } @{ $h->{results} } );
         my $error    = ( grep { $_->{level} eq 'ERROR' } @{ $h->{results} } );
         my $warning  = ( grep { $_->{level} eq 'WARNING' } @{ $h->{results} } );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -207,8 +207,7 @@ sub test_results {
 sub get_test_history {
     my ( $self, $p ) = @_;
 
-    my @results;
-    my $sth = {};
+    my $dbh = $self->dbh;
 
     my $undelegated = "";
     if ($p->{filter} eq "undelegated") {
@@ -217,8 +216,10 @@ sub get_test_history {
         $undelegated = 0;
     }
 
+    my @results;
+    my $sth = {};
     if ($p->{filter} eq "all") {
-        $sth = $self->dbh->prepare(
+        $sth = $dbh->prepare(
             q[SELECT
                 id,
                 hash_id,
@@ -235,7 +236,7 @@ sub get_test_history {
         );
         $sth->execute( $p->{frontend_params}{domain}, $p->{limit}, $p->{offset} );
     } else {
-        $sth = $self->dbh->prepare(
+        $sth = $dbh->prepare(
             q[SELECT
                 id,
                 hash_id,

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -5,7 +5,7 @@ our $VERSION = '1.1.0';
 use Moose;
 use 5.14.2;
 
-use DBI qw(:utils);
+use DBI qw(:utils :sql_types);
 use Digest::MD5 qw(md5_hex);
 use Encode;
 use JSON::PP;
@@ -207,11 +207,11 @@ sub get_test_history {
 
     my $dbh = $self->dbh;
 
-    my $undelegated = "";
+    my $undelegated = undef;
     if ($p->{filter} eq "undelegated") {
-        $undelegated = "AND undelegated = 1";
+        $undelegated = 1;
     } elsif ($p->{filter} eq "delegated") {
-        $undelegated = "AND undelegated = 0";
+        $undelegated = 0;
     }
 
     my @results;
@@ -225,13 +225,20 @@ sub get_test_history {
             undelegated,
             creation_time at time zone current_setting('TIMEZONE') at time zone 'UTC' as creation_time
         FROM test_results
-        WHERE progress = 100 AND domain = ? ] . $undelegated . q[
+        WHERE progress = 100 AND domain = ? AND ( ? IS NULL OR undelegated = ? )
         ORDER BY id DESC
         LIMIT ?
         OFFSET ?];
 
     my $sth1 = $dbh->prepare( $query );
-    $sth1->execute( $p->{frontend_params}{domain}, $p->{limit}, $p->{offset} );
+
+    $sth1->bind_param( 1, $p->{frontend_params}{domain} );
+    $sth1->bind_param( 2, $undelegated, SQL_INTEGER );
+    $sth1->bind_param( 3, $undelegated, SQL_INTEGER );
+    $sth1->bind_param( 4, $p->{limit} );
+    $sth1->bind_param( 5, $p->{offset} );
+
+    $sth1->execute();
 
     while ( my $h = $sth1->fetchrow_hashref ) {
         my $overall_result = 'ok';

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -226,6 +226,7 @@ sub get_test_history {
             creation_time at time zone current_setting('TIMEZONE') at time zone 'UTC' as creation_time
         FROM test_results
         WHERE progress = 100 AND domain = ? ] . $undelegated . q[
+        ORDER BY id DESC
         LIMIT ?
         OFFSET ?];
 

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -225,7 +225,7 @@ sub get_test_history {
             undelegated,
             creation_time at time zone current_setting('TIMEZONE') at time zone 'UTC' as creation_time
         FROM test_results
-        WHERE domain = ? ] . $undelegated . q[
+        WHERE progress = 100 AND domain = ? ] . $undelegated . q[
         LIMIT ?
         OFFSET ?];
 

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -5,7 +5,7 @@ our $VERSION = '1.1.0';
 use Moose;
 use 5.14.2;
 
-use DBI qw(:utils);
+use DBI qw(:utils :sql_types);
 use Digest::MD5 qw(md5_hex);
 use JSON::PP;
 
@@ -189,11 +189,11 @@ sub get_test_history {
 
     my $dbh = $self->dbh;
 
-    my $undelegated = "";
+    my $undelegated = undef;
     if ($p->{filter} eq "undelegated") {
-        $undelegated = "AND undelegated = 1";
+        $undelegated = 1;
     } elsif ($p->{filter} eq "delegated") {
-        $undelegated = "AND undelegated = 0";
+        $undelegated = 0;
     }
 
     my @results;
@@ -205,13 +205,20 @@ sub get_test_history {
             undelegated,
             results
         FROM test_results
-        WHERE progress = 100 AND domain = ? ] . $undelegated . q[
+        WHERE progress = 100 AND domain = ? AND ( ? IS NULL OR undelegated = ? )
         ORDER BY id DESC
         LIMIT ?
         OFFSET ?];
 
     my $sth1 = $dbh->prepare( $query );
-    $sth1->execute( $p->{frontend_params}{domain}, $p->{limit}, $p->{offset} );
+
+    $sth1->bind_param( 1, $p->{frontend_params}{domain} );
+    $sth1->bind_param( 2, $undelegated, SQL_INTEGER );
+    $sth1->bind_param( 3, $undelegated, SQL_INTEGER );
+    $sth1->bind_param( 4, $p->{limit} );
+    $sth1->bind_param( 5, $p->{offset} );
+
+    $sth1->execute();
 
     while ( my $h = $sth1->fetchrow_hashref ) {
         $h->{results} = decode_json($h->{results}) if $h->{results};

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -202,7 +202,6 @@ sub get_test_history {
             id,
             hash_id,
             creation_time,
-            params,
             undelegated,
             results
         FROM test_results

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -205,7 +205,7 @@ sub get_test_history {
             undelegated,
             results
         FROM test_results
-        WHERE domain = ? ] . $undelegated . q[
+        WHERE progress = 100 AND domain = ? ] . $undelegated . q[
         ORDER BY id DESC
         LIMIT ?
         OFFSET ?];


### PR DESCRIPTION
## Purpose

Harmonize the code for `get_test_history` across database engines and fixes #888.

## Context

Fixes #888 

## Changes

* refactoring
* use SQL bind parameters
* remove unused `params` value
* keep finished tests only 

## How to test this PR

see #888 description and example