### PR TITLE
Store times in UTC in database

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -985,7 +985,7 @@ There are two different results depending on the test creation method:
 
 In the case of a test created with `start_domain_test`:
 
-* `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued.
+* `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued (in UTC).
 * `"id"`: An integer.
 * `"hash_id"`: A *test id*. The *test* in question.
 * `"params"`: A normalized version `"params"` object sent to
@@ -994,7 +994,7 @@ In the case of a test created with `start_domain_test`:
 
 
 In the case of a test created with `add_batch_job`:
-* `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued.
+* `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued (in UTC).
 * `"id"`: An integer.
 * `"hash_id"`: A *test id*. The *test* in question.
 * `"params"`: A normalized version `"params"` object sent to `add_batch_job`
@@ -1089,7 +1089,7 @@ The value of "frontend_params" is an object with the following properties:
 An object with the following properties:
 
 * `"id"` A *test id*.
-* `"creation_time"`: A *timestamp*. Time when the Test was enqueued.
+* `"creation_time"`: A *timestamp*. The time at which the *test* was enqueued (in UTC).
 * `"overall_result"`: A string. It reflects the most severe problem level among
   the test results for the test. It has one of the following values:
   * `"ok"`, if there are only messages with *severity level* `"INFO"` or

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -14,6 +14,8 @@ single *Database*, a single *Test Agent* and one or more *RPC API daemons*.
 The *Database* stores health check requests and results. The *Backend*
 architecture is oriented around a single central *Database*.
 
+All times in the database are stored in UTC.
+
 
 ### Test Agent
 

--- a/docs/Upgrade.md
+++ b/docs/Upgrade.md
@@ -50,7 +50,8 @@ Current Zonemaster::Backend version | Link to instructions | Comments
  1.1.0 ≤ version < 5.0.0            | [Upgrade to 5.0.0]   |
  5.0.0 ≤ version < 5.0.2            | [Upgrade to 5.0.2]   | For MySQL/MariaDB only
  5.0.2 ≤ version < 8.0.0            | [Upgrade to 8.0.0]   |
- 8.0.0                              | -                    | No special steps needed for upgrade
+ 8.0.0 ≤ version < 8.2.0            | [Upgrade to 8.2.0]   |
+ 8.2.0 ≤ version                    | -                    | No special steps needed for upgrade
 
 ## 4. Find current version
 
@@ -69,4 +70,5 @@ perl -E 'use Zonemaster::Backend; say $Zonemaster::Backend::VERSION;'
 [Upgrade to 5.0.0]:  upgrade/upgrade_zonemaster_backend_ver_5.0.0.md
 [Upgrade to 5.0.2]:  upgrade/upgrade_zonemaster_backend_ver_5.0.2.md
 [Upgrade to 8.0.0]:  upgrade/upgrade_zonemaster_backend_ver_8.0.0.md
+[Upgrade to 8.2.0]:  upgrade/upgrade_zonemaster_backend_ver_8.2.0.md
 [Zonemaster::Engine installation]: https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md

