### PR TITLE
Test reuse - do not reuse tests created by a batch

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -198,6 +198,7 @@ sub recent_test_hash_id {
             SELECT hash_id
             FROM test_results
             WHERE fingerprint = ?
+              AND batch_id IS NULL
               AND ( started_at IS NULL
                  OR started_at >= ? )
         ],

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -141,7 +141,9 @@ subtest 'Everything but Test::NoWarnings' => sub {
             );
             @batch_test_ids = map { $$_[0] } @batch_test_ids;
 
-            is( @batch_test_ids, 2, 'two test created in batch' );
+            if ( @batch_test_ids != 2 ) {
+                BAIL_OUT( 'There should be 2 tests in database for this batch_id' );
+            }
 
             my ( $count_zone1 ) = $db->dbh->selectrow_array(
                 q[

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -112,6 +112,48 @@ subtest 'Everything but Test::NoWarnings' => sub {
 
             is count_cancellation_messages( $db->test_results( $testid4 ) ), 1, 'one cancellation message present after crash';
         };
+
+        subtest 'Do not reuse batch tests' => sub {
+            my %user = (
+                username => "user",
+                api_key  => "key"
+            );
+            my @domains = ( 'zone1.rpcapi.example', 'zone5.rpcapi.example' );
+            my $params = {
+                %user,
+                domains => \@domains,
+                test_params => {
+                    priority => 5,
+                    queue   => 0
+                }
+            };
+            $db->add_api_user( $user{username}, $user{api_key} );
+            my $batch_id = $db->add_batch_job( $params );
+
+            my @batch_test_ids = $db->dbh->selectall_array(
+                q[
+                    SELECT hash_id
+                    FROM test_results
+                    WHERE batch_id = ?
+                ],
+                undef,
+                $batch_id
+            );
+            @batch_test_ids = map { $$_[0] } @batch_test_ids;
+
+            is( @batch_test_ids, 2, 'two test created in batch' );
+
+            my ( $count_zone1 ) = $db->dbh->selectrow_array(
+                q[
+                    SELECT count(*)
+                    FROM test_results
+                    WHERE domain = 'zone1.rpcapi.example'
+                ]
+            );
+            is( $count_zone1, 3, '3 tests for domain "zone1.rpcapi.example' );
+            my $test_id = $db->create_new_test( 'zone5.rpcapi.example', {}, 10 );
+            ok( ! grep(/$test_id/, @batch_test_ids), 'new single test should not reuse batch tests' );
+        };
     };
 };
 


### PR DESCRIPTION
## Purpose

After thinking about test reusability between single tests and batch tests, I do agree that we need to properly handle things. This is about making the following choice:
* a batch test is never reused
* a single test can only be reused by a single test

## Context

#979, and all discussions on whether to reuse tests or not and how 

## Changes

Update a database call to exclude all tests started as batch.

## How to test this PR

A unit test is added along the PR.

---

### Some notes I used to get a better picture of the reusability problem

A test can be created in two different ways:
* as a _single test_
* as a _batch test_

One of the goal of test reuse is to avoid duplicates in database and gives a quick response to similar queries. Deciding that a test can always be reused would give the following constraints:
* a _single test_ has a higher precedence and need to be executed quickly (do not wait for a whole batch to finish)
* a _batch test_ should be associated to its batch creator (currently with the `batch_id` field)

To execute a test before any other, its `priority` can be increased.
To associate a test to a batch, its `batch_id` can be set.

Here are the different possibilities:

| | **reused as _single test_** | **reused as _batch test_** |
| :---: | :---: | :---: |
| **created as _single test_** | n/a | update the `batch_id` |
| **created as _batch test_** | update the `priority` | ?? | 

When it comes to reusing a _batch test_ within another batch, there is some work to associate this test to both (or more) batches. Thinking quickly about this, this could be achieved with a new table `batch_tests` that associates a `test_id` with a `batch_id`.

#### But then how can we deal with the current issue raised in #979?

The goal is to let a TestAgent know if a test is currently used as a _single test_ or not to be able to gradually update its `progress`.
In other word, if a test is only used in a batch context (and only if) then its `progress` is not updated.

How can we let the TestAgent know that a test is currently running as a _single test_?

This sounds like a tricky question to answer.

#### Using separate sets

If we chose to use distinct sets (which is something that has been considered but [we chose](https://github.com/zonemaster/zonemaster-backend/issues/840#issuecomment-901731760) [to try to use](https://github.com/zonemaster/zonemaster-backend/issues/840#issuecomment-901740711) [one unique set](https://github.com/zonemaster/zonemaster-backend/issues/840#issuecomment-919807767)), the problem is now much easier. We only have to look at the `batch_id` field to know if a test is used as a _single test_ or a _batch test_.

For now, we can stick to this scenario:
* a _single test_ can only be reused by another _single test_
* any tests created within a batch are created without looking for any previous test to reuse