### PR TITLE
Removes enabling IPv4 and IPv6 by default in zmtest

### DIFF
--- a/script/zmtest
+++ b/script/zmtest
@@ -15,8 +15,9 @@ usage () {
     echo >&2
     echo "Options:" >&2
     echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
-    echo "  --noipv4              Run the test without ipv4." >&2
-    echo "  --noipv6              Run the test without ipv6." >&2
+    echo "  --noipv4              Run the test with IPv4 disabled." >&2
+    echo "  --noipv6              Run the test with IPv6 disabled." >&2
+    echo "                        IPv4 and IPv6 follow the profile setting unless disabled by option." >&2
     echo "  --lang LANG           A language tag. Default is \"en\"." >&2
     echo "                        Valid values are determined by backend_config.ini." >&2
     echo "  --profile PROFILE     The name of a profile. Default is \"default\"." >&2
@@ -44,15 +45,15 @@ zmb () {
 
 domain=""
 server_url="http://localhost:5000/"
-ipv4="true"
-ipv6="true"
+ipv4=""
+ipv6=""
 lang="en"
 profile="default"
 while [ $# -gt 0 ] ; do
     case "$1" in
         -s|--server) server_url="$2"; shift 2;;
-        --noipv4) ipv4="false"; shift 1;;
-        --noipv6) ipv6="false"; shift 1;;
+        --noipv4) ipv4='--ipv4 "false"'; shift 1;;
+        --noipv6) ipv6='--ipv6 "false"'; shift 1;;
         --lang) lang="$2"; shift 2;;
         --profile) profile="$2"; shift 2;;
         *) domain="$1" ; shift 1;;
@@ -61,7 +62,7 @@ done
 [ -n "${domain}" ] || usage 2 "No domain specified"
 
 # Start test
-output="$(zmb "${server_url}" start_domain_test --domain "${domain}" --ipv4 "${ipv4}" --ipv6 "${ipv6}" --profile "${profile}")" || exit $?
+output="$(zmb "${server_url}" start_domain_test --domain "${domain}" ${ipv4} ${ipv6} --profile "${profile}")" || exit $?
 testid="$(printf "%s" "${output}" | "${JQ}" -r .result)" || exit $?
 printf "testid: %s\n" "${testid}" >&2
 


### PR DESCRIPTION
## Purpose

`zmtest` enables by default both IPv4 and IPv6. It should rather let profile setting rule, unless disabled by option.

## Context

Fixes #1040

## How to test this PR

1. Disable IPv4 or IPv6 in the default policy file (see #1039 why you currently must change there).
2. Start a test with `zmtest`
3. Verify that the selected protocol remains disabled.

