### PR TITLE
Do not expose database primary key

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -932,7 +932,6 @@ Example response:
   "result": {
     "creation_time": "2016-11-15 11:53:13.965982",
     "created_at": "2016-11-15T11:53:13Z",
-    "id": 25,
     "hash_id": "c45a3f8256c4a155",
     "params": {
       "ds_info": [],
@@ -991,7 +990,6 @@ An object with the following properties:
   The time in UTC at which the *test* was created.
 * `"created_at"`: A [*timestamp*][Timestamp]. The time in UTC at which the *test*
   was created.
-* `"id"`: **Deprecated** (planned removal: v2022.2). An integer.
 * `"hash_id"`: A [*test id*][Test id]. The *test* in question.
 * `"params"`: See below.
   `start_domain_test` when the *test* was started.

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -269,7 +269,6 @@ sub select_test_results {
     my ( $hrefs ) = $self->dbh->selectall_hashref(
         q[
             SELECT
-                id,
                 hash_id,
                 created_at AS creation_time,
                 params,

--- a/t/test01.t
+++ b/t/test01.t
@@ -118,7 +118,7 @@ subtest 'API calls' => sub {
 
     subtest 'get_test_results' => sub {
         my $res = $rpcapi->get_test_results( { id => $hash_id, language => 'en_US' } );
-        is( $res->{id}, $test_id, 'Retrieve the correct "id"' );
+        ok( ! defined $res->{id}, 'Do not expose primary key' );
         is( $res->{hash_id}, $hash_id, 'Retrieve the correct "hash_id"' );
         ok( defined $res->{params}, 'Value "params" properly defined' );
         ok( defined $res->{creation_time}, 'Value "creation_time" properly defined' );


### PR DESCRIPTION
## Purpose

There is no use of the database `id` since we have implemented the `hash_id`. Therefore, I think it is safe and good that we remove the `id` from the results in the `get_test_results` method.

## Context

Follows deprecation done in #949 (v2022.1).

## Changes

Update the API `get_test_results` method.

## How to test this PR

A call `get_test_results` should not give the database `id` of the test, but only its `hash_id`.
