### PR TITLE
Fix log output

### DIFF
--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -14,7 +14,7 @@ use Data::Dumper;
 use base qw(Log::Any::Adapter::Base);
 
 
-my $trace_level = Log::Any::Adapter::Util::numeric_level('trace');
+my $default_level = Log::Any::Adapter::Util::numeric_level('info');
 
 sub init {
     my ($self) = @_;
@@ -28,7 +28,7 @@ sub init {
         $self->{log_level} = $numeric_level;
     }
 
-    $self->{log_level} //= $trace_level;
+    $self->{log_level} //= $default_level;
 
     my $fd;
     if ( !exists $self->{file} || $self->{file} eq '-') {

--- a/lib/Zonemaster/Backend/Log.pm
+++ b/lib/Zonemaster/Backend/Log.pm
@@ -6,6 +6,7 @@ package Zonemaster::Backend::Log;
 use English qw( $PID );
 use POSIX;
 use JSON::PP;
+use IO::Handle;
 use Log::Any::Adapter::Util ();
 use Carp;
 use Data::Dumper;
@@ -32,9 +33,9 @@ sub init {
     my $fd;
     if ( !exists $self->{file} || $self->{file} eq '-') {
         if ( $self->{stderr} ) {
-            open( $fd, '>&', \*STDERR ) or croak "Can't dup STDERR: $!";
+            $fd = fileno(STDERR);
         } else {
-            open( $fd, '>&', \*STDOUT ) or croak "Can't dup STDOUT: $!";
+            $fd = fileno(STDOUT);
         }
     } else {
         open( $fd, '>>', $self->{file} ) or croak "Can't open log file: $!";


### PR DESCRIPTION
## Purpose

Fixes log messages not being redirected to log file when using starman.

## Context

fixes #1013

## Changes

* Don't duplicate the STDERR so log message are correctly redirected.
* Changes the default log level to `info` so that the default log level in RPCAPI is the same as the one in agent.
* Imports missing dependency.

## How to test this PR

Start the RPCAPI:
```
unset ZM_BACKEND_RPCAPI_LOGLEVEL
starman --preload-app --error-log=/tmp/zm-rpcapi.log --pid=/tmp/zm-rpcapi.pid --listen=127.0.0.1:5000  script/zonemaster_backend_rpcapi.psgi
```
 In another terminal start a new test:
```
./script/zmb start_domain_test --domain zonemaster.net
```

Only the pre-fork log messages should be displayed in STDERR:
```
2022-05-18T10:43:06Z [52630] [NOTICE] [Zonemaster::Backend::Config] Loading config: /tmp/zonemaster/backend_config.ini
2022-05-18T10:43:06Z [52630] [INFO] [Plack::Sandbox::_2fhome_2fgbm_2fworkspace_2fzonemaster_2fzonemaster_2dbackend_2fscript_2fzonemaster_backend_rpcapi_2epsgi] Enabling add_api_user method
2022-05-18T10:43:06Z [52630] [INFO] [Plack::Sandbox::_2fhome_2fgbm_2fworkspace_2fzonemaster_2fzonemaster_2dbackend_2fscript_2fzonemaster_backend_rpcapi_2epsgi] Enabling add_batch_job method
```

The file `/tmp/zm-rpcapi.log` should contain a line indicating the DB connection:
```
2022/05/18-12:39:12 Starman::Server (type Net::Server::PreFork) starting! pid(51380)
Binding to TCP port 5000 on host 127.0.0.1 with IPv4
Setting gid to "1000 1000 3 90 98 963 966 991 998 1000"
2022-05-18T10:39:15Z [51381] [NOTICE] [Zonemaster::Backend::DB] Connecting to database 'DBI:Pg:dbname=travis_zonemaster;host=10.10.86.42;port=5432' as user 'travis_zonemaster' Extra parameters: {'rpc_method' => 'start_domain_test'}
```

