### PR TITLE
Allow --queue in zmb's "start_domain_test" command's options

### DIFF
--- a/script/zmb
+++ b/script/zmb
@@ -152,6 +152,7 @@ sub cmd_get_language_tags {
     --client-id CLIENT_ID
     --client-version CLIENT_VERSION
     --profile PROFILE_NAME
+    --queue QUEUE
     --language LANGUAGE
 
  DS_INFO is a comma separated list of key-value pairs. The expected pairs are:
@@ -174,6 +175,7 @@ sub cmd_start_domain_test {
     my $opt_ipv4;
     my $opt_ipv6;
     my $opt_profile;
+    my $opt_queue;
     my $opt_language;
     GetOptionsFromArray(
         \@opts,
@@ -185,6 +187,7 @@ sub cmd_start_domain_test {
         'ipv4=s'           => \$opt_ipv4,
         'ipv6=s'           => \$opt_ipv6,
         'profile=s'        => \$opt_profile,
+        'queue=s'          => \$opt_queue,
         'language=s'       => \$opt_language,
     ) or pod2usage( 2 );
 
@@ -237,6 +240,10 @@ sub cmd_start_domain_test {
 
     if ( $opt_profile ) {
         $params{profile} = $opt_profile;
+    }
+
+    if ( $opt_queue ) {
+        $params{queue} = $opt_queue;
     }
 
     if ( $opt_language ) {

--- a/script/zmb
+++ b/script/zmb
@@ -452,6 +452,7 @@ sub cmd_add_api_user {
     --client-id CLIENT_ID
     --client-version CLIENT_VERSION
     --profile PROFILE_NAME
+    --queue QUEUE
 
  "--domain" is repeated for each domain to be tested.
  "--nameserver" can be repeated for each name server.
@@ -479,6 +480,7 @@ sub cmd_add_batch_job {
     my $opt_ipv4;
     my $opt_ipv6;
     my $opt_profile;
+    my $opt_queue;
     GetOptionsFromArray(
         \@opts,
         'username|u=s'     => \$opt_username,
@@ -491,6 +493,7 @@ sub cmd_add_batch_job {
         'ipv4=s'           => \$opt_ipv4,
         'ipv6=s'           => \$opt_ipv6,
         'profile=s'        => \$opt_profile,
+        'queue=s'          => \$opt_queue,
     ) or pod2usage( 2 );
 
 
@@ -547,6 +550,10 @@ sub cmd_add_batch_job {
 
     if ( $opt_profile ) {
         $params{test_params}{profile} = $opt_profile;
+    }
+
+    if ( $opt_queue ) {
+        $params{test_params}{queue} = $opt_queue;
     }
 
     return to_jsonrpc(


### PR DESCRIPTION
## Purpose

This PR adds the --queue option to zmb's "start_domain_test" and "add_batch_job" commands.

## Context

Resolves #1002 

## Changes

...

## How to test this PR

1. Keep `lock_on_queue` to default value (0).
2. Create tests with `queue` set to 5.
3. Verify that the new tests are never run.
4. Set `lock_on_queue` to 5 under `ZONEMASTER` section in backend_config.ini and restart Backend.
5. Verify that tests with `queue` 5 are run, but not tests with `queue` 0.