--- a/docs/upgrade/upgrade_zonemaster_backend_ver_8.2.0.md
+++ b/docs/upgrade/upgrade_zonemaster_backend_ver_8.2.0.md
@@ -1,0 +1,13 @@
+# Upgrade to 8.2.0
+
+## Upgrading the database
+
+If your Zonemaster database was created by a Zonemaster-Backend version smaller
+than v8.2.0, and not upgraded, use the following instruction.
+
+> You may need to run the command with root privileges.
+
+```sh
+cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`
+perl patch/patch_db_zonemaster_backend_ver_8.2.0.pl
+```

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -21,10 +21,8 @@ requires qw(
   drop_tables
   from_config
   get_test_history
-  process_unfinished_tests_give_up
   get_dbh_specific_attributes
   select_test_results
-  test_progress
   get_relative_start_time
 );
 
@@ -208,6 +206,46 @@ sub recent_test_hash_id {
     );
 
     return $recent_hash_id;
+}
+
+sub test_progress {
+    my ( $self, $test_id, $progress ) = @_;
+
+    my $dbh = $self->dbh;
+    if ( $progress ) {
+        if ( $progress == 1 ) {
+            $dbh->do(
+                q[
+                    UPDATE test_results
+                    SET progress = ?,
+                        test_start_time = ?
+                    WHERE hash_id = ?
+                      AND progress <> 100
+                ],
+                undef,
+                $progress,
+                $self->format_time( time() ),
+                $test_id,
+            );
+        }
+        else {
+            $dbh->do(
+                q[
+                    UPDATE test_results
+                    SET progress = ?
+                    WHERE hash_id = ?
+                      AND progress <> 100
+                ],
+                undef,
+                $progress,
+                $test_id,
+            );
+        }
+    }
+
+    my ( $result ) = $self->dbh->selectrow_array( "SELECT progress FROM test_results WHERE hash_id=?", undef, $test_id );
+
+    return $result;
 }
 
 sub test_results {
@@ -453,7 +491,20 @@ sub force_end_test {
         "tag"       => "UNABLE_TO_FINISH_TEST",
         "timestamp" => $timestamp,
         };
-    $self->process_unfinished_tests_give_up($result, $hash_id);
+
+    $self->dbh->do(
+        q[
+            UPDATE test_results
+            SET progress = 100,
+                test_end_time = ?,
+                results = ?
+            WHERE hash_id = ?
+        ],
+        undef,
+        $self->format_time( time() ),
+        encode_json($result),
+        $hash_id,
+    );
 }
 
 sub process_dead_test {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -22,7 +22,6 @@ requires qw(
   from_config
   get_test_history
   get_dbh_specific_attributes
-  select_test_results
   get_relative_start_time
 );
 
@@ -244,6 +243,33 @@ sub test_progress {
     }
 
     my ( $result ) = $self->dbh->selectrow_array( "SELECT progress FROM test_results WHERE hash_id=?", undef, $test_id );
+
+    return $result;
+}
+
+sub select_test_results {
+    my ( $self, $test_id ) = @_;
+
+    my ( $hrefs ) = $self->dbh->selectall_hashref(
+        q[
+            SELECT
+                id,
+                hash_id,
+                creation_time,
+                params,
+                results
+            FROM test_results
+            WHERE hash_id = ?
+        ],
+        'hash_id',
+        undef,
+        $test_id
+    );
+
+    my $result = $hrefs->{$test_id};
+
+    die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } )
+        unless defined $result;
 
     return $result;
 }

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -67,9 +67,9 @@ sub create_schema {
             hash_id VARCHAR(16) NOT NULL,
             domain varchar(255) NOT NULL,
             batch_id integer NULL,
-            creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-            test_start_time TIMESTAMP NULL DEFAULT NULL,
-            test_end_time TIMESTAMP NULL DEFAULT NULL,
+            creation_time DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+            test_start_time DATETIME NULL DEFAULT NULL,
+            test_end_time DATETIME NULL DEFAULT NULL,
             priority integer DEFAULT 10,
             queue integer DEFAULT 0,
             progress integer DEFAULT 0,
@@ -121,7 +121,7 @@ sub create_schema {
         'CREATE TABLE IF NOT EXISTS batch_jobs (
             id integer AUTO_INCREMENT PRIMARY KEY,
             username character varying(50) NOT NULL,
-            creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+            creation_time DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL
         ) ENGINE=InnoDB;
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'batch_jobs' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -158,46 +158,6 @@ sub drop_tables {
     return;
 }
 
-sub test_progress {
-    my ( $self, $test_id, $progress ) = @_;
-
-    my $dbh = $self->dbh;
-    if ( $progress ) {
-        if ( $progress == 1 ) {
-            $dbh->do(
-                q[
-                    UPDATE test_results
-                    SET progress = ?,
-                        test_start_time = ?
-                    WHERE hash_id = ?
-                      AND progress <> 100
-                ],
-                undef,
-                $progress,
-                $self->format_time( time() ),
-                $test_id,
-            );
-        }
-        else {
-            $dbh->do(
-                q[
-                    UPDATE test_results
-                    SET progress = ?
-                    WHERE hash_id = ?
-                      AND progress <> 100
-                ],
-                undef,
-                $progress,
-                $test_id,
-            );
-        }
-    }
-
-    my ( $result ) = $self->dbh->selectrow_array( "SELECT progress FROM test_results WHERE hash_id=?", undef, $test_id );
-
-    return $result;
-}
-
 sub select_test_results {
     my ( $self, $test_id ) = @_;
 
@@ -356,24 +316,6 @@ sub add_batch_job {
     }
 
     return $batch_id;
-}
-
-sub process_unfinished_tests_give_up {
-    my ( $self, $result, $hash_id ) = @_;
-
-    $self->dbh->do(
-        q[
-            UPDATE test_results
-            SET progress = 100,
-                test_end_time = ?,
-                results = ?
-            WHERE hash_id = ?
-        ],
-        undef,
-        $self->format_time( time() ),
-        encode_json( $result ),
-        $hash_id,
-    );
 }
 
 sub get_relative_start_time {

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -67,9 +67,9 @@ sub create_schema {
             hash_id VARCHAR(16) NOT NULL,
             domain varchar(255) NOT NULL,
             batch_id integer NULL,
-            creation_time DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
-            test_start_time DATETIME NULL DEFAULT NULL,
-            test_end_time DATETIME NULL DEFAULT NULL,
+            creation_time DATETIME NOT NULL,
+            test_start_time DATETIME DEFAULT NULL,
+            test_end_time DATETIME DEFAULT NULL,
             priority integer DEFAULT 10,
             queue integer DEFAULT 0,
             progress integer DEFAULT 0,
@@ -121,7 +121,7 @@ sub create_schema {
         'CREATE TABLE IF NOT EXISTS batch_jobs (
             id integer AUTO_INCREMENT PRIMARY KEY,
             username character varying(50) NOT NULL,
-            creation_time DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL
+            creation_time DATETIME NOT NULL
         ) ENGINE=InnoDB;
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'batch_jobs' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -158,33 +158,6 @@ sub drop_tables {
     return;
 }
 
-sub select_test_results {
-    my ( $self, $test_id ) = @_;
-
-    my ( $hrefs ) = $self->dbh->selectall_hashref(
-        q[
-            SELECT
-                id,
-                hash_id,
-                creation_time,
-                params,
-                results
-            FROM test_results
-            WHERE hash_id = ?
-        ],
-        'hash_id',
-        undef,
-        $test_id
-    );
-
-    my $result = $hrefs->{$test_id};
-
-    die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } )
-        unless defined $result;
-
-    return $result;
-}
-
 sub get_test_history {
     my ( $self, $p ) = @_;
 

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -166,7 +166,7 @@ sub select_test_results {
             SELECT
                 id,
                 hash_id,
-                CONVERT_TZ(`creation_time`, @@session.time_zone, '+00:00') AS creation_time,
+                creation_time,
                 params,
                 results
             FROM test_results
@@ -202,7 +202,7 @@ sub get_test_history {
         SELECT
             id,
             hash_id,
-            CONVERT_TZ(`creation_time`, @@session.time_zone, '+00:00') AS creation_time,
+            creation_time,
             undelegated,
             results
         FROM test_results

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -156,36 +156,6 @@ sub drop_tables {
     return;
 }
 
-sub test_progress {
-    my ( $self, $test_id, $progress ) = @_;
-
-    my $dbh = $self->dbh;
-    if ( $progress ) {
-        if ( $progress == 1 ) {
-            $dbh->do(
-                q[
-                    UPDATE test_results
-                    SET progress = ?,
-                        test_start_time = ?
-                    WHERE hash_id = ?
-                      AND progress <> 100
-                ],
-                undef,
-                $progress,
-                $self->format_time( time() ),
-                $test_id,
-            );
-        }
-        else {
-            $dbh->do( "UPDATE test_results SET progress=? WHERE hash_id=? AND progress <> 100", undef, $progress, $test_id );
-        }
-    }
-
-    my ( $result ) = $dbh->selectrow_array( "SELECT progress FROM test_results WHERE hash_id=?", undef, $test_id );
-
-    return $result;
-}
-
 sub select_test_results {
     my ( $self, $test_id ) = @_;
 
@@ -345,24 +315,6 @@ sub add_batch_job {
     }
 
     return $batch_id;
-}
-
-sub process_unfinished_tests_give_up {
-    my ( $self, $result, $hash_id ) = @_;
-
-    $self->dbh->do(
-        q[
-            UPDATE test_results
-            SET progress = 100,
-                test_end_time = ?,
-                results = ?
-            WHERE hash_id = ?
-        ],
-        undef,
-        $self->format_time( time() ),
-        encode_json($result),
-        $hash_id,
-    );
 }
 
 sub get_relative_start_time {

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -7,7 +7,6 @@ use 5.14.2;
 
 use DBI qw(:utils :sql_types);
 use Digest::MD5 qw(md5_hex);
-use Encode;
 use JSON::PP;
 use Try::Tiny;
 

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -164,7 +164,7 @@ sub select_test_results {
             SELECT
                 id,
                 hash_id,
-                creation_time at time zone current_setting('TIMEZONE') at time zone 'UTC' as creation_time,
+                creation_time,
                 params,
                 results
             FROM test_results
@@ -204,7 +204,7 @@ sub get_test_history {
             id,
             hash_id,
             undelegated,
-            creation_time at time zone current_setting('TIMEZONE') at time zone 'UTC' as creation_time
+            creation_time
         FROM test_results
         WHERE progress = 100 AND domain = ? AND ( ? IS NULL OR undelegated = ? )
         ORDER BY id DESC

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -156,33 +156,6 @@ sub drop_tables {
     return;
 }
 
-sub select_test_results {
-    my ( $self, $test_id ) = @_;
-
-    my ( $hrefs ) = $self->dbh->selectall_hashref(
-        q[
-            SELECT
-                id,
-                hash_id,
-                creation_time,
-                params,
-                results
-            FROM test_results
-            WHERE hash_id = ?
-        ],
-        'hash_id',
-        undef,
-        $test_id
-    );
-
-    my $result = $hrefs->{$test_id};
-
-    die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } )
-        unless defined $result;
-
-    return $result;
-}
-
 sub get_test_history {
     my ( $self, $p ) = @_;
 

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -65,9 +65,9 @@ sub create_schema {
                 hash_id VARCHAR(16) NOT NULL,
                 domain VARCHAR(255) NOT NULL,
                 batch_id integer,
-                creation_time timestamp without time zone DEFAULT NOW() NOT NULL,
-                test_start_time timestamp without time zone DEFAULT NULL,
-                test_end_time timestamp without time zone DEFAULT NULL,
+                creation_time TIMESTAMP DEFAULT NOW() NOT NULL,
+                test_start_time TIMESTAMP DEFAULT NULL,
+                test_end_time TIMESTAMP DEFAULT NULL,
                 priority integer DEFAULT 10,
                 queue integer DEFAULT 0,
                 progress integer DEFAULT 0,
@@ -108,7 +108,7 @@ sub create_schema {
         'CREATE TABLE IF NOT EXISTS batch_jobs (
                 id serial PRIMARY KEY,
                 username varchar(50) NOT NULL,
-                creation_time timestamp without time zone DEFAULT NOW() NOT NULL
+                creation_time TIMESTAMP DEFAULT NOW() NOT NULL
             )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'batch_jobs' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -65,7 +65,7 @@ sub create_schema {
                 hash_id VARCHAR(16) NOT NULL,
                 domain VARCHAR(255) NOT NULL,
                 batch_id integer,
-                creation_time TIMESTAMP DEFAULT NOW() NOT NULL,
+                creation_time TIMESTAMP NOT NULL,
                 test_start_time TIMESTAMP DEFAULT NULL,
                 test_end_time TIMESTAMP DEFAULT NULL,
                 priority integer DEFAULT 10,
@@ -108,7 +108,7 @@ sub create_schema {
         'CREATE TABLE IF NOT EXISTS batch_jobs (
                 id serial PRIMARY KEY,
                 username varchar(50) NOT NULL,
-                creation_time TIMESTAMP DEFAULT NOW() NOT NULL
+                creation_time TIMESTAMP NOT NULL
             )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'batch_jobs' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -63,7 +63,7 @@ sub create_schema {
                  hash_id VARCHAR(16) NOT NULL,
                  domain VARCHAR(255) NOT NULL,
                  batch_id integer NULL,
-                 creation_time DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                 creation_time DATETIME NOT NULL,
                  test_start_time DATETIME DEFAULT NULL,
                  test_end_time DATETIME DEFAULT NULL,
                  priority integer DEFAULT 10,
@@ -101,7 +101,7 @@ sub create_schema {
         'CREATE TABLE IF NOT EXISTS batch_jobs (
                  id integer PRIMARY KEY,
                  username character varying(50) NOT NULL,
-                 creation_time DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL
+                 creation_time DATETIME NOT NULL
            )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'batch_jobs' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -138,33 +138,6 @@ sub drop_tables {
     return;
 }
 
-sub select_test_results {
-    my ( $self, $test_id ) = @_;
-
-    my ( $hrefs ) = $self->dbh->selectall_hashref(
-        q[
-            SELECT
-                id,
-                hash_id,
-                creation_time,
-                params,
-                results
-            FROM test_results
-            WHERE hash_id = ?
-        ],
-        'hash_id',
-        undef,
-        $test_id
-    );
-
-    my $result = $hrefs->{$test_id};
-
-    die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } )
-        unless defined $result;
-
-    return $result;
-}
-
 sub get_test_history {
     my ( $self, $p ) = @_;
 

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -138,46 +138,6 @@ sub drop_tables {
     return;
 }
 
-sub test_progress {
-    my ( $self, $test_id, $progress ) = @_;
-
-    my $dbh = $self->dbh;
-    if ( $progress ) {
-        if ( $progress == 1 ) {
-            $dbh->do(
-                q[
-                    UPDATE test_results
-                    SET progress = ?,
-                        test_start_time = ?
-                    WHERE hash_id = ?
-                      AND progress <> 100
-                ],
-                undef,
-                $progress,
-                $self->format_time( time() ),
-                $test_id,
-            );
-        }
-        else {
-            $dbh->do(
-                q[
-                    UPDATE test_results
-                    SET progress = ?
-                    WHERE hash_id = ?
-                      AND progress <> 100
-                ],
-                undef,
-                $progress,
-                $test_id,
-            );
-        }
-    }
-
-    my ( $result ) = $self->dbh->selectrow_array( "SELECT progress FROM test_results WHERE hash_id=?", undef, $test_id );
-
-    return $result;
-}
-
 sub select_test_results {
     my ( $self, $test_id ) = @_;
 
@@ -334,24 +294,6 @@ sub add_batch_job {
     }
 
     return $batch_id;
-}
-
-sub process_unfinished_tests_give_up {
-    my ( $self, $result, $hash_id ) = @_;
-
-    $self->dbh->do(
-        q[
-            UPDATE test_results
-            SET progress = 100,
-                test_end_time = ?,
-                results = ?
-            WHERE hash_id = ?
-        ],
-        undef,
-        $self->format_time( time() ),
-        encode_json( $result ),
-        $hash_id,
-    );
 }
 
 sub get_relative_start_time {

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -63,9 +63,9 @@ sub create_schema {
                  hash_id VARCHAR(16) NOT NULL,
                  domain VARCHAR(255) NOT NULL,
                  batch_id integer NULL,
-                 creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
-                 test_start_time TIMESTAMP DEFAULT NULL,
-                 test_end_time TIMESTAMP DEFAULT NULL,
+                 creation_time DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                 test_start_time DATETIME DEFAULT NULL,
+                 test_end_time DATETIME DEFAULT NULL,
                  priority integer DEFAULT 10,
                  queue integer DEFAULT 0,
                  progress integer DEFAULT 0,
@@ -101,7 +101,7 @@ sub create_schema {
         'CREATE TABLE IF NOT EXISTS batch_jobs (
                  id integer PRIMARY KEY,
                  username character varying(50) NOT NULL,
-                 creation_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+                 creation_time DATETIME DEFAULT CURRENT_TIMESTAMP NOT NULL
            )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'batch_jobs' table", data => $dbh->errstr() );

--- a/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
@@ -5,14 +5,19 @@ use Zonemaster::Backend::Config;
 
 my $config = Zonemaster::Backend::Config->load_config();
 
-if ( $config->DB_engine eq 'MySQL' ) {
-    patch_db_mysql();
+my %patch = (
+    mysql       => \&patch_db_mysql,
+    postgresql  => \&patch_db_postgresql,
+    sqlite      => \&patch_db_sqlite,
+);
+
+my $db_engine = $config->DB_engine;
+
+if ( $db_engine =~ /^(MySQL|PostgreSQL|SQLite)$/ ) {
+    $patch{ lc $db_engine }();
 }
-if ( $config->DB_engine eq 'PostgreSQL' ) {
-    patch_db_postgresql();
-}
-if ( $config->DB_engine eq 'SQLite' ) {
-    patch_db_sqlite();
+else {
+    die "Unknown database engine configured: $db_engine\n";
 }
 
 sub patch_db_mysql {

--- a/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
@@ -1,0 +1,106 @@
+use strict;
+use warnings;
+
+use Zonemaster::Backend::Config;
+
+my $config = Zonemaster::Backend::Config->load_config();
+
+if ( $config->DB_engine eq 'MySQL' ) {
+    patch_db_mysql();
+}
+if ( $config->DB_engine eq 'PostgreSQL' ) {
+    patch_db_postgresql();
+}
+if ( $config->DB_engine eq 'SQLite' ) {
+    patch_db_sqlite();
+}
+
+sub patch_db_mysql {
+    use Zonemaster::Backend::DB::MySQL;
+
+    my $db = Zonemaster::Backend::DB::MySQL->from_config( $config );
+    my $dbh = $db->dbh;
+
+    # update columns data type from TIMESTAMP to DATETIME and default
+    eval {
+        $dbh->do( 'ALTER TABLE test_results MODIFY COLUMN creation_time DATETIME NOT NULL' );
+        $dbh->do( 'ALTER TABLE test_results MODIFY COLUMN test_start_time DATETIME DEFAULT NULL' );
+        $dbh->do( 'ALTER TABLE test_results MODIFY COLUMN test_end_time DATETIME DEFAULT NULL' );
+
+        $dbh->do( 'ALTER TABLE batch_jobs MODIFY COLUMN creation_time DATETIME DEFAULT NULL' );
+    };
+    print( "Could not update column data type:  " . $@ ) if ($@);
+}
+
+sub patch_db_postgresql {
+    use Zonemaster::Backend::DB::PostgreSQL;
+
+    my $db = Zonemaster::Backend::DB::PostgreSQL->from_config( $config );
+    my $dbh = $db->dbh;
+
+    # remove default value for "creation_time"
+    eval {
+        $dbh->do( 'ALTER TABLE test_results ALTER COLUMN creation_time DROP DEFAULT' );
+        $dbh->do( 'ALTER TABLE batch_jobs ALTER COLUMN creation_time DROP DEFAULT' );
+    };
+    print( "Error while droping column default:  " . $@ ) if ($@);
+
+    # change "creation_time" type from TIMESTAMP to DATETIME
+    eval {
+        $dbh->do( 'ALTER TABLE test_results ALTER COLUMN creation_time SET DATE TYPE TIMESTAMP' );
+        $dbh->do( 'ALTER TABLE batch_jobs ALTER COLUMN creation_time SET DATE TYPE TIMESTAMP' );
+    };
+    print( "Could not update column data type:  " . $@ ) if ($@);
+}
+
+sub patch_db_sqlite {
+    use Zonemaster::Backend::DB::SQLite;
+
+    my $db = Zonemaster::Backend::DB::SQLite->from_config( $config );
+    my $dbh = $db->dbh;
+
+    # since we change the default value for a column, the whole table needs to
+    # be recreated
+    #  1. rename the "test_results" table to "test_results_old"
+    #  2. create the new "test_results" table
+    #  3. populate it with the values from "test_results_old"
+    #  4. remove old table and indexes
+    #  5. recreate the indexes
+    eval {
+        $dbh->do('ALTER TABLE test_results RENAME TO test_results_old');
+
+        # create the table
+        $db->create_schema();
+
+        # populate it
+        $dbh->do('
+            INSERT INTO test_results
+            SELECT * FROM test_results_old
+        ');
+
+        $dbh->do('DROP TABLE test_results_old');
+
+        # recreate indexes
+        $db->create_schema();
+    };
+    print( "Error while updating the 'test_results' table schema:  " . $@ ) if ($@);
+
+    eval {
+        $dbh->do('ALTER TABLE batch_jobs RENAME TO batch_jobs_old');
+
+        # create the table
+        $db->create_schema();
+
+        # populate it
+        $dbh->do('
+            INSERT INTO batch_jobs
+            SELECT * FROM batch_jobs_old
+        ');
+
+        $dbh->do('DROP TABLE batch_jobs_old');
+
+        # recreate indexes
+        $db->create_schema();
+    };
+    print( "Error while updating the 'batch_jobs' table schema:  " . $@ ) if ($@);
+}

--- a/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
@@ -59,10 +59,6 @@ sub patch_db_postgresql {
         $dbh->do( 'ALTER TABLE test_results ALTER COLUMN creation_time DROP DEFAULT' );
         $dbh->do( 'ALTER TABLE batch_jobs ALTER COLUMN creation_time DROP DEFAULT' );
 
-        # change "creation_time" type from TIMESTAMP to DATETIME
-        $dbh->do( 'ALTER TABLE test_results ALTER COLUMN creation_time SET DATE TYPE TIMESTAMP' );
-        $dbh->do( 'ALTER TABLE batch_jobs ALTER COLUMN creation_time SET DATE TYPE TIMESTAMP' );
-
         $dbh->commit();
     } catch {
         print( "Could not upgrade database:  " . $_ );


### PR DESCRIPTION
## Purpose

With #769 we don't use the database time and pass a time in UTC to the database. I think we were already storing date and times in UTC before. So this is just about making it explicit and use a more suitable data type.

## Context

n/a

## Changes

* Modify data types in database
* Deduplicate some code (since we don't rely on databases time functions anymore)
* Provide an upgrade script to update the database (cover the N.B. from #769) 

## How to test this PR

Follow the upgrade instructions, tables schema should be properly updated.