### PR TITLE
fix initialization of logger when level variable is undef

### DIFF
--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -18,7 +18,8 @@ my $trace_level = Log::Any::Adapter::Util::numeric_level('trace');
 sub init {
     my ($self) = @_;
 
-    if ( exists $self->{log_level} && $self->{log_level} =~ /\D/ ) {
+    if ( defined $self->{log_level} && $self->{log_level} =~ /\D/ ) {
+        $self->{log_level} = lc $self->{log_level};
         my $numeric_level = Log::Any::Adapter::Util::numeric_level( $self->{log_level} );
         if ( !defined($numeric_level) ) {
             croak "Error: Unrecognized log level " . $self->{log_level} . "\n";

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -30,7 +30,7 @@ local $| = 1;
 
 Log::Any::Adapter->set(
     '+Zonemaster::Backend::Log',
-    log_level => lc $ENV{ZM_BACKEND_RPCAPI_LOGLEVEL},
+    log_level => $ENV{ZM_BACKEND_RPCAPI_LOGLEVEL},
     json => $ENV{ZM_BACKEND_RPCAPI_LOGJSON},
     stderr => 1
 );


### PR DESCRIPTION
## Purpose

Fix logger initialization when passing an undefined level. For instance when the environment variable not present the following error messages are displayed

```
Use of uninitialized value $ENV{"ZM_BACKEND_RPCAPI_LOGLEVEL"} in lc at /home/gbm/workspace/zonemaster/zonemaster-backend/script/zonemaster_backend_rpcapi.psgi line 35, <DATA> line 1.
Argument "" isn't numeric in numeric le (<=) at /home/gbm/workspace/zonemaster/zonemaster-backend/lib/Zonemaster/Backend/Log.pm line 121, <DATA> line 1.
```

## Context

\-

## Changes

* Do log level normalization after checking that it is defined
* Use default level when level is undef

## How to test this PR

* Start the RPCAPI after unsetting the log level environment variable.
```
unset ZM_BACKEND_RPCAPI_LOGLEVEL
starman --preload-app script/zonemaster_backend_rpcapi.psgi
```
* Make sure not error message is displayed.
* Check that messages (e.g. "Loading config") are correctly logged.
