### PR TITLE
Dependencies: upgrade some versions and add a missing one

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,6 +43,7 @@ test_requires 'DBD::SQLite' => 1.4702;
 test_requires 'Test::NoWarnings';
 test_requires 'Test::Exception';
 test_requires 'Test::Differences';
+test_requires 'Time::Local' => 1.26;
 
 recommends 'DBD::mysql';
 recommends 'DBD::Pg';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,7 +12,7 @@ bugtracker 'https://github.com/zonemaster/zonemaster-backend/issues';
 requires
   'Class::Method::Modifiers'    => 1.09,
   'Config::IniFiles'            => 0,
-  'DBI'                         => 1.616,
+  'DBI'                         => 1.635,
   'Daemon::Control'             => 0.001007,
   'File::ShareDir'              => 0,
   'File::Slurp'                 => 0,
@@ -39,7 +39,7 @@ requires
   'Locale::TextDomain'          => 1.20,
   ;
 
-test_requires 'DBD::SQLite';
+test_requires 'DBD::SQLite' => 1.4702;
 test_requires 'Test::NoWarnings';
 test_requires 'Test::Exception';
 test_requires 'Test::Differences';


### PR DESCRIPTION
## Purpose

Some packages require newer versions for Zonemaster::Backend to be installed (especially on Centos 7 where such packages come with an unsupported version from the repositories).

## Context

n/a

## Changes

Manifest.PL

## How to test this PR

Installation should work on all supported OS.
