### PR TITLE
Normalize domain column

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -136,7 +136,7 @@ sub create_new_test {
 
     my $dbh = $self->dbh;
 
-    $test_params->{domain} = $domain;
+    $test_params->{domain} = _normalize_domain( $domain );
 
     my $fingerprint = $self->generate_fingerprint( $test_params );
     my $encoded_params = $self->encode_params( $test_params );

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -585,6 +585,17 @@ sub process_dead_test {
     $self->force_end_test($hash_id, $results, $self->get_relative_start_time($hash_id));
 }
 
+# Converts the domain to lowercase and if the domain is not the root ('.')
+# removes any trailing dot
+sub _normalize_domain {
+    my ( $domain ) = @_;
+
+    $domain = lc( $domain );
+    $domain =~ s/\.$// unless $domain eq '.';
+
+    return $domain;
+}
+
 sub _project_params {
     my ( $self, $params ) = @_;
 
@@ -592,8 +603,7 @@ sub _project_params {
 
     my %projection = ();
 
-    $projection{domain}   = lc( $$params{domain}  // "" );
-    $projection{domain}   =~ s/\.$// unless $projection{domain} eq '.';
+    $projection{domain}   = _normalize_domain( $$params{domain} // "" );
     $projection{ipv4}     = $$params{ipv4}       // $profile->get( 'net.ipv4' );
     $projection{ipv6}     = $$params{ipv6}       // $profile->get( 'net.ipv6' );
     $projection{profile}  = lc( $$params{profile} // "default" );
@@ -613,8 +623,7 @@ sub _project_params {
         if ( defined $$nameserver{ip} and $$nameserver{ip} eq "" ) {
             delete $$nameserver{ip};
         }
-        $$nameserver{ns} = lc $$nameserver{ns};
-        $$nameserver{ns} =~ s/\.$// unless $$nameserver{ns} eq '.';
+        $$nameserver{ns} = _normalize_domain( $$nameserver{ns} );
     }
     my @array_nameservers_sort = sort {
         $a->{ns} cmp $b->{ns} or

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -349,7 +349,7 @@ sub get_test_history {
 
     my $sth = $dbh->prepare( $query );
 
-    $sth->bind_param( 1, $p->{frontend_params}{domain} );
+    $sth->bind_param( 1, _normalize_domain( $p->{frontend_params}{domain} ) );
     $sth->bind_param( 2, $undelegated, SQL_INTEGER );
     $sth->bind_param( 3, $undelegated, SQL_INTEGER );
     $sth->bind_param( 4, $p->{limit} );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -198,7 +198,7 @@ sub add_batch_job {
             ],
         );
         foreach my $domain ( @{$params->{domains}} ) {
-            $test_params->{domain} = $domain;
+            $test_params->{domain} = _normalize_domain( $domain );
 
             my $fingerprint = $self->generate_fingerprint( $test_params );
             my $encoded_params = $self->encode_params( $test_params );

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -201,7 +201,7 @@ sub add_batch_job {
         );
 
         foreach my $domain ( @{$params->{domains}} ) {
-            $test_params->{domain} = $domain;
+            $test_params->{domain} = _normalize_domain( $domain );
 
             my $fingerprint = $self->generate_fingerprint( $test_params );
             my $encoded_params = $self->encode_params( $test_params );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -177,7 +177,7 @@ sub add_batch_job {
             ) VALUES (?,?,?,?,?,?,?,?,?)'
         );
         foreach my $domain ( @{$params->{domains}} ) {
-            $test_params->{domain} = $domain;
+            $test_params->{domain} = _normalize_domain( $domain );
 
             my $fingerprint = $self->generate_fingerprint( $test_params );
             my $encoded_params = $self->encode_params( $test_params );

--- a/t/test01.t
+++ b/t/test01.t
@@ -405,6 +405,26 @@ subtest 'check historic tests' => sub {
     is( scalar( @$test_history_delegated ), 1, 'One delegated test created' );
     # diag explain( $test_history_undelegated );
     is( scalar( @$test_history_undelegated ), 2, 'Two undelegated tests created' );
+
+    subtest 'domain is case and trailing dot insensitive' => sub {
+        my $test_history_delegated = $backend->get_test_history(
+            {
+                filter => 'delegated',
+                frontend_params => {
+                    domain => $domain . '.',
+                }
+            } );
+        my $test_history_undelegated = $backend->get_test_history(
+            {
+                filter => 'undelegated',
+                frontend_params => {
+                    domain => ucfirst( $domain ),
+                }
+            } );
+
+        is( scalar( @$test_history_delegated ), 1, 'One delegated test created' );
+        is( scalar( @$test_history_undelegated ), 2, 'Two undelegated tests created' );
+    };
 };
 
 subtest 'normalize "domain" column' => sub {

--- a/t/test01.t
+++ b/t/test01.t
@@ -407,6 +407,27 @@ subtest 'check historic tests' => sub {
     is( scalar( @$test_history_undelegated ), 2, 'Two undelegated tests created' );
 };
 
+subtest 'normalize "domain" column' => sub {
+    my %domains_to_test = (
+        "aFnIc.Fr"  => "afnic.fr",
+        "afnic.fr." => "afnic.fr",
+        "aFnic.Fr." => "afnic.fr"
+    );
+
+    my $test_params = {
+        client_id      => 'Unit Test',
+        client_version => '1.0',
+    };
+
+    while ( my ($domain, $expected) = each (%domains_to_test) ) {
+        $test_params->{domain} = $domain;
+
+        $hash_id = $backend->start_domain_test( $test_params );
+        my ( $db_domain ) = $dbh->selectrow_array( "SELECT domain FROM test_results WHERE hash_id=?", undef, $hash_id );
+        is( $db_domain, $expected, 'stored domain name is normalized' );
+    }
+};
+
 if ( $ENV{ZONEMASTER_RECORD} ) {
     Zonemaster::Engine->save_cache( $datafile );
 }


### PR DESCRIPTION
## Purpose

Store the normalized domain value in the "domain" column in database.

## Context

Follow-up of #983 

## Changes

Database files.
Normalize passed "domain" in get_test_history() before retrieval (since domains are now normalized in database).
Update the upgrade script.

## How to test this PR

Unit tests are added, they should pass. Or start a test with a trailing dot to the domain (and/or with uppercase letters), the domain stored in database should be normalized.

Using the upgrade script should remove any trailing dot from the domain column, as well as down casing it.