### PR TITLE
overload the string operator for errors

### DIFF
--- a/lib/Zonemaster/Backend/Errors.pm
+++ b/lib/Zonemaster/Backend/Errors.pm
@@ -2,6 +2,7 @@ package Zonemaster::Backend::Error;
 use Moose;
 use Data::Dumper;
 
+use overload '""' => \&as_string;
 
 has 'message' => (
     is => 'ro',
@@ -52,6 +53,8 @@ sub _data_dump {
 
 package Zonemaster::Backend::Error::Internal;
 use Moose;
+
+use overload '""' => \&as_string;
 
 extends 'Zonemaster::Backend::Error';
 


### PR DESCRIPTION
## Purpose

Improve display of error

## Context

#933

## Changes

* Overload the string operator for Errors objects

## How to test this PR

* Use the sqlite or mysql db engine
* Create a test using the RPCAPI
* Alter the `params` field in the db to make it an invalid JSON object
* Run the test agent
* Check that a informative error message is displayed

Example:

```
2022-03-02T09:23:02Z [82595] INFO - Test starting: 08c673d5197dc6b6
2022-03-02T09:23:02Z [82595] NOTICE - Connecting to database 'DBI:SQLite:dbname=/workspace/zonemaster/db.sqlite'
2022-03-02T09:23:02Z [82595] ERROR - Test died: 08c673d5197dc6b6: Caught Zonemaster::Backend::Error::JsonError in the `Zonemaster::Backend::DB::get_test_params` method: , or } expected while parsing object/hash, at character offset 126 (before "(end of string)") at /workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB.pm line 266. Context: {'test_id' => '08c673d5197dc6b6'}
```
