### PR TITLE
Fix crash when calling "get_test_results"

### DIFF
--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -18,7 +18,7 @@ extends 'Zonemaster::Engine::Translator';
 sub translate_tag {
     my ( $self, $hashref ) = @_;
 
-    my $entry = Zonemaster::Engine::Logger::Entry->new( %{ $hashref } );
+    my $entry = Zonemaster::Engine::Logger::Entry->new( { %{ $hashref } } );
     my $octets = Zonemaster::Engine::Translator::translate_tag( $self, $entry );
 
     return decode_utf8( $octets );


### PR DESCRIPTION
## Purpose

The way the hash is passed in the Translator and how the Logger is implemented will alter the data in the origin hash resulting in an error when calling `get_test_results`:

```
$ zmb get_test_results --test-id ccaaf2e5df7a26f6 --language  | jq
{
  "error": {
    "data": null,
    "code": -32603,
    "message": "Internal server error"
  },
  "id": 1,
  "jsonrpc": "2.0"
}
```

## Context

n/a

## Changes

Fix Translator.pm

## How to test this PR

1. create a test, get its id
2. call `get_test_results`: `zmb get_test_results --test-id ccaaf2e5df7a26f6 --language  | jq`
3. there should be results and not an "Internal server error" message