### PR TITLE
Bypass update of "progress" for batch tests

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -384,11 +384,10 @@ sub get_test_request {
         ( $id, $hash_id ) = $dbh->selectrow_array( q[ SELECT id, hash_id FROM test_results WHERE progress=0 ORDER BY priority DESC, id ASC LIMIT 1 ] );
     }
 
-    if ($id) {
-        $dbh->do( q[UPDATE test_results SET progress=1 WHERE id=?], undef, $id );
-        $result_id = $hash_id;
+    if ( $hash_id ) {
+        $self->test_progress( $hash_id, 1 );
     }
-    return $result_id;
+    return $hash_id;
 }
 
 sub get_test_params {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -376,18 +376,18 @@ sub get_test_request {
     my $result_id;
     my $dbh = $self->dbh;
 
-    my ( $id, $hash_id );
+    my ( $id, $hash_id, $batch_id );
     if ( defined $queue_label ) {
-        ( $id, $hash_id ) = $dbh->selectrow_array( qq[ SELECT id, hash_id FROM test_results WHERE progress=0 AND queue=? ORDER BY priority DESC, id ASC LIMIT 1 ], undef, $queue_label );
+        ( $id, $hash_id, $batch_id ) = $dbh->selectrow_array( qq[ SELECT id, hash_id, batch_id FROM test_results WHERE progress=0 AND queue=? ORDER BY priority DESC, id ASC LIMIT 1 ], undef, $queue_label );
     }
     else {
-        ( $id, $hash_id ) = $dbh->selectrow_array( q[ SELECT id, hash_id FROM test_results WHERE progress=0 ORDER BY priority DESC, id ASC LIMIT 1 ] );
+        ( $id, $hash_id, $batch_id ) = $dbh->selectrow_array( q[ SELECT id, hash_id, batch_id FROM test_results WHERE progress=0 ORDER BY priority DESC, id ASC LIMIT 1 ] );
     }
 
     if ( $hash_id ) {
         $self->test_progress( $hash_id, 1 );
     }
-    return $hash_id;
+    return ( $hash_id, $batch_id );
 }
 
 sub get_test_params {

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -65,8 +65,6 @@ sub run {
 
     my $params;
 
-    my $progress = $self->{_db}->test_progress( $test_id, 1 );
-
     $params = $self->{_db}->get_test_params( $test_id );
 
     my %methods = Zonemaster::Engine->all_methods;
@@ -172,7 +170,7 @@ sub run {
 
     $self->{_db}->test_results( $test_id, Zonemaster::Engine->logger->json( 'INFO' ) );
 
-    $progress = $self->{_db}->test_progress( $test_id );
+    $self->{_db}->test_progress( $test_id );
 
     return;
 } ## end sub run

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -58,7 +58,7 @@ sub new {
 }
 
 sub run {
-    my ( $self, $test_id ) = @_;
+    my ( $self, $test_id, $show_progress ) = @_;
     my @accumulator;
     my %counter;
     my %counter_for_progress_indicator;
@@ -124,7 +124,7 @@ sub run {
 
             $counter{ uc $entry->level } += 1;
         }
-    );
+    ) if ( $show_progress );
 
     if ( $params->{nameservers} && @{ $params->{nameservers} } > 0 ) {
         $self->add_fake_delegation( $domain, $params->{nameservers} );

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -172,8 +172,6 @@ sub run {
 
     $self->{_db}->test_results( $test_id, Zonemaster::Engine->logger->json( 'INFO' ) );
 
-    $self->{_db}->test_progress( $test_id );
-
     return;
 } ## end sub run
 

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -165,21 +165,21 @@ sub main {
         my $show_progress = defined $batch_id ? 0 : 1;
 
         if ( $test_id ) {
-            $log->info( "Test found: $test_id" );
+            $log->infof( "Test found: %s", $test_id );
             if ( $self->pm->start( $test_id ) == 0 ) {    # Forks off child process
-                $log->info( "Test starting: $test_id" );
+                $log->infof( "Test starting: %s", $test_id );
                 Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_started");
                 my $start_time = [ gettimeofday ];
                 eval { $agent->run( $test_id, $show_progress ) };
                 if ( $@ ) {
                     chomp $@;
                     Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_died");
-                    $log->error( "Test died: $test_id: $@" );
+                    $log->errorf( "Test died: %s: %s", $test_id, $@ );
                     $self->db->process_dead_test( $test_id )
                 }
                 else {
                     Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_completed");
-                    $log->info( "Test completed: $test_id" );
+                    $log->infof( "Test completed: %s", $test_id );
                 }
                 Zonemaster::Backend::Metrics::timing("zonemaster.testagent.tests_duration_seconds", tv_interval($start_time) * 1000);
                 $agent->reset();

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -147,14 +147,14 @@ sub main {
 
         my $fetch_test_timer = [ gettimeofday ];
 
-        my $id;
+        my $test_id;
         eval {
             $self->db->process_unfinished_tests(
                 $self->config->ZONEMASTER_lock_on_queue,
                 $self->config->ZONEMASTER_max_zonemaster_execution_time,
             );
 
-            $id = $self->db->get_test_request( $self->config->ZONEMASTER_lock_on_queue );
+            $test_id = $self->db->get_test_request( $self->config->ZONEMASTER_lock_on_queue );
 
             Zonemaster::Backend::Metrics::timing("zonemaster.testagent.fetchtests_duration_seconds", tv_interval($fetch_test_timer) * 1000);
         };
@@ -162,22 +162,22 @@ sub main {
             $log->error( $@ );
         }
 
-        if ( $id ) {
-            $log->info( "Test found: $id" );
-            if ( $self->pm->start( $id ) == 0 ) {    # Forks off child process
-                $log->info( "Test starting: $id" );
+        if ( $test_id ) {
+            $log->info( "Test found: $test_id" );
+            if ( $self->pm->start( $test_id ) == 0 ) {    # Forks off child process
+                $log->info( "Test starting: $test_id" );
                 Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_started");
                 my $start_time = [ gettimeofday ];
-                eval { $agent->run( $id ) };
+                eval { $agent->run( $test_id ) };
                 if ( $@ ) {
                     chomp $@;
                     Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_died");
-                    $log->error( "Test died: $id: $@" );
-                    $self->db->process_dead_test( $id )
+                    $log->error( "Test died: $test_id: $@" );
+                    $self->db->process_dead_test( $test_id )
                 }
                 else {
                     Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_completed");
-                    $log->info( "Test completed: $id" );
+                    $log->info( "Test completed: $test_id" );
                 }
                 Zonemaster::Backend::Metrics::timing("zonemaster.testagent.tests_duration_seconds", tv_interval($start_time) * 1000);
                 $agent->reset();

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -147,14 +147,14 @@ sub main {
 
         my $fetch_test_timer = [ gettimeofday ];
 
-        my $test_id;
+        my ( $test_id, $batch_id );
         eval {
             $self->db->process_unfinished_tests(
                 $self->config->ZONEMASTER_lock_on_queue,
                 $self->config->ZONEMASTER_max_zonemaster_execution_time,
             );
 
-            $test_id = $self->db->get_test_request( $self->config->ZONEMASTER_lock_on_queue );
+            ( $test_id, $batch_id ) = $self->db->get_test_request( $self->config->ZONEMASTER_lock_on_queue );
 
             Zonemaster::Backend::Metrics::timing("zonemaster.testagent.fetchtests_duration_seconds", tv_interval($fetch_test_timer) * 1000);
         };
@@ -162,13 +162,15 @@ sub main {
             $log->error( $@ );
         }
 
+        my $show_progress = defined $batch_id ? 0 : 1;
+
         if ( $test_id ) {
             $log->info( "Test found: $test_id" );
             if ( $self->pm->start( $test_id ) == 0 ) {    # Forks off child process
                 $log->info( "Test starting: $test_id" );
                 Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_started");
                 my $start_time = [ gettimeofday ];
-                eval { $agent->run( $test_id ) };
+                eval { $agent->run( $test_id, $show_progress ) };
                 if ( $@ ) {
                     chomp $@;
                     Zonemaster::Backend::Metrics::increment("zonemaster.testagent.tests_died");

--- a/t/test01.t
+++ b/t/test01.t
@@ -154,7 +154,7 @@ subtest 'add a first test' => sub {
 };
 
 subtest 'get and run test' => sub {
-    my $hash_id_from_db = $backend->{db}->get_test_request();
+    my ( $hash_id_from_db ) = $backend->{db}->get_test_request();
     is( $hash_id_from_db, $hash_id, 'Get correct test to run' );
 
     my $progress = $backend->test_progress( { test_id => $hash_id } );
@@ -312,7 +312,7 @@ subtest 'get_test_history' => sub {
 
         # create the test, retrieve its id but we don't run it
         $backend->start_domain_test( $params );
-        $hash_id = $backend->{db}->get_test_request();
+        ( $hash_id ) = $backend->{db}->get_test_request();
 
         $test_history = $backend->get_test_history( $method_params );
         #diag explain( $test_history );


### PR DESCRIPTION
## Purpose

When running batches, updating the `progress` while the test is running will perform a lot of unnecessary database writes which may lead to performance issues. This remove the `progress` database update for a test with a `batch_id`.

## Context

Addresses #274

## Changes

Extract the `batch_id` of a test when retrieving the next test so that we can check if the test belongs to a batch or not and bypass the `progress` update or not.

## How to test this PR

Create a batch job and check that the `progress` of each test goes from 0 to 1 and then from 1 to 100 without any steps.
Create a test and check that the `progress` of the test goes from 0 to 1 and then gradually until 100.
