### PR TITLE
Testagent survive database connection failure

### DIFF
--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -149,11 +149,12 @@ sub main {
 
         my $fetch_test_timer = [ gettimeofday ];
 
-        my $id = $self->db->get_test_request( $self->config->ZONEMASTER_lock_on_queue );
         $self->db->process_unfinished_tests(
             $self->config->ZONEMASTER_lock_on_queue,
             $self->config->ZONEMASTER_max_zonemaster_execution_time,
         );
+
+        my $id = $self->db->get_test_request( $self->config->ZONEMASTER_lock_on_queue );
 
         Zonemaster::Backend::Metrics::timing("zonemaster.testagent.fetchtests_duration_seconds", tv_interval($fetch_test_timer) * 1000);
 

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -149,14 +149,20 @@ sub main {
 
         my $fetch_test_timer = [ gettimeofday ];
 
-        $self->db->process_unfinished_tests(
-            $self->config->ZONEMASTER_lock_on_queue,
-            $self->config->ZONEMASTER_max_zonemaster_execution_time,
-        );
+        my $id;
+        eval {
+            $self->db->process_unfinished_tests(
+                $self->config->ZONEMASTER_lock_on_queue,
+                $self->config->ZONEMASTER_max_zonemaster_execution_time,
+            );
 
-        my $id = $self->db->get_test_request( $self->config->ZONEMASTER_lock_on_queue );
+            $id = $self->db->get_test_request( $self->config->ZONEMASTER_lock_on_queue );
 
-        Zonemaster::Backend::Metrics::timing("zonemaster.testagent.fetchtests_duration_seconds", tv_interval($fetch_test_timer) * 1000);
+            Zonemaster::Backend::Metrics::timing("zonemaster.testagent.fetchtests_duration_seconds", tv_interval($fetch_test_timer) * 1000);
+        };
+        if ( $@ ) {
+            $log->error( $@ );
+        }
 
         if ( $id ) {
             $log->info( "Test found: $id" );


### PR DESCRIPTION
## Purpose

Prevent crash of the TestAgent if the database becomes unavailable.

## Context

Addresses #878 

## Changes

Catch database connection error when retrieving next test to run.

## How to test this PR

For the error related to #878
1. start the testagent daemon
2. stop the MySQL or PostgreSQL server
3. the testagent daemon should still be running and an error should be logged every `DB.polling_interval` seconds