### PR TITLE
Normalize profile name in DB

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -533,10 +533,10 @@ sub _project_params {
 
     my %projection = ();
 
-    $projection{domain}   = lc $$params{domain} // "";
-    $projection{ipv4}     = $$params{ipv4}      // $profile->get( 'net.ipv4' );
-    $projection{ipv6}     = $$params{ipv6}      // $profile->get( 'net.ipv6' );
-    $projection{profile}  = $$params{profile}   // "default";
+    $projection{domain}   = lc $$params{domain}  // "";
+    $projection{ipv4}     = $$params{ipv4}       // $profile->get( 'net.ipv4' );
+    $projection{ipv6}     = $$params{ipv6}       // $profile->get( 'net.ipv6' );
+    $projection{profile}  = lc $$params{profile} // "default";
 
     my $array_ds_info = $$params{ds_info} // [];
     my @array_ds_info_sort = sort {


### PR DESCRIPTION
## Purpose

* Make profile case insensitive when computing the fingerprint.
* Normalize profile name before storing it.

## Context

\-

## Changes

*Lower case the profile name when projecting the params.

## How to test this PR

The following commands should return the same test id when executed
* `./script/zmb start_domain_test --domain 'zonemaster.net' --lang en --profile DEFAULT`
* `./script/zmb start_domain_test --domain 'zonemaster.net' --lang en --profile default` 
