### PR TITLE
Use libidn2 instead of libidn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ addons:
     - libclone-perl
     - libfile-sharedir-perl
     - libfile-slurp-perl
-    - libidn11-dev
+    - libidn2-dev
     - libintl-perl
     - libio-socket-inet6-perl
     - libjson-pp-perl

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -232,7 +232,7 @@ sub to_idn {
         return Zonemaster::LDNS::to_idn( $str );
     }
     else {
-        warn __( "Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII names correctly." );
+        warn __( "Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII names correctly." );
         return $str;
     }
 }

--- a/share/da.po
+++ b/share/da.po
@@ -48,9 +48,9 @@ msgid "Missing property"
 msgstr "Manglende egenskab"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
-msgstr "Advarsel: Zonemaster::LDNS ikke kompileret med libidn - kan ikke "
+msgstr "Advarsel: Zonemaster::LDNS ikke kompileret med libidn2 - kan ikke "
 "håndtere ikke-ascii-navne korrekt"
 
 msgid "The domain name contains a character or characters not supported"

--- a/share/es.po
+++ b/share/es.po
@@ -51,10 +51,10 @@ msgid "Missing property"
 msgstr "Propiedad no incluída"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
-"Advertencia: Zonemaster::LDNS no fue compilado con libidn, no se puede "
+"Advertencia: Zonemaster::LDNS no fue compilado con libidn2, no se puede "
 "manejar correctamente los nombres no-ASCII."
 
 msgid "The domain name contains a character or characters not supported"

--- a/share/fi.po
+++ b/share/fi.po
@@ -52,7 +52,7 @@ msgid "Missing property"
 msgstr "Kenttä puuttuu"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
 "Varoitus: Zonemaster :: LDNS ei ole käännetty libidnillä, eikä pysty "

--- a/share/fr.po
+++ b/share/fr.po
@@ -18,7 +18,7 @@ msgid "Missing property"
 msgstr "Champ manquant"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
 

--- a/share/nb.po
+++ b/share/nb.po
@@ -49,10 +49,10 @@ msgid "Missing property"
 msgstr "Mangler verdi"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
-"Advarsel: Zonemaster::LDNS som ikke er kompilert med libidn kan ikke "
+"Advarsel: Zonemaster::LDNS som ikke er kompilert med libidn2 kan ikke "
 "håndtere non-ASCII navn korrekt."
 
 msgid "The domain name contains a character or characters not supported"

--- a/share/sv.po
+++ b/share/sv.po
@@ -51,10 +51,10 @@ msgid "Missing property"
 msgstr "Värde saknas"
 
 msgid ""
-"Warning: Zonemaster::LDNS not compiled with libidn, cannot handle non-ASCII "
+"Warning: Zonemaster::LDNS not compiled with libidn2, cannot handle non-ASCII "
 "names correctly."
 msgstr ""
-"Varning: Zonemaster::LDNS har inte kompilerats med libidn vilket gör att "
+"Varning: Zonemaster::LDNS har inte kompilerats med libidn2 vilket gör att "
 "icke-ASCII-strängar inte kan hanteras korrekt"
 
 msgid "The domain name contains a character or characters not supported"


### PR DESCRIPTION
## Purpose

Replace libidn with libidn2.

## Context

https://github.com/zonemaster/zonemaster-ldns/pull/133

## Changes

* Update Travis dependency
* Replace references to "libidn" with "libidn2"

## How to test this PR

Using Zonemaster::LDNS (with libidn2 support), Zonemaster should work the same as before.