### PR TITLE
Produce an error on unknown batch

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1433,9 +1433,21 @@ An object with the following properties:
 
 #### `"error"`
 
->
-> TODO: List all possible error codes and describe what they mean enough for clients to know how react to them.
->
+If the `batch_id` is undefined the following error is returned:
+
+```json
+{
+  "id": 1,
+  "error": {
+    "data": {
+      "batch_id": "10"
+    },
+    "message": "Unknown batch",
+    "code": -32603
+  },
+  "jsonrpc": "2.0"
+}
+```
 
 ## API method: `get_test_params`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1287,7 +1287,7 @@ An object with the following properties:
 
 * `"username"`: A *username*, required. The name of the account of an authorized user.
 * `"api_key"`: An *api key*, required. The api_key associated with the username.
-* `"domains"`: A list of *domain names*, required. The domains to be tested.
+* `"domains"`: A non-empty list of *domain names*, required. The domains to be tested.
 * `"test_params"`: As described below, optional. (default: `{}`)
 
 The value of `"test_params"` is an object with the following properties:
@@ -1346,6 +1346,25 @@ Trying to add a batch when wrong *username* or *api key* is used:
   },
   "id": 1,
   "jsonrpc": "2.0"
+}
+```
+
+Trying to add a batch with an empty list of domains:
+
+```json
+{
+  "id": 1,
+  "jsonrpc": "2.0",
+  "error": {
+    "data": [
+      {
+        "message": "Not enough items: 0/1.",
+        "path": "/domains"
+      }
+    ],
+    "message": "Invalid method parameter(s).",
+    "code": "-32602"
+  }
 }
 ```
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -105,15 +105,6 @@ sub dbh {
     return $self->dbhandle;
 }
 
-sub user_exists {
-    my ( $self, $user ) = @_;
-
-    die Zonemaster::Backend::Error::Internal->new( reason => "username not provided to the method user_exists")
-        unless ( $user );
-
-    return $self->user_exists_in_db( $user );
-}
-
 sub add_api_user {
     my ( $self, $username, $api_key ) = @_;
 
@@ -121,7 +112,7 @@ sub add_api_user {
         unless ( $username && $api_key );
 
     die Zonemaster::Backend::Error::Conflict->new( message => 'User already exists', data => { username => $username } )
-        if ( $self->user_exists( $username ) );
+        if ( $self->user_exists_in_db( $username ) );
 
     my $result = $self->add_api_user_to_db( $username, $api_key );
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -131,7 +131,6 @@ sub add_api_user {
     return $result;
 }
 
-# Standard SQL, can be here
 sub create_new_test {
     my ( $self, $domain, $test_params, $seconds_between_tests_with_same_params, $batch_id ) = @_;
 
@@ -248,7 +247,6 @@ sub test_results {
     return $result;
 }
 
-# Standard SQL, can be here
 sub create_new_batch_job {
     my ( $self, $username ) = @_;
 
@@ -276,7 +274,6 @@ sub create_new_batch_job {
     return $new_batch_id;
 }
 
-# Standard SQL, can be here
 sub user_exists_in_db {
     my ( $self, $user ) = @_;
 
@@ -290,7 +287,6 @@ sub user_exists_in_db {
     return $id;
 }
 
-# Standard SQL, can be here
 sub add_api_user_to_db {
     my ( $self, $user_name, $api_key  ) = @_;
 
@@ -305,7 +301,6 @@ sub add_api_user_to_db {
     return $nb_inserted;
 }
 
-# Standard SQL, can be here
 sub user_authorized {
     my ( $self, $user, $api_key ) = @_;
 
@@ -333,7 +328,6 @@ sub batch_exists_in_db {
     return $id;
 }
 
-# Standard SQL, can be here
 sub get_test_request {
     my ( $self, $queue_label ) = @_;
 
@@ -355,7 +349,6 @@ sub get_test_request {
     return $result_id;
 }
 
-# Standard SQL, can be here
 sub get_test_params {
     my ( $self, $test_id ) = @_;
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -390,6 +390,9 @@ sub get_batch_job_result {
         }
     }
 
+    die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Unknown batch", data => { batch_id => $batch_id } )
+        if ( $result{nb_running} == 0 and $result{nb_finished} == 0 );
+
     return \%result;
 }
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -590,7 +590,8 @@ $json_schemas{add_batch_job} = {
         domains => {
             type => "array",
             additionalItems => 0,
-            items => $zm_validator->domain_name
+            items => $zm_validator->domain_name,
+            minItems => 1
         },
         test_params => joi->object->strict->props(
             ipv4 => joi->boolean,

--- a/t/test01.t
+++ b/t/test01.t
@@ -253,8 +253,17 @@ subtest 'API calls' => sub {
     };
 
     # TODO add_batch_job
-    # TODO get_batch_job_result
+    subtest 'get_batch_job_result' => sub {
+        subtest 'unknown batch' => sub {
+            dies_ok {
+                $backend->get_batch_job_result( { batch_id => 10 } );
+            };
+            my $res = $@;
+            is( $res->{error}, "Zonemaster::Backend::Error::ResourceNotFound", 'Correct error type' );
+        };
 
+        # TODO get_batch_job_result with known batch
+    };
 };
 
 # start a second test with IPv6 disabled


### PR DESCRIPTION
## Purpose

When calling "get_batch_job_result", if the batch is undefined then produce an error `Zonemaster::Backend::Error::ResourceNotFound`.

## Context

#860 

## Changes

* make the domain list in `add_batch_job` non empty
* update `get_batch_job_result()` in DB.pm
* document the error message
* small cleanup: remove the `user_exists` abstraction

## How to test this PR

Can be manually tested using #860.
A new test has also been added.