### PR TITLE
Don't die if domain is '0'

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -255,7 +255,7 @@ sub start_domain_test {
     eval {
         $params->{domain} =~ s/^\.// unless ( !$params->{domain} || $params->{domain} eq '.' );
 
-        die "No domain in parameters\n" unless ( $params->{domain} );
+        die "No domain in parameters\n" unless ( defined $params->{domain} && length($params->{domain}) );
 
         $params->{priority}  //= 10;
         $params->{queue}     //= 0;


### PR DESCRIPTION
## Purpose

When starting a test with `0` as domain the test does not start and a error is returned to the user:
```
./script/zmb start_domain_test --domain 0 | jq
{
  "id": 1,
  "jsonrpc": "2.0",
  "error": {
    "code": -32603,
    "data": null,
    "message": "Internal server error"
  }
}
```
relevant rpcapi log entry:
```json
{
  "category": "Zonemaster::Backend::RPCAPI",
  "code": -32603,
  "error": "Zonemaster::Backend::Error::Internal",
  "level": "error",
  "message": "Caught Zonemaster::Backend::Error::Internal in the `Zonemaster::Backend::RPCAPI::start_domain_test` method: No domain in parameters",
  "method": "Zonemaster::Backend::RPCAPI::start_domain_test",
  "pid": 70063,
  "reason": "No domain in parameters\n",
  "rpc_method": "start_domain_test",
  "timestamp": "2022-05-02T15:06:45Z"
}
```

This PR intends to fix this issue.

## Context

\-

## Changes

* Change the condition on which the method dies

## How to test this PR

* `./script/zmb start_domain_test --domain 0` should return a test id
