### PR TITLE
Small fixes testagent

### DIFF
--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -12,6 +12,7 @@ use Daemon::Control;
 use Log::Any qw( $log );
 use Log::Any::Adapter;
 use Log::Dispatch;
+use Log::Dispatch::Vars qw( %CanonicalLevelNames );
 
 use English;
 use Pod::Usage;
@@ -60,7 +61,7 @@ $opt_outfile //= '/var/log/zonemaster/zonemaster_backend_testagent.out';
 $loglevel    //= 'info';
 $loglevel = lc $loglevel;
 
-$loglevel =~ /^(?:trace|debug|info|inform|notice|warning|warn|error|err|critical|crit|fatal|alert|emergency)$/ or die "Error: Unrecognized --loglevel $loglevel\n";
+die "Error: Unrecognized --loglevel $loglevel\n" unless exists $CanonicalLevelNames{$loglevel};
 
 # Returns a Log::Dispatch object logging to STDOUT
 #
@@ -305,7 +306,7 @@ When FILE is -, the log is written to standard output.
 
 The location of the log level to use.
 
-The allowed values are specified at L<Log::Any/LOG-LEVELS>.
+The allowed values are specified at L<Log::Dispatch/LOG-LEVELS>.
 
 =item B<COMMAND>
 

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -224,7 +224,7 @@ Log::Any::Adapter->set( 'Dispatch', dispatcher => $dispatcher );
 my $initial_config;
 
 # Make sure the environment is alright before forking (only on startup)
-if ( grep /start/, @ARGV ) {
+if ( grep /^foreground$|^restart$|^start$/, @ARGV ) {
     eval {
         $initial_config = preflight_checks();
     };


### PR DESCRIPTION
## Purpose

Fix a couple of inconsistencies in the test agent script

## Context


## Changes

* Uses Log::Dispatch log levels for validation (more or less a subset the Log::Any levels), to avoid a crash because of a bad log level.
* Run preflight checks on both `start` and `foreground`.

## How to test this PR

* `perl script/zonemaster_backend_testagent --logfile=- --outfile=/tmp/zonemaster_testagent.out --loglevel=trace foreground` Return `Error: Unrecognized --loglevel trace` and not a stack trace.
* `perl script/zonemaster_backend_testagent --logfile=- --outfile=/tmp/zonemaster_testagent.out --loglevel=debug foreground` Show the `Starting pre-flight check` log message.
