### PR TITLE
Use Perl time on test creation

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -140,7 +140,18 @@ sub create_new_test {
     else {
         $hash_id = substr(md5_hex($now.rand()), 0, 16);
         $dbh->do(
-            "INSERT INTO test_results (hash_id, batch_id, priority, queue, fingerprint, params, domain, undelegated) VALUES (?,?,?,?,?,?,?,?)",
+            q[
+                INSERT INTO test_results (
+                    hash_id,
+                    batch_id,
+                    priority,
+                    queue,
+                    fingerprint,
+                    params,
+                    domain,
+                    undelegated
+                ) VALUES (?,?,?,?,?,?,?,?,?)
+            ],
             undef,
             $hash_id,
             $batch_id,

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -144,6 +144,7 @@ sub create_new_test {
                 INSERT INTO test_results (
                     hash_id,
                     batch_id,
+                    creation_time,
                     priority,
                     queue,
                     fingerprint,
@@ -155,6 +156,7 @@ sub create_new_test {
             undef,
             $hash_id,
             $batch_id,
+            $self->format_time( time() ),
             $priority,
             $queue_label,
             $fingerprint,

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -324,7 +324,22 @@ sub add_batch_job {
         $dbh->do( "DROP INDEX IF EXISTS test_results__progress" );
         $dbh->do( "DROP INDEX IF EXISTS test_results__domain_undelegated" );
 
-        $dbh->do( "COPY test_results(hash_id,domain ,batch_id, priority, queue, fingerprint, params, undelegated) FROM STDIN" );
+        $dbh->do(
+            q[
+                COPY test_results (
+                    hash_id,
+                    domain,
+                    batch_id,
+                    priority,
+                    queue,
+                    fingerprint,
+                    params,
+                    undelegated
+                )
+                FROM STDIN
+            ]
+        );
+
         foreach my $domain ( @{$params->{domains}} ) {
             $test_params->{domain} = $domain;
 

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -316,6 +316,8 @@ sub add_batch_job {
         my $priority    = $test_params->{priority};
         my $queue_label = $test_params->{queue};
 
+        my $creation_time = $self->format_time( time() );
+
         $dbh->begin_work();
         $dbh->do( "ALTER TABLE test_results DROP CONSTRAINT IF EXISTS test_results_pkey" );
         $dbh->do( "DROP INDEX IF EXISTS test_results__hash_id" );
@@ -330,6 +332,7 @@ sub add_batch_job {
                     hash_id,
                     domain,
                     batch_id,
+                    creation_time,
                     priority,
                     queue,
                     fingerprint,
@@ -348,7 +351,9 @@ sub add_batch_job {
             my $undelegated = $self->undelegated ( $test_params );
 
             my $hash_id = substr(md5_hex(time().rand()), 0, 16);
-            $dbh->pg_putcopydata("$hash_id\t$test_params->{domain}\t$batch_id\t$priority\t$queue_label\t$fingerprint\t$encoded_params\t$undelegated\n");
+            $dbh->pg_putcopydata(
+                "$hash_id\t$test_params->{domain}\t$batch_id\t$creation_time\t$priority\t$queue_label\t$fingerprint\t$encoded_params\t$undelegated\n"
+            );
         }
         $dbh->pg_putcopyend();
         $dbh->do( "ALTER TABLE test_results ADD PRIMARY KEY (id)" );


### PR DESCRIPTION
## Purpose

From #769 

> N.B. The database schemas still use references to NOW() in default value definitions for certain fields, but all insert queries are updated to make sure that those default values are never used.

It seems we missed some insert queries. This PR fixes that.

## Context

Follow-up on #769

## Changes

Set the `creation_time` with Perl time.

## How to test this PR

Check that all `creation_time` in database are UTC.
