### PR TITLE
Removes Locale::Msgfmt as required from Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,8 +9,6 @@ bugtracker 'https://github.com/zonemaster/zonemaster-backend/issues';
 # "2.1.0" could be declared as "2.001" but not as "2.1"
 # (see Zonemaster::LDNS below)
 
-configure_requires 'Locale::Msgfmt' => 0.15;
-
 requires
   'Class::Method::Modifiers'    => 1.09,
   'Config::IniFiles'            => 0,


### PR DESCRIPTION
## Purpose

Removes Locale::Msgfmt from Makefile.PL as required since it is not used

## Context

Resolves #990

## Changes

Updates Makefile.PL

## How to test this PR

Backend should not complain of missing Locale::Msgfmt and Locale::Msgfmt should not be installed.
