### PR TITLE
Fix precedence when normalizing params

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -533,10 +533,10 @@ sub _project_params {
 
     my %projection = ();
 
-    $projection{domain}   = lc $$params{domain}  // "";
+    $projection{domain}   = lc( $$params{domain}  // "" );
     $projection{ipv4}     = $$params{ipv4}       // $profile->get( 'net.ipv4' );
     $projection{ipv6}     = $$params{ipv6}       // $profile->get( 'net.ipv6' );
-    $projection{profile}  = lc $$params{profile} // "default";
+    $projection{profile}  = lc( $$params{profile} // "default" );
 
     my $array_ds_info = $$params{ds_info} // [];
     my @array_ds_info_sort = sort {


### PR DESCRIPTION
## Purpose

Suppress WARNING messages when value is undefined.

## Context

Appears with #972.

## Changes

Always pass a defined value to `lc()` when normalizing the params.

## How to test this PR

Run the command from #972 without any profile defined, no Warning message should be logged.
