### PR TITLE
Fix zmb as empty string is no longer accepted in IP field

### DIFF
--- a/script/zmb
+++ b/script/zmb
@@ -218,12 +218,11 @@ sub cmd_start_domain_test {
         my @nameserver_objects;
         for my $domain_ip_pair ( @opt_nameserver ) {
             my ( $domain, $ip ) = split /:/, $domain_ip_pair, 2;
-            $ip //= "";
-            push @nameserver_objects,
-              {
-                ns => $domain,
-                ip => $ip,
-              };
+            if ($ip) {
+                push @nameserver_objects, { ns => $domain, ip => $ip };
+            } else {
+                push @nameserver_objects, { ns => $domain };
+            }
         }
         $params{nameservers} = \@nameserver_objects;
     }


### PR DESCRIPTION
## Purpose

* Do not send IP in NS if there is no IP to send

## Context

A side effect of https://github.com/zonemaster/zonemaster-backend/pull/957 is that the IP fields no longer accept the empty string as a valid value. After reading through the API documentation it appears that the empty string was never documented as being an accepted value so I do not consider it a breaking change.

## Changes

* Omit IP field if it no IP was given

## How to test this PR

* `./script/zmb start_domain_test --domain zonemaster.net.  --nameserver ns2.nic.fr` should work fine again
