### PR TITLE
Improve loggers

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -33,6 +33,7 @@ lib/Zonemaster/Backend/DB/MySQL.pm
 lib/Zonemaster/Backend/DB/PostgreSQL.pm
 lib/Zonemaster/Backend/DB/SQLite.pm
 lib/Zonemaster/Backend/Errors.pm
+lib/Zonemaster/Backend/Log.pm
 lib/Zonemaster/Backend/Metrics.pm
 lib/Zonemaster/Backend/RPCAPI.pm
 lib/Zonemaster/Backend/TestAgent.pm

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -56,6 +56,9 @@ Repeating a key name in one section is forbidden.
 
 Each section in `backend_config.ini` is documented below.
 
+In addition to the configuration file, some settings can configured using
+[environement variables][Environement Variables].
+
 ## RPCAPI section
 
 Available keys: `enable_add_batch_job`, `enable_add_api_user`.
@@ -379,6 +382,7 @@ Otherwise a new test request is enqueued.
 [API documentation]:                  API.md
 [DBD::mysql documentation]:           https://metacpan.org/pod/DBD::mysql#host
 [Default JSON profile file]:          https://github.com/zonemaster/zonemaster-engine/blob/master/share/profile.json
+[Environement Variables]:             EnvironementVariables.md
 [File format]:                        https://metacpan.org/pod/Config::IniFiles#FILE-FORMAT
 [ISO 3166-1 alpha-2]:                 https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                          https://en.wikipedia.org/wiki/ISO_639-1

--- a/docs/EnvironmentVariables.md
+++ b/docs/EnvironmentVariables.md
@@ -1,0 +1,18 @@
+# Environment variables
+
+The PSGI server (`zonemaster_backend_rpcapi.psgi`) support the following
+environment variables.
+
+* `ZM_BACKEND_RPCAPI_LOGLEVEL`: Configure the log level, `trace` by default.
+  Accepted values are:
+  * `trace`
+  * `debug`
+  * `info` (also accepted: `inform`)
+  * `notice`
+  * `warning` (also accepted: `warn`)
+  * `error` (also accepted: `err`)
+  * `critical` (also accepted: `crit`, `fatal`)
+  * `alert`
+  * `emergency`
+* `ZM_BACKEND_RPCAPI_LOGJSON`: Setting it to any value will configure the
+  logger to log in JSON format, undefined by default.

--- a/docs/EnvironmentVariables.md
+++ b/docs/EnvironmentVariables.md
@@ -14,5 +14,6 @@ environment variables.
   * `critical` (also accepted: `crit`, `fatal`)
   * `alert`
   * `emergency`
-* `ZM_BACKEND_RPCAPI_LOGJSON`: Setting it to any value will configure the
-  logger to log in JSON format, undefined by default.
+* `ZM_BACKEND_RPCAPI_LOGJSON`: Setting it to any thruthy value (non-empty
+  string or non-zero number) will configure the logger to log in JSON format,
+  undefined by default.

--- a/lib/Zonemaster/Backend/Errors.pm
+++ b/lib/Zonemaster/Backend/Errors.pm
@@ -91,26 +91,28 @@ sub _build_method {
     return $c[3];
 }
 
-around 'BUILDARGS', sub {
-    my ($orig, $class, %args) = @_;
-
-    if(exists $args{reason}) {
-        # trim new lines
-        $args{reason} =~ s/\n/ /g;
-        $args{reason} =~ s/^\s+|\s+$//g;
-    }
-
-    $class->$orig(%args);
-};
-
 sub as_string {
     my $self = shift;
-    my $str = sprintf "Caught %s in the `%s` method: %s", ref($self), $self->method, $self->reason;
+
+    my $reason = $self->reason;
+    $reason =~ s/\s+/ /g;
+    $reason =~ s/^\s+|\s+$//g;
+
+    my $str = sprintf "Caught %s in the `%s` method: %s", ref($self), $self->method, $reason;
     if (defined $self->data) {
         $str .= sprintf " Context: %s", $self->_data_dump;
     }
     return $str;
 }
