### PR TITLE
Add missing text library to TestAgent.pm

### DIFF
--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -9,6 +9,7 @@ use DBI qw(:utils);
 use JSON::PP;
 use Scalar::Util qw( blessed );
 use File::Slurp;
+use Locale::TextDomain qw[Zonemaster-Backend];
 
 use Zonemaster::LDNS;
 


### PR DESCRIPTION
## Purpose

This PR adds a missing library to TestAgent.pm, to be able to show warning messages. Currently it will crash:
`[ERROR] [main] Test died: 8b96afcc7a6ad5b8: Undefined subroutine &Zonemaster::Backend::TestAgent::__ called at /usr/local/share/perl/5.32.1/Zonemaster/Backend/TestAgent.pm line 206`

## Context

See [#986](https://github.com/zonemaster/zonemaster-backend/pull/986#issuecomment-1143388127) (comments)

## How to test this PR

Install Zonemaster::LDNS, without IDN support
Create a test with IDN characters (e.g., `café.fr`)
Start the testagent
Logs should show a warning message instead of crashing, like so:
`[WARNING] [main] Warning: Zonemaster::LDNS not compiled with IDN support, cannot handle non-ASCII names correctly. at /usr/local/share/perl/5.32.1/Zonemaster/Backend/TestAgent.pm line 208.`
