### PR TITLE
Don't set pid in log context

### DIFF
--- a/script/zonemaster_backend_testagent
+++ b/script/zonemaster_backend_testagent
@@ -67,7 +67,6 @@ Log::Any::Adapter->set(
     json => $logjson,
     file => $logfile,
 );
-$log->context->{pid} = $PID;
 
 $SIG{__WARN__} = sub {
     $log->warning(map s/^\s+|\s+$//gr, map s/\n/ /gr, @_);


### PR DESCRIPTION
## Purpose

Fix regression from #966 

## Context

\-

## Changes

* remove line setting pid in context at start of test agent

## How to test this PR

* Run test agent and rpcapi
* Start a test
* Check that the pid changes when the test start (59623 and 59634 in the following example)

`perl script/zonemaster_backend_testagent --logfile=- --outfile=/tmp/zonemaster_testagent.out --loglevel=debug foreground --logjson | jq -c`
```json
{"category":"main","level":"debug","message":"Starting pre-flight check","pid":59623,"timestamp":"2022-05-02T13:21:34Z"}
{"category":"Zonemaster::Backend::Config","level":"notice","message":"Loading config: /home/gbm/workspace/zonemaster/backend_config.ini","pid":59623,"timestamp":"2022-05-02T13:21:34Z"}
{"category":"main","level":"debug","message":"Completed pre-flight check","pid":59623,"timestamp":"2022-05-02T13:21:35Z"}
{"category":"main","level":"notice","message":"Daemon spawned","pid":59623,"timestamp":"2022-05-02T13:21:35Z"}
{"category":"Zonemaster::Backend::DB","level":"notice","message":"Connecting to database 'DBI:Pg:dbname=travis_zonemaster;host=10.10.86.42;port=5432' as user 'travis_zonemaster'","pid":59623,"timestamp":"2022-05-02T13:21:36Z"}
{"category":"main","level":"info","message":"Test found: b6abef8460ef8541","pid":59623,"timestamp":"2022-05-02T13:21:40Z"}
{"category":"main","level":"info","message":"Test starting: b6abef8460ef8541","pid":59634,"timestamp":"2022-05-02T13:21:40Z"}
{"category":"Zonemaster::Backend::DB","level":"notice","message":"Connecting to database 'DBI:Pg:dbname=travis_zonemaster;host=10.10.86.42;port=5432' as user 'travis_zonemaster'","pid":59634,"timestamp":"2022-05-02T13:21:40Z"}
{"category":"main","level":"info","message":"Test completed: b6abef8460ef8541","pid":59634,"timestamp":"2022-05-02T13:21:41Z"}
{"category":"Zonemaster::Backend::Config","level":"notice","message":"Worker process (pid 59634, testid b6abef8460ef8541): Terminated with exit code 0","pid":59623,"timestamp":"2022-05-02T13:21:41Z"}
```
