### PR TITLE
Fix trailing dot removal in migration script

### DIFF
--- a/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_8.2.0.pl
@@ -54,6 +54,13 @@ sub patch_db_mysql {
         $dbh->do(
             q[
                 UPDATE test_results
+                SET domain = '.'
+                WHERE domain = '..' OR domain = '...' OR domain = '....'
+            ]
+        );
+        $dbh->do(
+            q[
+                UPDATE test_results
                 SET domain = TRIM( TRAILING '.' FROM domain )
                 WHERE domain != '.' AND domain LIKE '%.'
             ]
@@ -100,6 +107,13 @@ sub patch_db_postgresql {
                 UPDATE test_results
                 SET domain = LOWER(domain)
                 WHERE domain != LOWER(domain)
+            ]
+        );
+        $dbh->do(
+            q[
+                UPDATE test_results
+                SET domain = '.'
+                WHERE domain = '..' OR domain = '...' OR domain = '....'
             ]
         );
         $dbh->do(
@@ -164,11 +178,7 @@ sub patch_db_sqlite {
                 SELECT
                     id,
                     hash_id,
-                    CASE
-                        WHEN (domain != '.' AND domain LIKE '%.')
-                        THEN rtrim(lower(domain), '.')
-                        ELSE lower(domain)
-                        END,
+                    lower(domain),
                     batch_id,
                     creation_time,
                     test_start_time,
@@ -181,6 +191,20 @@ sub patch_db_sqlite {
                     results,
                     undelegated
                 FROM test_results_old
+            ]
+        );
+        $dbh->do(
+            q[
+                UPDATE test_results
+                SET domain = '.'
+                WHERE domain = '..' OR domain = '...' OR domain = '....'
+            ]
+        );
+        $dbh->do(
+            q[
+                UPDATE test_results
+                SET domain = RTRIM(domain, '.')
+                WHERE domain != '.' AND domain LIKE '%.'
             ]
         );
 


### PR DESCRIPTION
## Purpose

After #983 (and https://github.com/zonemaster/zonemaster-engine/issues/1055), we update the logic around trailing dots (and consecutive trailing dots). It seems that previously it was ok to run a test for a domain such as `afnic.fr...` or `...`. They would result in testing `afnic.fr` and `.`. So it's fair to clean the database to remove any trailing dots. But careful when it comes to domains composed of only dots.


documentations:
MySQL: https://dev.mysql.com/doc/refman/5.7/en/string-functions.html
PostgreSQL: https://www.postgresql.org/docs/10/functions-string.html
SQLite: https://www.sqlite.org/lang_corefunc.html#substr

## Context

Follow-up on #1030

## Changes

patch script for 8.2.0

## How to test this PR

Insert domains with only 4 dots `....`. Running the patch script should normalize such domain to `.`.


## Discussion on previous behaviour

In Engine it is possible to run a test for a domain with multiple trailing dots. Using the [sanity check](https://github.com/zonemaster/zonemaster-engine/blob/master/docs/Installation.md#Post-installation-sanity-check):

```
$ time perl -MZonemaster::Engine -E 'say join "\n", Zonemaster::Engine->test_module("BASIC", "zonemaster.net...")'
SYSTEM:UNSPECIFIED:START_TIME string=2022-06-03 13:30:05 +0000; time_t=1654263005
SYSTEM:UNSPECIFIED:TEST_TARGET module=BASIC; zone=zonemaster.net
...
```

This might come from how we construct a DNSName object:

https://github.com/zonemaster/zonemaster-engine/blob/c59711aafc0ba571b8fc00b19dbeb0acd6946644/lib/Zonemaster/Engine/DNSName.pm#L24

From [split perldoc](https://perldoc.perl.org/functions/split):

> An empty trailing field, on the other hand, is produced when
            there is a match at the end of EXPR, regardless of the length of
            the match (of course, unless a non-zero LIMIT is given
            explicitly, such fields are removed, as in the last example).

To reproduce uncomment the line in the following snippet:

```perl
sub f {
    my $in = shift;
    print "$in: ";
    print join(":", split( /[.]/, $in ) ) . "\n";
    #print join(":", split( /[.]/, $in, -1 ) ) . "\n";
}

f( "..." );
f( "a.b" );
f( "a...b" ); 
f( "a.c..." );
```
