### PR TITLE
Store index using BIGINT in database

### DIFF
--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -63,7 +63,7 @@ sub create_schema {
     ####################################################################
     $dbh->do(
         'CREATE TABLE IF NOT EXISTS test_results (
-            id integer AUTO_INCREMENT PRIMARY KEY,
+            id BIGINT AUTO_INCREMENT PRIMARY KEY,
             hash_id VARCHAR(16) NOT NULL,
             domain varchar(255) NOT NULL,
             batch_id integer NULL,

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -60,7 +60,7 @@ sub create_schema {
     ####################################################################
     $dbh->do(
         'CREATE TABLE IF NOT EXISTS test_results (
-                id serial PRIMARY KEY,
+                id BIGSERIAL PRIMARY KEY,
                 hash_id VARCHAR(16) NOT NULL,
                 domain VARCHAR(255) NOT NULL,
                 batch_id integer,

--- a/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
@@ -32,6 +32,7 @@ sub patch_db_mysql {
 
     try {
         # update columns names, data type and default value
+        $dbh->do( 'ALTER TABLE test_results MODIFY COLUMN id BIGINT AUTO_INCREMENT' );
         $dbh->do( 'ALTER TABLE test_results CHANGE COLUMN creation_time created_at DATETIME NOT NULL' );
         $dbh->do( 'ALTER TABLE test_results CHANGE COLUMN test_start_time started_at DATETIME DEFAULT NULL' );
         $dbh->do( 'ALTER TABLE test_results CHANGE COLUMN test_end_time ended_at DATETIME DEFAULT NULL' );
@@ -59,6 +60,10 @@ sub patch_db_postgresql {
     $dbh->{AutoCommit} = 0;
 
     try {
+        # update sequence data type to BIGINT
+        $dbh->do( 'ALTER SEQUENCE test_results_id_seq AS BIGINT' );
+        $dbh->do( 'ALTER TABLE test_results ALTER COLUMN id SET DATA TYPE BIGINT' );
+
         # remove default value for "creation_time"
         $dbh->do( 'ALTER TABLE test_results ALTER COLUMN creation_time DROP DEFAULT' );
         $dbh->do( 'ALTER TABLE batch_jobs ALTER COLUMN creation_time DROP DEFAULT' );


### PR DESCRIPTION
## Purpose

Currently we store the index using an INTEGER in database. When using batches there is a risk we reach the upper limit.

## Context

n/a

## Changes

* update database schema for PostgreSQL and MySQL
* update the database upgrade script

## How to test this PR

Run the upgrade script and check that the `id` field has the right data type