+
+around as_hash => sub {
+    my ($orig, $self) = @_;
+
+    my $hash = $self->$orig;
+    $hash->{reason} = $self->reason;
+    $hash->{method} = $self->method;
+    return $hash;
+};
 
 
 package Zonemaster::Backend::Error::ResourceNotFound;

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -56,15 +56,14 @@ sub format_text {
     $msg .= sprintf "%s ", $log_params->{timestamp};
     delete $log_params->{timestamp};
     if (exists $log_params->{pid}) {
-        $msg .= sprintf "[%d] ", $log_params->{pid};
-        delete $log_params->{pid};
+        $msg .= sprintf "[%d] ", delete $log_params->{pid};
     }
     $msg .= sprintf "[%s] [%s] %s", uc $log_params->{level}, $log_params->{category}, $log_params->{message};
     delete $log_params->{level};
     delete $log_params->{message};
     delete $log_params->{category};
 
-    if ( keys %$log_params ) {
+    if ( %$log_params ) {
         local $Data::Dumper::Indent = 0;
         local $Data::Dumper::Terse = 1;
         my $data = Dumper($log_params);

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -6,8 +6,11 @@ package Zonemaster::Backend::Log;
 use POSIX;
 use JSON::PP;
 use Log::Any::Adapter::Util ();
-use base qw(Log::Any::Adapter::Base);
 use Carp;
+use Data::Dumper;
+
+use base qw(Log::Any::Adapter::Base);
+
 
 my $trace_level = Log::Any::Adapter::Util::numeric_level('trace');
 
@@ -63,8 +66,15 @@ sub format_text {
     delete $log_params->{message};
     delete $log_params->{category};
 
-    return $msg
+    if ( keys %$log_params ) {
+        local $Data::Dumper::Indent = 0;
+        local $Data::Dumper::Terse = 1;
+        my $data = Dumper($log_params);
 
+        $msg .= " Extra parameters: $data";
+    }
+
+    return $msg
 }
 
 sub format_json {

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -1,0 +1,118 @@
+use strict;
+use warnings;
+
+package Zonemaster::Backend::Log;
+
+use POSIX;
+use JSON::PP;
+use Log::Any::Adapter::Util ();
+use base qw(Log::Any::Adapter::Base);
+
+my $trace_level = Log::Any::Adapter::Util::numeric_level('trace');
+
+sub init {
+    my ($self) = @_;
+
+    if ( exists $self->{log_level} && $self->{log_level} =~ /\D/ ) {
+        my $numeric_level = Log::Any::Adapter::Util::numeric_level( $self->{log_level} );
+        if ( !defined($numeric_level) ) {
+            die "Error: Unrecognized log level " . $self->{log_level} . "\n";
+        }
+        $self->{log_level} = $numeric_level;
+    }
+
+    if ( !defined $self->{log_level} ) {
+        $self->{log_level} = $trace_level;
+    }
+
+    my $fd;
+    if ( !exists $self->{file} || $self->{file} eq '-') {
+        if ( $self->{stderr} ) {
+            open( $fd, '>&', \*STDERR ) or die "Can't dup STDERR: $!";
+        } else {
+            open( $fd, '>&', \*STDOUT ) or die "Can't dup STDOUT: $!";
+        }
+        my $handle = IO::Handle->new_from_fd( $fd, "w" ) or die "Can't fdopen duplicated STDOUT: $!";
+    } else {
+        open( $fd, '>>', $self->{file} ) or die "Can't open log file: $!";
+    }
+    $self->{handle} = IO::Handle->new_from_fd( $fd, "w" ) or die "Can't fdopen file: $!";
+    $self->{handle}->autoflush(1);
+
+    if ( !exists $self->{formatter} ) {
+        if ( $self->{json} ) {
+            $self->{formatter} = \&format_json;
+        } else {
+            $self->{formatter} = \&format_text;
+        }
+    }
+}
+
+sub format_text {
+    my ($self, $log_params) = @_;
+    my $msg;
+    $msg .= sprintf "%s ", $log_params->{timestamp};
+    delete $log_params->{timestamp};
+    if (exists $log_params->{pid}) {
+        $msg .= sprintf "[%d] ", $log_params->{pid};
+        delete $log_params->{pid};
+    }
+    $msg .= sprintf "[%s] [%s] %s", uc $log_params->{level}, $log_params->{category}, $log_params->{message};
+    delete $log_params->{level};
+    delete $log_params->{message};
+    delete $log_params->{category};
+
+    return $msg
+
+}
+
+sub format_json {
+    my ($self, $log_params) = @_;
+
+    my $js = JSON::PP->new;
+    $js->canonical( 1 );
+
+    return $js->encode( $log_params );
+}
+
+
+sub structured {
+    my ($self, $level, $category, $string, @items) = @_;
+
+    my $log_level = Log::Any::Adapter::Util::numeric_level($level);
+
+    return if $log_level > $self->{log_level};
+
+    my %log_params = (
+        timestamp => strftime( "%FT%TZ", gmtime ),
+        level => $level,
+        category => $category,
+        message => $string
+    );
+
+    for my $item ( @items ) {
+        if (ref($item) eq 'HASH') {
+            if (exists $item->{context}) {
+                $item = $item->{context};
+            }
+            for my $key (keys %$item) {
+                $log_params{$key} = $item->{$key};
+            }
+        }
+    }
+
+    my $msg = $self->{formatter}->($self, \%log_params);
+    $self->{handle}->print($msg . "\n");
+}
+
+# From Log::Any::Adapter::File
+foreach my $method ( Log::Any::Adapter::Util::detection_methods() ) {
+    no strict 'refs';
+    my $base = substr($method,3);
+    my $method_level = Log::Any::Adapter::Util::numeric_level( $base );
+    *{$method} = sub {
+        return !!(  $method_level <= $_[0]->{log_level} );
+    };
+}
+
+1;

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -7,6 +7,7 @@ use POSIX;
 use JSON::PP;
 use Log::Any::Adapter::Util ();
 use base qw(Log::Any::Adapter::Base);
+use Carp;
 
 my $trace_level = Log::Any::Adapter::Util::numeric_level('trace');
 
@@ -16,7 +17,7 @@ sub init {
     if ( exists $self->{log_level} && $self->{log_level} =~ /\D/ ) {
         my $numeric_level = Log::Any::Adapter::Util::numeric_level( $self->{log_level} );
         if ( !defined($numeric_level) ) {
-            die "Error: Unrecognized log level " . $self->{log_level} . "\n";
+            croak "Error: Unrecognized log level " . $self->{log_level} . "\n";
         }
         $self->{log_level} = $numeric_level;
     }

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -3,6 +3,7 @@ use warnings;
 
 package Zonemaster::Backend::Log;
 
+use English qw( $PID );
 use POSIX;
 use JSON::PP;
 use Log::Any::Adapter::Util ();
@@ -55,13 +56,13 @@ sub format_text {
     my $msg;
     $msg .= sprintf "%s ", $log_params->{timestamp};
     delete $log_params->{timestamp};
-    if (exists $log_params->{pid}) {
-        $msg .= sprintf "[%d] ", delete $log_params->{pid};
-    }
-    $msg .= sprintf "[%s] [%s] %s", uc $log_params->{level}, $log_params->{category}, $log_params->{message};
-    delete $log_params->{level};
-    delete $log_params->{message};
-    delete $log_params->{category};
+    $msg .= sprintf(
+        "[%d] [%s] [%s] %s",
+        delete $log_params->{pid},
+        uc delete $log_params->{level},
+        delete $log_params->{category},
+        delete $log_params->{message}
+    );
 
     if ( %$log_params ) {
         local $Data::Dumper::Indent = 0;
@@ -95,7 +96,8 @@ sub structured {
         timestamp => strftime( "%FT%TZ", gmtime ),
         level => $level,
         category => $category,
-        message => $string
+        message => $string,
+        pid => $PID,
     );
 
     for my $item ( @items ) {

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -92,9 +92,6 @@ sub structured {
 
     for my $item ( @items ) {
         if (ref($item) eq 'HASH') {
-            if (exists $item->{context}) {
-                $item = $item->{context};
-            }
             for my $key (keys %$item) {
                 $log_params{$key} = $item->{$key};
             }

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -25,22 +25,20 @@ sub init {
         $self->{log_level} = $numeric_level;
     }
 
-    if ( !defined $self->{log_level} ) {
-        $self->{log_level} = $trace_level;
-    }
+    $self->{log_level} //= $trace_level;
 
     my $fd;
     if ( !exists $self->{file} || $self->{file} eq '-') {
         if ( $self->{stderr} ) {
-            open( $fd, '>&', \*STDERR ) or die "Can't dup STDERR: $!";
+            open( $fd, '>&', \*STDERR ) or croak "Can't dup STDERR: $!";
         } else {
-            open( $fd, '>&', \*STDOUT ) or die "Can't dup STDOUT: $!";
+            open( $fd, '>&', \*STDOUT ) or croak "Can't dup STDOUT: $!";
         }
-        my $handle = IO::Handle->new_from_fd( $fd, "w" ) or die "Can't fdopen duplicated STDOUT: $!";
     } else {
-        open( $fd, '>>', $self->{file} ) or die "Can't open log file: $!";
+        open( $fd, '>>', $self->{file} ) or croak "Can't open log file: $!";
     }
-    $self->{handle} = IO::Handle->new_from_fd( $fd, "w" ) or die "Can't fdopen file: $!";
+
+    $self->{handle} = IO::Handle->new_from_fd( $fd, "w" ) or croak "Can't fdopen file: $!";
     $self->{handle}->autoflush(1);
 
     if ( !exists $self->{formatter} ) {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -89,10 +89,13 @@ sub handle_exception {
         $exception = Zonemaster::Backend::Error::Internal->new( reason => $reason );
     }
 
+    my $log_extra = $exception->as_hash;
+    delete $log_extra->{message};
+
     if ( $exception->isa('Zonemaster::Backend::Error::Internal') ) {
-        $log->error($exception->as_string);
+        $log->error($exception->as_string, $log_extra);
     } else {
-        $log->info($exception->as_string);
+        $log->info($exception->as_string, $log_extra);
     }
 
     die $exception->as_hash;

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -156,6 +156,7 @@ my $rpcapi_app = sub {
           $res->body( encode_json($errors) );
           $res->finalize;
         } else {
+            local $log->context->{rpc_method} = $content->{method};
             $res = $dispatch->handle_psgi($env, $env->{REMOTE_ADDR});
             my $status = Zonemaster::Backend::Metrics->code_to_status(decode_json(@{@$res[2]}[0])->{error}->{code});
             Zonemaster::Backend::Metrics::increment("zonemaster.rpcapi.requests.$content->{method}.$status");

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -34,7 +34,6 @@ Log::Any::Adapter->set(
     json => $ENV{ZM_BACKEND_RPCAPI_LOGJSON},
     stderr => 1
 );
-$log->context->{pid} = $PID;
 
 $SIG{__WARN__} = sub {
     $log->warning(map s/^\s+|\s+$//gr, map s/\n/ /gr, @_);

--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -11,7 +11,6 @@ use Parallel::ForkManager;
 use Daemon::Control;
 use Log::Any qw( $log );
 use Log::Any::Adapter;
-use Log::Dispatch;
 
 use English;
 use Pod::Usage;
@@ -40,6 +39,7 @@ my $user;
 my $group;
 my $logfile;
 my $loglevel;
+my $logjson;
 my $opt_outfile;
 my $opt_help;
 GetOptions(
@@ -49,6 +49,7 @@ GetOptions(
     'group=s'    => \$group,
     'logfile=s'  => \$logfile,
     'loglevel=s' => \$loglevel,
+    'logjson!'  => \$logjson,
     'outfile=s'  => \$opt_outfile,
 ) or pod2usage( "Try '$0 --help' for more information." );
 
@@ -60,56 +61,13 @@ $opt_outfile //= '/var/log/zonemaster/zonemaster_backend_testagent.out';
 $loglevel    //= 'info';
 $loglevel = lc $loglevel;
 
-$loglevel =~ /^(?:trace|debug|info|inform|notice|warning|warn|error|err|critical|crit|fatal|alert|emergency)$/ or die "Error: Unrecognized --loglevel $loglevel\n";
-
-# Returns a Log::Dispatch object logging to STDOUT
-#
-# This procedure duplicates the STDOUT file descriptor to make sure that it keeps
-# logging to the same place even if STDOUT is later redirected.
-sub log_dispatcher_dup_stdout {
-    my $min_level = shift;
-
-    open( my $fd, '>&', \*STDOUT ) or die "Can't dup STDOUT: $!";
-    my $handle = IO::Handle->new_from_fd( $fd, "w" ) or die "Can't fdopen duplicated STDOUT: $!";
-    $handle->autoflush(1);
-
-    return Log::Dispatch->new(
-        outputs => [
-            [
-                'Handle',
-                handle    => $handle,
-                min_level => $min_level,
-                newline   => 1,
-                callbacks => sub {
-                    my %args = @_;
-                    $args{message} = sprintf "%s [%d] %s - %s", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
-                },
-            ],
-        ]
-    );
-}
-
-# Returns a Log::Dispatch object logging to a file
-sub log_dispatcher_file {
-    my $min_level = shift;
-    my $log_file  = shift;
-
-    return Log::Dispatch->new(
-        outputs => [
-            [
-                'File',
-                filename  => $log_file,
-                mode      => '>>',
-                min_level => $min_level,
-                newline   => 1,
-                callbacks => sub {
-                    my %args = @_;
-                    $args{message} = sprintf "%s [%d] %s - %s", strftime( "%FT%TZ", gmtime ), $PID, uc $args{level}, $args{message};
-                },
-            ],
-        ]
-    );
-}
+Log::Any::Adapter->set(
+    '+Zonemaster::Backend::Log',
+    log_level => $loglevel,
+    json => $logjson,
+    file => $logfile,
+);
+$log->context->{pid} = $PID;
 
 $SIG{__WARN__} = sub {
     $log->warning(map s/^\s+|\s+$//gr, map s/\n/ /gr, @_);
@@ -214,16 +172,6 @@ sub preflight_checks {
 }
 
 
-# Initialize logging
-my $dispatcher;
-if ( $logfile eq '-' ) {
-    $dispatcher = log_dispatcher_dup_stdout( $loglevel );
-}
-else {
-    $dispatcher = log_dispatcher_file( $loglevel, $logfile );
-    print STDERR "zonemaster-testagent logging to file $logfile\n";
-}
-Log::Any::Adapter->set( 'Dispatch', dispatcher => $dispatcher );
 
 my $initial_config;
 
@@ -311,6 +259,10 @@ When FILE is -, the log is written to standard output.
 The location of the log level to use.
 
 The allowed values are specified at L<Log::Any/LOG-LEVELS>.
+
+=item B<--logjson>
+
+Enable JSON logging when specified.
 
 =item B<COMMAND>
 


### PR DESCRIPTION
## Purpose

Following the discussion at https://github.com/zonemaster/zonemaster-backend/pull/959#pullrequestreview-898947996 I decided to do a dedicated PR for logging.

## Context

* Replace part of #959
* Maybe address partially #214

## Changes
* Drop Log::Dispatcher
* Implementation of log levels now corresponds to the documentation
* Add support for structured logging (JSON) using context and extra parameters
  * `ZM_BACKEND_RPCAPI_LOGJSON=1` for RPCAPI
  * `--logjson` for test agent
* Use same init function for logger from RPCAPI script and test agent

## How to test this PR
* Structured logging

`ZM_BACKEND_RPCAPI_LOGJSON=1 ZM_BACKEND_RPCAPI_LOGLEVEL=debug starman --preload-app script/zonemaster_backend_rpcapi.psgi  2>&1 | jq -crR '. as $raw | try fromjson catch $raw'`
```json
{"category":"Zonemaster::Backend::Config","level":"notice","message":"Loading config: /home/gbm/workspace/zonemaster/backend_config.ini","pid":91858,"timestamp":"2022-03-28T16:11:45Z"}
{"category":"Plack::Sandbox::_2fhome_2fgbm_2fworkspace_2fzonemaster_2fzonemaster_2dbackend_2fscript_2fzonemaster_backend_rpcapi_2epsgi","level":"info","message":"Enabling add_api_user method","pid":91858,"timestamp":"2022-03-28T16:11:45Z"}
{"category":"Plack::Sandbox::_2fhome_2fgbm_2fworkspace_2fzonemaster_2fzonemaster_2dbackend_2fscript_2fzonemaster_backend_rpcapi_2epsgi","level":"info","message":"Enabling add_batch_job method","pid":91858,"timestamp":"2022-03-28T16:11:45Z"}
{"category":"Zonemaster::Backend::DB","level":"notice","message":"Connecting to database 'DBI:Pg:dbname=travis_zonemaster;host=127.0.0.1;port=5432' as user 'travis_zonemaster'","pid":91858,"timestamp":"2022-03-28T16:11:49Z"}
{"category":"Zonemaster::Backend::RPCAPI","code":-32001,"data":{"username":"toto"},"error":"Zonemaster::Backend::Error::PermissionDenied","level":"info","message":"User not authorized to use batch mode (code -32001). Context: {'username' => 'toto'}","pid":91858,"timestamp":"2022-03-28T16:11:49Z"}
```
`perl script/zonemaster_backend_testagent --logfile=- --outfile=/tmp/zonemaster_testagent.out --loglevel=debug foreground --logjson | jq -c`
```json
{"category":"main","level":"notice","message":"Daemon spawned","pid":91993,"timestamp":"2022-03-28T16:13:44Z"}
{"category":"Zonemaster::Backend::Config","level":"notice","message":"Loading config: /home/gbm/workspace/zonemaster/backend_config.ini","pid":91993,"timestamp":"2022-03-28T16:13:44Z"}
{"category":"Zonemaster::Backend::DB","level":"notice","message":"Connecting to database 'DBI:Pg:dbname=travis_zonemaster;host=10.10.86.42;port=5432' as user 'travis_zonemaster'","pid":91993,"timestamp":"2022-03-28T16:13:45Z"}
{"category":"main","level":"error","message":"DBI connect('dbname=travis_zonemaster;host=10.10.86.42;port=5432','travis_zonemaster',...) failed: n'a pas pu se connecter au serveur : Connexion refusée\n\tLe serveur est-il actif sur l'hôte « 10.10.86.42 » et accepte-t-il les connexions\n\tTCP/IP sur le port 5432 ? at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/DB.pm line 96.\n","pid":91993,"timestamp":"2022-03-28T16:13:45Z"
```
* Log::Any log levels work correctly

`perl script/zonemaster_backend_testagent --logfile=- --outfile=/tmp/zonemaster_testagent.out --loglevel=trace foreground`
```
2022-03-28T16:19:35Z [92354] [NOTICE] [main] Daemon spawned
2022-03-28T16:19:35Z [92354] [NOTICE] [Zonemaster::Backend::Config] Loading config: /home/gbm/workspace/zonemaster/backend_config.ini
```