### PR TITLE
Adds missing default value in ZONEMASTER section

### DIFF
--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -24,6 +24,7 @@ database_file = /var/lib/zonemaster/db.sqlite
 #max_zonemaster_execution_time            = 600
 #number_of_processes_for_frontend_testing = 20
 #number_of_processes_for_batch_testing    = 20
+#lock_on_queue                            = 0
 #age_reuse_previous_test                  = 600
 
 [RPCAPI]


### PR DESCRIPTION
## Purpose

Adds the missing `lock_on_queue` key under ZONEMASTER section in backend_config.ini.

The key is commented so it does not change any execution. It is there to make it easy for the user to change the value.

This PR is related to #1006.

## How to test this PR

Nothing to test. Reviewing is enough.
