### PR TITLE
Fix unstoppable Testagent daemon

### DIFF
--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -191,6 +191,23 @@ sub main {
     return;
 }
 
+sub preflight_checks {
+    # Make sure we can load the configuration file
+    $log->debug("Starting pre-flight check");
+    my $initial_config = Zonemaster::Backend::Config->load_config();
+
+    Zonemaster::Backend::Metrics->setup($initial_config->METRICS_statsd_host, $initial_config->METRICS_statsd_port);
+
+    # Validate the Zonemaster-Engine profile
+    Zonemaster::Backend::TestAgent->new( { config => $initial_config } );
+
+    # Connect to the database
+    $initial_config->new_DB();
+    $log->debug("Completed pre-flight check");
+
+    return $initial_config;
+}
+
 
 # Initialize logging
 my $dispatcher;
@@ -206,18 +223,7 @@ Log::Any::Adapter->set( 'Dispatch', dispatcher => $dispatcher );
 # Make sure the environment is alright before forking
 my $initial_config;
 eval {
-    # Make sure we can load the configuration file
-    $log->debug("Starting pre-flight check");
-    $initial_config = Zonemaster::Backend::Config->load_config();
-
-    Zonemaster::Backend::Metrics->setup($initial_config->METRICS_statsd_host, $initial_config->METRICS_statsd_port);
-
-    # Validate the Zonemaster-Engine profile
-    Zonemaster::Backend::TestAgent->new( { config => $initial_config } );
-
-    # Connect to the database
-    $initial_config->new_DB();
-    $log->debug("Completed pre-flight check");
+    $initial_config = preflight_checks();
 };
 if ( $@ ) {
     $log->critical( "Aborting startup: $@" );

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -220,15 +220,18 @@ else {
 }
 Log::Any::Adapter->set( 'Dispatch', dispatcher => $dispatcher );
 
-# Make sure the environment is alright before forking
 my $initial_config;
-eval {
-    $initial_config = preflight_checks();
-};
-if ( $@ ) {
-    $log->critical( "Aborting startup: $@" );
-    print STDERR "Aborting startup: $@";
-    exit 1;
+
+# Make sure the environment is alright before forking (only on startup)
+if ( grep /start/, @ARGV ) {
+    eval {
+        $initial_config = preflight_checks();
+    };
+    if ( $@ ) {
+        $log->critical( "Aborting startup: $@" );
+        print STDERR "Aborting startup: $@";
+        exit 1;
+    }
 }
 
 ###

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -25,7 +25,7 @@ use sigtrap qw(die normal-signals);
 ###
 
 BEGIN {
-	$ENV{PERL_JSON_BACKEND} = 'JSON::PP';
+    $ENV{PERL_JSON_BACKEND} = 'JSON::PP';
 }
 
 # Enable immediate flush to stdout and stderr


### PR DESCRIPTION
## Purpose

The pre-flight checks were always run when calling `zonemaster_backend_testagent` daemon. If they fail the daemon stops without performing its task. Therefore the daemon cannot be properly stopped if the checks fail. This runs the checks only on daemon `start`.

## Context

Fixes #905

## Changes

Add a check before running pre-flight checks to run them only when calling the agent with the `start` parameter and bypass them for any other parameters.

## How to test this PR

see #905 description
