### PR TITLE
Use ISO 8601 to represent datetimes

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -986,11 +986,11 @@ An object with the following properties:
 
 #### `"result"`
 
-* `"creation_time"`: **Deprecated**. A [*deprecated timestamp*][Timestamp deprecated].
+* `"creation_time"`: **Deprecated** (planned removal: v2022.2). A [*deprecated timestamp*][Timestamp deprecated].
   The time at which the *test* was created (in UTC).
 * `"created_at"`: A [*timestamp*][Timestamp]. The time at which the *test* was created
   (in UTC).
-* `"id"`: **Deprecated** (will be removed in v2022.2). An integer.
+* `"id"`: **Deprecated** (planned removal: v2022.2). An integer.
 * `"hash_id"`: A [*test id*][Test id]. The *test* in question.
 * `"params"`: See below.
   `start_domain_test` when the *test* was started.
@@ -1098,7 +1098,7 @@ The value of "frontend_params" is an object with the following properties:
 An object with the following properties:
 
 * `"id"` A *test id*.
-* `"creation_time"`: **Deprecated**. A [*deprecated timestamp*][Timestamp deprecated].
+* `"creation_time"`: **Deprecated** (planned removal: v2022.2). A [*deprecated timestamp*][Timestamp deprecated].
   The time at which the *test* was created (in UTC).
 * `"created_at"`: A [*timestamp*][Timestamp]. The time at which the *test* was created
   (in UTC).

--- a/docs/API.md
+++ b/docs/API.md
@@ -987,9 +987,9 @@ An object with the following properties:
 #### `"result"`
 
 * `"creation_time"`: **Deprecated** (planned removal: v2022.2). A [*deprecated timestamp*][Timestamp deprecated].
-  The time at which the *test* was created (in UTC).
-* `"created_at"`: A [*timestamp*][Timestamp]. The time at which the *test* was created
-  (in UTC).
+  The time in UTC at which the *test* was created.
+* `"created_at"`: A [*timestamp*][Timestamp]. The time in UTC at which the *test*
+  was created.
 * `"id"`: **Deprecated** (planned removal: v2022.2). An integer.
 * `"hash_id"`: A [*test id*][Test id]. The *test* in question.
 * `"params"`: See below.
@@ -1099,9 +1099,9 @@ An object with the following properties:
 
 * `"id"` A *test id*.
 * `"creation_time"`: **Deprecated** (planned removal: v2022.2). A [*deprecated timestamp*][Timestamp deprecated].
-  The time at which the *test* was created (in UTC).
-* `"created_at"`: A [*timestamp*][Timestamp]. The time at which the *test* was created
-  (in UTC).
+  The time in UTC at which the *test* was created.
+* `"created_at"`: A [*timestamp*][Timestamp]. The time in UTC at which the *test*
+  was created.
 * `"overall_result"`: A string. It reflects the most severe problem level among
   the test results for the test. It has one of the following values:
   * `"ok"`, if there are only messages with [*severity level*][Severity level] `"INFO"` or

--- a/docs/API.md
+++ b/docs/API.md
@@ -397,7 +397,7 @@ This key is added when the module name is `"NAMESERVER"`.
 
 Basic data type: string
 
-**Deprecated representation**
+**Deprecated representation** (planned removal: v2023.1).
 Default database timestamp format: "Y-M-D H:M:S.ms".
 Example: "2017-12-18 07:56:17.156939"
 
@@ -986,7 +986,7 @@ An object with the following properties:
 
 #### `"result"`
 
-* `"creation_time"`: **Deprecated** (planned removal: v2022.2). A [*deprecated timestamp*][Timestamp deprecated].
+* `"creation_time"`: **Deprecated** (planned removal: v2023.1). A [*deprecated timestamp*][Timestamp deprecated].
   The time in UTC at which the *test* was created.
 * `"created_at"`: A [*timestamp*][Timestamp]. The time in UTC at which the *test*
   was created.
@@ -1098,7 +1098,7 @@ The value of "frontend_params" is an object with the following properties:
 An object with the following properties:
 
 * `"id"` A *test id*.
