### PR TITLE
Simplify test progress' computation

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -209,6 +209,16 @@ sub recent_test_hash_id {
     return $recent_hash_id;
 }
 
+=head2 test_progress($test_id, $progress)
+
+Takes a test_id and returns the current progress value for the associated test.
+If progress is set, update the progress value of the test.
+If the progress value is 1, set the C<started_at> field to the current time in UTC.
+
+The progress value is an integer in the range 0-100.
+
+=cut
+
 sub test_progress {
     my ( $self, $test_id, $progress ) = @_;
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -215,7 +215,7 @@ Takes a test_id and returns the current progress value for the associated test.
 If progress is set, update the progress value of the test.
 If the progress value is 1, set the C<started_at> field to the current time in UTC.
 
-The progress value is an integer in the range 0-100.
+The C<$progress> value is an integer in the range 1-99.
 
 =cut
 
@@ -224,6 +224,8 @@ sub test_progress {
 
     my $dbh = $self->dbh;
     if ( $progress ) {
+        $progress = $progress < 1 ? 1 :
+                    $progress > 99 ? 99 : $progress;
         if ( $progress == 1 ) {
             $dbh->do(
                 q[

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -122,7 +122,7 @@ sub run {
                 if ( $entry->{tag} and $entry->{tag} eq 'TEST_CASE_END' ) {
                     $nbr_testcases_finished++;
                     # limit to max 99%, 100% is reached when data is stored in database
-                    my $progress_percent = 99 * $nbr_testcases_finished /  $nbr_testcases_planned;
+                    my $progress_percent = int( 99 * $nbr_testcases_finished /  $nbr_testcases_planned );
                     $self->{_db}->test_progress( $test_id, $progress_percent );
                 }
             }

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -101,22 +101,21 @@ sub run {
         Zonemaster::Engine::Profile->effective->set( q{net.ipv6}, ( $params->{ipv6} ) ? ( 1 ) : ( 0 ) );
     }
 
-    my %methods = Zonemaster::Engine->all_methods;
+    if ( $show_progress ) {
+        my %methods = Zonemaster::Engine->all_methods;
 
-    # BASIC methods are always run: Basic0{0..4}
-    my $nbr_testcases_planned = 5;
-    my $nbr_testcases_finished = 0;
+        # BASIC methods are always run: Basic0{0..4}
+        my $nbr_testcases_planned = 5;
+        my $nbr_testcases_finished = 0;
 
-    foreach my $module ( keys %methods ) {
-        foreach my $method ( @{ $methods{$module} } ) {
-            if ( Zonemaster::Engine::Util::should_run_test( $method ) ) {
-                $nbr_testcases_planned++;
+        foreach my $module ( keys %methods ) {
+            foreach my $method ( @{ $methods{$module} } ) {
+                if ( Zonemaster::Engine::Util::should_run_test( $method ) ) {
+                    $nbr_testcases_planned++;
+                }
             }
         }
-    }
 
-
-    if ( $show_progress ) {
         Zonemaster::Engine->logger->callback(
             sub {
                 my ( $entry ) = @_;

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -113,6 +113,7 @@ sub run {
         }
     }
 
+    my @planned_methods = sort keys %{ $counter_for_progress_indicator{planned} };
 
     # used for progress indicator
     my ( $previous_module, $previous_method ) = ( '', '' );
@@ -124,7 +125,7 @@ sub run {
                 my ( $entry ) = @_;
 
                 foreach my $trace ( reverse @{ $entry->trace } ) {
-                    foreach my $module_method ( keys %{ $counter_for_progress_indicator{planned} } ) {
+                    foreach my $module_method ( @planned_methods ) {
                         if ( index( $trace->[1], $module_method ) > -1 ) {
                             my $percent_progress = 0;
                             my ( $module ) = ( $module_method =~ /(.+::)[^:]+/ );
@@ -132,7 +133,7 @@ sub run {
                                 $counter_for_progress_indicator{executed}{$module_method}++;
                             }
                             elsif ( $previous_module ) {
-                                foreach my $planned_module_method ( keys %{ $counter_for_progress_indicator{planned} } ) {
+                                foreach my $planned_module_method ( @planned_methods ) {
                                     if ( $counter_for_progress_indicator{planned}{$planned_module_method} eq $previous_module ) {
                                         $counter_for_progress_indicator{executed}{$planned_module_method}++;
                                     }
@@ -145,7 +146,7 @@ sub run {
                                     "%.0f",
                                     99 * (
                                         scalar( keys %{ $counter_for_progress_indicator{executed} } ) /
-                                          scalar( keys %{ $counter_for_progress_indicator{planned} } )
+                                          scalar( @planned_methods )
                                     )
                                 );
                                 $self->{_db}->test_progress( $test_id, $percent_progress );

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -123,11 +123,7 @@ sub run {
                 my ( $entry ) = @_;
                 if ( $entry->{tag} and $entry->{tag} eq 'TEST_CASE_END' ) {
                     $nbr_testcases_finished++;
-                    my $progress_percent = sprintf(
-                        "%.0f",
-                        99 * $nbr_testcases_finished /  $nbr_testcases_planned
-                    );
-
+                    my $progress_percent = 99 * $nbr_testcases_finished /  $nbr_testcases_planned;
                     $self->{_db}->test_progress( $test_id, $progress_percent );
                 }
             }

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -105,6 +105,14 @@ sub run {
 
     my %methods = Zonemaster::Engine->all_methods;
 
+    # BASIC methods are always run
+    $counter_for_progress_indicator{planned} = {
+        'Basic::basic00' => 'Basic::',
+        'Basic::basic01' => 'Basic::',
+        'Basic::basic02' => 'Basic::',
+        'Basic::basic03' => 'Basic::',
+        'Basic::basic04' => 'Basic::',
+    };
     foreach my $module ( keys %methods ) {
         foreach my $method ( @{ $methods{$module} } ) {
             if ( Zonemaster::Engine::Util::should_run_test( $method ) ) {

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -61,7 +61,6 @@ sub new {
 sub run {
     my ( $self, $test_id, $show_progress ) = @_;
     my @accumulator;
-    my %counter;
     my %counter_for_progress_indicator;
 
     my $params;
@@ -164,8 +163,6 @@ sub run {
                         }
                     }
                 }
-
-                $counter{ uc $entry->level } += 1;
             }
         );
     }

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -123,6 +123,7 @@ sub run {
                 my ( $entry ) = @_;
                 if ( $entry->{tag} and $entry->{tag} eq 'TEST_CASE_END' ) {
                     $nbr_testcases_finished++;
+                    # limit to max 99%, 100% is reached when data is stored in database
                     my $progress_percent = 99 * $nbr_testcases_finished /  $nbr_testcases_planned;
                     $self->{_db}->test_progress( $test_id, $progress_percent );
                 }

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -117,7 +117,6 @@ sub run {
 
 
     if ( $show_progress ) {
-        # Callback defined here so it closes over the setup above.
         Zonemaster::Engine->logger->callback(
             sub {
                 my ( $entry ) = @_;

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -106,16 +106,16 @@ sub run {
 
     # BASIC methods are always run
     $counter_for_progress_indicator{planned} = {
-        'Basic::basic00' => 'Basic::',
-        'Basic::basic01' => 'Basic::',
-        'Basic::basic02' => 'Basic::',
-        'Basic::basic03' => 'Basic::',
-        'Basic::basic04' => 'Basic::',
+        'Basic::basic00' => 1,
+        'Basic::basic01' => 1,
+        'Basic::basic02' => 1,
+        'Basic::basic03' => 1,
+        'Basic::basic04' => 1,
     };
     foreach my $module ( keys %methods ) {
         foreach my $method ( @{ $methods{$module} } ) {
             if ( Zonemaster::Engine::Util::should_run_test( $method ) ) {
-                $counter_for_progress_indicator{planned}{ $module . '::' . $method } = $module . '::';
+                $counter_for_progress_indicator{planned}{ $module . '::' . $method } = 1;
             }
         }
     }


### PR DESCRIPTION
## Purpose

The progress computation relies on parsing the logger trace which is quite heavy work. It appears that the searched values are available in the entry directly when receiving "TEST_CASE_END" message (at least).

## Context

n/a

## Changes

* Fix the total number of planned methods (check that each method is part of the current profile)
* Update TestAgent.pm and the progress computation
* Provide some small refactoring (see the commits' history to follow the changes)

## How to test this PR

Tests should pass.

## Note

I've set this PR to next release, I think this is a nice improvement that removes some heavy code and computation power. However this is totally fine to move it to v2022.2 if it appears to be too short to have a proper review process.