### PR TITLE
Allow DB adapter consturction without actually connecting

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -47,7 +47,7 @@ has 'password' => (
 
 has 'dbhandle' => (
     is       => 'rw',
-    isa      => 'DBI::db',
+    isa      => 'Maybe[DBI::db]',
     required => 1,
 );
 
@@ -73,7 +73,7 @@ sub get_db_class {
 sub dbh {
     my ( $self ) = @_;
 
-    if ( !$self->dbhandle->ping ) {
+    if ( !$self->dbhandle || !$self->dbhandle->ping ) {
         my $dbh = $self->_new_dbh(    #
             $self->data_source_name,
             $self->user,

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -39,18 +39,12 @@ sub from_config {
 
     my $data_source_name = "DBI:mysql:database=$database;host=$host;port=$port";
 
-    my $dbh = $class->_new_dbh(
-        $data_source_name,
-        $user,
-        $password,
-    );
-
     return $class->new(
         {
             data_source_name => $data_source_name,
             user             => $user,
             password         => $password,
-            dbhandle         => $dbh,
+            dbhandle         => undef,
         }
     );
 }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -36,18 +36,12 @@ sub from_config {
 
     my $data_source_name = "DBI:Pg:dbname=$database;host=$host;port=$port";
 
-    my $dbh = $class->_new_dbh(
-        $data_source_name,
-        $user,
-        $password,
-    );
-
     return $class->new(
         {
             data_source_name => $data_source_name,
             user             => $user,
             password         => $password,
-            dbhandle         => $dbh,
+            dbhandle         => undef,
         }
     );
 }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -30,14 +30,12 @@ sub from_config {
 
     my $data_source_name = "DBI:SQLite:dbname=$file";
 
-    my $dbh = $class->_new_dbh( $data_source_name, '', '' );
-
     return $class->new(
         {
             data_source_name => $data_source_name,
             user             => '',
             password         => '',
-            dbhandle         => $dbh,
+            dbhandle         => undef,
         }
     );
 }

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -133,8 +133,6 @@ sub main {
     local $SIG{TERM} = $catch_sigterm;
 
     my $agent = Zonemaster::Backend::TestAgent->new( { config => $self->config } );
-    # Disconnect from database in parent to avoid sharing the connection between children
-    $agent->{_db}->dbh->disconnect;
 
     while ( !$caught_sigterm ) {
         my $cleanup_timer = [ gettimeofday ];


### PR DESCRIPTION
## Purpose

Remove double connection to the database on startup.

## Context

This came up as an alternative solution to a drive-by fix in #955.

## Changes

This PR decouples the opening of database connections from the construction of Zonemaster::Backend::RPCAPI and Zonemaster::Backend::TestAgent instances. This allow us greater flexibility in how we can express initialization code for our daemons and it also makes the initialization code more understandable.

## How to test this PR

Run the [smoke test](https://github.com/zonemaster/zonemaster-backend/blob/develop/docs/Installation.md#61-smoke-test).