-* `"creation_time"`: **Deprecated** (planned removal: v2022.2). A [*deprecated timestamp*][Timestamp deprecated].
+* `"creation_time"`: **Deprecated** (planned removal: v2023.1). A [*deprecated timestamp*][Timestamp deprecated].
   The time in UTC at which the *test* was created.
 * `"created_at"`: A [*timestamp*][Timestamp]. The time in UTC at which the *test*
   was created.

--- a/docs/API.md
+++ b/docs/API.md
@@ -398,6 +398,7 @@ This key is added when the module name is `"NAMESERVER"`.
 Basic data type: string
 
 **Deprecated representation** (planned removal: v2023.1).
+
 Default database timestamp format: "Y-M-D H:M:S.ms".
 Example: "2017-12-18 07:56:17.156939"
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -27,6 +27,7 @@
   * [Severity level](#severity-level)
   * [Test id](#test-id)
   * [Test result](#test-result)
+  * [Timestamp (deprecated)](#timestamp-deprecated)
   * [Timestamp](#timestamp)
   * [Username](#username)
 * [API method: version_info](#api-method-version_info)
@@ -392,12 +393,22 @@ Sometimes additional keys are present.
 This key is added when the module name is `"NAMESERVER"`.
 
 
+### Timestamp (deprecated)
+
+Basic data type: string
+
+**Deprecated representation**
+Default database timestamp format: "Y-M-D H:M:S.ms".
+Example: "2017-12-18 07:56:17.156939"
+
+
 ### Timestamp
 
 Basic data type: string
 
-Default database timestamp format: "Y-M-D H:M:S.ms".
-Example: "2017-12-18 07:56:17.156939"
+A string representing a date and time using the following ISO 8601 format:
+"YYYY-MM-DDThh:mm:ssZ".
+Example: "2017-12-18T07:56:17Z"
 
 ### Username
 
@@ -919,6 +930,7 @@ Example response:
   "id": 6,
   "result": {
     "creation_time": "2016-11-15 11:53:13.965982",
+    "created_at": "2016-11-15T11:53:13Z",
     "id": 25,
     "hash_id": "c45a3f8256c4a155",
     "params": {
@@ -974,8 +986,10 @@ An object with the following properties:
 
 #### `"result"`
 
-* `"creation_time"`: A [*timestamp*][Timestamp]. The time at which the *test*
-   was enqueued (in UTC).
+* `"creation_time"`: **Deprecated**. A [*deprecated timestamp*][Timestamp deprecated].
+  The time at which the *test* was created (in UTC).
+* `"created_at"`: A [*timestamp*][Timestamp]. The time at which the *test* was created
+  (in UTC).
 * `"id"`: **Deprecated** (will be removed in v2022.2). An integer.
 * `"hash_id"`: A [*test id*][Test id]. The *test* in question.
 * `"params"`: See below.
@@ -1036,6 +1050,7 @@ Example response:
     {
       "id": "c45a3f8256c4a155",
       "creation_time": "2016-11-15 11:53:13.965982",
+      "created_at": "2016-11-15T11:53:13Z",
       "undelegated": true,
       "overall_result": "error",
     },
@@ -1043,6 +1058,7 @@ Example response:
       "id": "32dd4bc0582b6bf9",
       "undelegated": false,
       "creation_time": "2016-11-14 08:46:41.532047",
+      "created_at": "2016-11-14T08:46:41Z",
       "overall_result": "error",
     },
     ...
@@ -1082,8 +1098,10 @@ The value of "frontend_params" is an object with the following properties:
 An object with the following properties:
 
 * `"id"` A *test id*.
-* `"creation_time"`: A [*timestamp*][Timestamp]. The time at which the *test*
-  was enqueued (in UTC).
+* `"creation_time"`: **Deprecated**. A [*deprecated timestamp*][Timestamp deprecated].
+  The time at which the *test* was created (in UTC).
+* `"created_at"`: A [*timestamp*][Timestamp]. The time at which the *test* was created
+  (in UTC).
 * `"overall_result"`: A string. It reflects the most severe problem level among
   the test results for the test. It has one of the following values:
   * `"ok"`, if there are only messages with [*severity level*][Severity level] `"INFO"` or
@@ -1318,6 +1336,7 @@ request:
   "error": {
     "data": {
       "creation_time": "2021-09-27 07:33:40",
+      "created_at": "2021-09-27T07:33:40Z",
       "batch_id": 1
     },
     "code": -32603,
@@ -1542,6 +1561,7 @@ The `"params"` object sent to [`start_domain_test`][start_domain_test] or
 [Test id]:                            #test-id
 [Test result]:                        #test-result
 [Timestamp]:                          #timestamp
+[Timestamp deprecated]:               #timestamp-deprecated
 [Username]:                           #username
 [Validation error data]:              #validation-error-data
 [ZONEMASTER.age_reuse_previous_test]: Configuration.md#age_reuse_previous_test

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -261,6 +261,8 @@ sub select_test_results {
     die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } )
         unless defined $result;
 
+    $result->{created_at} = $self->to_iso8601( $result->{creation_time} );
+
     return $result;
 }
 
@@ -652,6 +654,12 @@ sub undelegated {
 sub format_time {
     my ( $class, $time ) = @_;
     return strftime "%Y-%m-%d %H:%M:%S", gmtime( $time );
+}
+
+sub to_iso8601 {
+    my ( $class, $time ) = @_;
+    $time =~ s/^([^ ]+) (.*)$/$1T$2Z/;
+    return $time;
 }
 
 no Moose::Role;

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -211,6 +211,7 @@ sub get_test_history {
             {
                 id               => $h->{hash_id},
                 creation_time    => $h->{creation_time},
+                created_at       => $self->to_iso8601( $h->{creation_time} ),
                 undelegated      => $h->{undelegated},
                 overall_result   => $overall,
             }

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -210,6 +210,7 @@ sub get_test_history {
             {
                 id               => $h->{hash_id},
                 creation_time    => $h->{creation_time},
+                created_at       => $self->to_iso8601( $h->{creation_time} ),
                 undelegated      => $h->{undelegated},
                 overall_result   => $overall_result,
             }

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -190,6 +190,7 @@ sub get_test_history {
             {
                 id               => $h->{hash_id},
                 creation_time    => $h->{creation_time},
+                created_at       => $self->to_iso8601( $h->{creation_time} ),
                 undelegated      => $h->{undelegated},
                 overall_result   => $overall,
             }

--- a/t/test01.t
+++ b/t/test01.t
@@ -175,6 +175,7 @@ subtest 'API calls' => sub {
         is( $res->{hash_id}, $hash_id, 'Retrieve the correct "hash_id"' );
         ok( defined $res->{params}, 'Value "params" properly defined' );
         ok( defined $res->{creation_time}, 'Value "creation_time" properly defined' );
+        ok( defined $res->{created_at}, 'Value "created_at" properly defined' );
         ok( defined $res->{results}, 'Value "results" properly defined' );
         if ( @{ $res->{results} } > 1 ) {
             pass 'The test has some results';
@@ -300,6 +301,7 @@ subtest 'get_test_history' => sub {
         is( length($res->{id}), 16, 'Test has 16 characters length hash ID' );
         is( $res->{undelegated}, JSON::PP::true, 'Test is undelegated' );
         ok( defined $res->{creation_time}, 'Value "creation_time" properly defined' );
+        ok( defined $res->{created_at}, 'Value "created_at" properly defined' );
         ok( defined $res->{overall_result}, 'Value "overall_result" properly defined' );
     }
 


### PR DESCRIPTION
## Purpose

Standardize the way datetimes are represented in results from the RCPAPI.

## Context

This work has been first conducted in #964, but due to a possible breaking change, this has been moved to another PR.

## Changes

* New `created_at` field in `get_test_results` and `get_test_history` with the time represented using ISO 8601 `2022-03-28T12:07:40Z`
* Deprecate the `creation_time` field in `get_test_results` and `get_test_history`
* Update API documentation

## How to test this PR

Check that there is a new `created_at` field in the output from the `get_test_result` and `get_test_history` methods is in ISO 8601 format.