### PR TITLE
Fix travis-perl error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,9 @@ before_install:
   - export PERL5LIB=/usr/share/perl5
 
     # Provide cpanm helper
-    # the eval call combines all lines into one, therefore comments should be
-    # removed before executing the script
-  - eval $(curl https://travis-perl.github.io/init | grep -v '#') --auto
+    # quoting preserves newlines in the script and then avoid error when
+    # the script contains comments
+  - eval "$(curl https://travis-perl.github.io/init)" --auto
 
     # Zonemaster LDNS needs a newer version of Module::Install
   - cpan-install Module::Install Module::Install::XSUtil

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,8 @@ before_install:
   - export PERL5LIB=/usr/share/perl5
 
     # Provide cpanm helper
+    # the eval call combines all lines into one, therefore comments should be
+    # removed before executing the script
   - eval $(curl https://travis-perl.github.io/init | grep -v '#') --auto
 
     # Zonemaster LDNS needs a newer version of Module::Install

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ before_install:
   - export PERL5LIB=/usr/share/perl5
 
     # Provide cpanm helper
-  - eval $(curl https://travis-perl.github.io/init) --auto
+  - eval $(curl https://travis-perl.github.io/init | grep -v '#') --auto
 
     # Zonemaster LDNS needs a newer version of Module::Install
   - cpan-install Module::Install Module::Install::XSUtil


### PR DESCRIPTION
An update in travis-perl added comment to the init file. This makes the `eval` call fail because the script become a one-liner in this case with a comment in the middle.

This PR is about removing commented lines from the script before running it.

https://github.com/travis-perl/travis-perl.github.io/commit/34d18cc150497a00dc7719fea2472c183e6607ad
    
Credits to @blacksponge 