### PR TITLE
Fix some problems when upgrading the database to the schema for 8.2.0

### DIFF
--- a/docs/upgrade/upgrade_zonemaster_backend_ver_8.2.0.md
+++ b/docs/upgrade/upgrade_zonemaster_backend_ver_8.2.0.md
@@ -5,7 +5,25 @@
 If your Zonemaster database was created by a Zonemaster-Backend version smaller
 than v8.2.0, and not upgraded, use the following instruction.
 
-> You may need to run the command with root privileges.
+> You may need to run these command with root privileges.
+
+### Preparation when using MariaDB
+
+If you're using MariaDB you need to make a backup of your database before
+upgrading its schema.
+
+```sh
+mysqldump zonemaster > backup-file.sql
+```
+
+In case the schema upgrade fails you may need to restore the backup before
+trying again.
+
+```sh
+mysql zonemaster < backup-file.sql
+```
+
+### Upgrade database schema
 
 ```sh
 cd `perl -MFile::ShareDir -le 'print File::ShareDir::dist_dir("Zonemaster-Backend")'`

--- a/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
@@ -28,21 +28,21 @@ sub patch_db_mysql {
     my $db = Zonemaster::Backend::DB::MySQL->from_config( $config );
     my $dbh = $db->dbh;
 
+    # add table constraints
+    $dbh->do( 'ALTER TABLE users ADD CONSTRAINT UNIQUE (username)' );
+    $dbh->do( 'ALTER TABLE test_results ADD CONSTRAINT UNIQUE (hash_id)' );
+
+    # update columns names, data type and default value
+    $dbh->do( 'ALTER TABLE test_results MODIFY COLUMN id BIGINT AUTO_INCREMENT' );
+    $dbh->do( 'ALTER TABLE test_results CHANGE COLUMN creation_time created_at DATETIME NOT NULL' );
+    $dbh->do( 'ALTER TABLE test_results CHANGE COLUMN test_start_time started_at DATETIME DEFAULT NULL' );
+    $dbh->do( 'ALTER TABLE test_results CHANGE COLUMN test_end_time ended_at DATETIME DEFAULT NULL' );
+
+    $dbh->do( 'ALTER TABLE batch_jobs CHANGE COLUMN creation_time created_at DATETIME NOT NULL' );
+
     $dbh->{AutoCommit} = 0;
 
     try {
-        # update columns names, data type and default value
-        $dbh->do( 'ALTER TABLE test_results MODIFY COLUMN id BIGINT AUTO_INCREMENT' );
-        $dbh->do( 'ALTER TABLE test_results CHANGE COLUMN creation_time created_at DATETIME NOT NULL' );
-        $dbh->do( 'ALTER TABLE test_results CHANGE COLUMN test_start_time started_at DATETIME DEFAULT NULL' );
-        $dbh->do( 'ALTER TABLE test_results CHANGE COLUMN test_end_time ended_at DATETIME DEFAULT NULL' );
-
-        $dbh->do( 'ALTER TABLE batch_jobs CHANGE COLUMN creation_time created_at DATETIME NOT NULL' );
-
-        # add table constraints
-        $dbh->do( 'ALTER TABLE test_results ADD CONSTRAINT UNIQUE (hash_id)' );
-        $dbh->do( 'ALTER TABLE users ADD CONSTRAINT UNIQUE (username)' );
-
         # normalize "domain" column
         $dbh->do(
             q[

--- a/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
@@ -105,7 +105,7 @@ sub patch_db_postgresql {
         $dbh->do(
             q[
                 UPDATE test_results
-                SET domain = RTRIM('.', domain)
+                SET domain = RTRIM(domain, '.')
                 WHERE domain != '.' AND domain LIKE '%.'
             ]
         );


### PR DESCRIPTION
## Purpose

This PR fixes problems found during release testing.

## Context

Fixes problems introduced in #1005 and #970.

## Changes

* MariaDB: Adds an instruction to back up the zonemaster database before running the migration script. This is needed because ALTER TABLE statements don't respect transactions on MariaDB.
* MariaDB: Refactors the migration code so the somewhat riskiest operation comes first. I.e. the one to add the unique constraint to users.username.
* PostgreSQL: Fixes the normalization of domain names.

## How to test this PR

### PostgreSQL
1. Install Backend 8.1.0.
2. Run `zmtest zonemaster.net` and `zmtest zonemaster.net.`.
3. Install this branch of Backend on top of it. (Or current develop to reproduce the bug.)
4. Run the database migration script.
5. Run `echo "select domain from test_results;" | sudo -u zonemaster psql zonemaster`.

Before this fix domain names with trailing dots get normalized to the empty string.
With this fix domain names are properly normalized.

### MariaDB
1. Pretend we have the previous version installed, that we've somehow managed to get two users with the same name into the database:
   1. Install Backend 8.1.0.
   2. Run `zmb add_api_user --username jdoe --api-key asdfasdf` to create a user.
   3. Run `echo "insert into users (username, api_key) values ('jdoe', 'qwerqwer');" | sudo mysql zonemaster`. To force the creation of a second user with the same name.
2. Upgrade to this version of Backend:
   1. Install this branch of Backend on top of it.
3. Follow the database upgrade instruction:
   1. Take a backup of the zonemaster database.
   2. Run the database migration script.
4. Trying to solve the problem we notice that the database was broken by the migration script:
   1. Notice the error message about the duplicate entry.
   2. Run `echo "delete from users where api_key = 'qwerqwer';" | sudo mysql zonemaster` so we can add the unique constraint.
   3. Run the database migration script again to see it fail. (The tables were already altered.)
5. Get the database back into a healthy state:
   1. Restore the database from the backup.
6. Fix the duplicate entry problem before running the upgrade script.
   1. Run `echo "delete from users where api_key = 'qwerqwer';" | sudo mysql zonemaster` so we can add the unique constraint.
   2. Run the database migration script again.
7. Make sure the migration was successful:
   1. Run `echo "select * from table_constraints where constraint_schema = 'zonemaster';" | sudo mysql information_schema` and make sure the unique constraint has been added.