### PR TITLE
run preflight on foreground

### DIFF
--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -228,7 +228,7 @@ Log::Any::Adapter->set( 'Dispatch', dispatcher => $dispatcher );
 my $initial_config;
 
 # Make sure the environment is alright before forking (only on startup)
-if ( grep /start/, @ARGV ) {
+if ( grep /^foreground$|^restart$|^start$/, @ARGV ) {
     eval {
         $initial_config = preflight_checks();
     };


### PR DESCRIPTION
## Purpose

* Run preflight checks on both start and foreground.

## Context

Replace part of #959

## Changes

* Run preflight checks on both start and foreground.

## How to test this PR

* `perl script/zonemaster_backend_testagent --logfile=- --outfile=/tmp/zonemaster_testagent.out --loglevel=debug foreground` shows the `Starting pre-flight check` log message.