### PR TITLE
Fix handling of consecutive and final dots

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -551,7 +551,7 @@ sub _project_params {
             delete $$nameserver{ip};
         }
         $$nameserver{ns} = lc $$nameserver{ns};
-        $$nameserver{ns} =~ s/\.$//;
+        $$nameserver{ns} =~ s/\.$// unless $$nameserver{ns} eq '.';
     }
     my @array_nameservers_sort = sort {
         $a->{ns} cmp $b->{ns} or

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -530,6 +530,7 @@ sub _project_params {
     my %projection = ();
 
     $projection{domain}   = lc( $$params{domain}  // "" );
+    $projection{domain}   =~ s/\.$// unless $projection{domain} eq '.';
     $projection{ipv4}     = $$params{ipv4}       // $profile->get( 'net.ipv4' );
     $projection{ipv6}     = $$params{ipv6}       // $profile->get( 'net.ipv6' );
     $projection{profile}  = lc( $$params{profile} // "default" );
@@ -550,6 +551,7 @@ sub _project_params {
             delete $$nameserver{ip};
         }
         $$nameserver{ns} = lc $$nameserver{ns};
+        $$nameserver{ns} =~ s/\.$//;
     }
     my @array_nameservers_sort = sort {
         $a->{ns} cmp $b->{ns} or

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -297,6 +297,10 @@ sub check_domain {
         return  N__ 'The domain name character(s) are not supported';
     }
 
+    if ( $domain =~ m/\.\./i ) {
+        return  N__ 'The domain name contains consecutive dots';
+    }
+
     my %levels = Zonemaster::Engine::Logger::Entry::levels();
     my @res;
     @res = Zonemaster::Engine::Test::Basic->basic00( $domain );

--- a/share/fr.po
+++ b/share/fr.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-28 15:58+0200\n"
+"POT-Creation-Date: 2022-05-02 14:21+0200\n"
 "PO-Revision-Date: 2021-10-14 11:25+0200\n"
 "Last-Translator: \n"
 "Language-Team: Zonemaster project\n"
@@ -51,6 +51,9 @@ msgstr ""
 
 msgid "The domain name character(s) are not supported"
 msgstr "Les caractères du nom de domaine ne sont pas supportés"
+
+msgid "The domain name contains consecutive dots"
+msgstr "Le nom de domaine contient plusieurs points consécutifs"
 
 msgid "The domain name or label is too long"
 msgstr "Le nom de domaine ou les labels sont trop longs"

--- a/t/db.t
+++ b/t/db.t
@@ -180,6 +180,41 @@ subtest 'encoding and fingerprint' => sub {
         is $encoded_params, $expected_encoded_params, 'IDN domain: the encoded strings should match';
         is $fingerprint, $expected_fingerprint, 'IDN domain: correct fingerprint';
     };
+
+    subtest 'final dots' => sub {
+        subtest 'in domain' => sub {
+            my %params1 = ( domain => "example.com" );
+            my %params2 = ( domain => "example.com." );
+            my $expected_encoded_params = encode_utf8( '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}' );
+
+            my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
+            my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
+            is $fingerprint1, $fingerprint2, 'same fingerprint';
+            is $encoded_params1, $expected_encoded_params, 'the encoded strings should match';
+
+        };
+
+        subtest 'in nameserver' => sub {
+            my %params1 = ( domain => "example.com", nameservers => [ { ns => "ns1.example.com." } ] );
+            my %params2 = ( domain => "example.com", nameservers => [ { ns => "ns1.example.com" } ] );
+            my $expected_encoded_params = encode_utf8( '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[{"ns":"ns1.example.com"}],"profile":"default"}' );
+
+            my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
+            my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
+            is $fingerprint1, $fingerprint2, 'same fingerprint';
+            is $encoded_params1, $expected_encoded_params, 'the encoded strings should match';
+
+        };
+
+        subtest 'root is not modified' => sub {
+            my %params = ( domain => "." );
+            my $expected_encoded_params = encode_utf8( '{"domain":".","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}' );
+
+            my ( $encoded_params, $fingerprint ) = encode_and_fingerprint( \%params );
+            is $encoded_params, $expected_encoded_params, 'the encoded strings should match';
+
+        };
+    };
 };
 
 done_testing();

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -61,6 +61,16 @@ subtest 'Everything but NoWarnings' => sub {
         is( scalar @res, 0 );
     };
 
+    subtest 'consecutive dots' => sub {
+        my @res = start_domain_validate_params(
+            {
+                %$frontend_params, domain => 'afnic..fr'
+            }
+        );
+
+        is( scalar @res, 1 );
+    };
+
     subtest encode_utf8( 'idn domain=[é]' ) => sub {
         my @res = start_domain_validate_params(
             {


### PR DESCRIPTION
## Purpose

* NS with final dot should not make the test crash
* Having a final dot should not result in a different hash
* Domain with consecutive dots should not be accepted as valid

## Context

https://github.com/zonemaster/zonemaster-engine/issues/1055
https://github.com/zonemaster/zonemaster-backend/issues/854

## Changes

* Remove final dot from domain if not root
* Remove final dot from NS
* Return an error if a domain contains consecutive dots

## How to test this PR

* `./script/zmb start_domain_test --domain zonemaster.net  --nameserver ns2.nic.fr.:192.93.0.4` should not crash
* `./script/zmb start_domain_test --domain zonemaster.net.  --nameserver ns2.nic.fr:192.93.0.4` should return the same hash id
* `./script/zmb start_domain_test --domain zonemaster..net.  --nameserver ns2.nic.fr...:192.93.0.4` should return an validation error