### PR TITLE
Deprecate the result 'id' field in get_test_results

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -982,7 +982,7 @@ An object with the following properties:
 #### `"result"`
 
 * `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued (in UTC).
-* `"id"`: An integer.
+* `"id"`: **Deprecated**. An integer.
 * `"hash_id"`: A *test id*. The *test* in question.
 * `"params"`: See below.
   `start_domain_test` when the *test* was started.

--- a/docs/API.md
+++ b/docs/API.md
@@ -982,7 +982,7 @@ An object with the following properties:
 #### `"result"`
 
 * `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued (in UTC).
-* `"id"`: **Deprecated**. An integer.
+* `"id"`: **Deprecated** (will be removed in v2022.2). An integer.
 * `"hash_id"`: A *test id*. The *test* in question.
 * `"params"`: See below.
   `start_domain_test` when the *test* was started.


### PR DESCRIPTION
## Purpose

The "id" field in the "result" object is leaking the PRIMARY KEY from the database. It should then be removed from the results. Furthermore there is no use of it.

In order to properly remove this field from the results, it needs to be deprecated first.

## Context

As discussed in #946, the field should be first documented as _Deprecated_.

## Changes

Deprecate the "id" field from the "result" object in `get_test_results`.

## How to test this PR

Documentation only
