### PR TITLE
Fixes when IPv4/6 setting is overwritten by default profile

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -617,8 +617,8 @@ sub _project_params {
     my %projection = ();
 
     $projection{domain}   = _normalize_domain( $$params{domain} // "" );
-    $projection{ipv4}     = $$params{ipv4}       // $profile->get( 'net.ipv4' );
-    $projection{ipv6}     = $$params{ipv6}       // $profile->get( 'net.ipv6' );
+    $projection{ipv4}     = $$params{ipv4};
+    $projection{ipv6}     = $$params{ipv6};
     $projection{profile}  = lc( $$params{profile} // "default" );
 
     my $array_ds_info = $$params{ds_info} // [];

--- a/t/db.t
+++ b/t/db.t
@@ -20,18 +20,18 @@ sub encode_and_fingerprint {
 subtest 'encoding and fingerprint' => sub {
 
     subtest 'missing properties' => sub {
-        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}';
-
         my %params = ( domain => "example.com" );
 
+        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":null,"ipv6":null,"nameservers":[],"profile":"default"}';
         my ( $encoded_params, $fingerprint ) = encode_and_fingerprint( \%params );
         is $encoded_params, $expected_encoded_params, 'domain only: the encoded strings should match';
         #diag ($fingerprint);
 
+        my $expected_encoded_params_v4_true = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":null,"nameservers":[],"profile":"default"}';
         $params{ipv4} = JSON::PP->true;
         my ( $encoded_params_ipv4, $fingerprint_ipv4 ) = encode_and_fingerprint( \%params );
-        is $encoded_params_ipv4, $expected_encoded_params, 'add ipv4: the encoded strings should match';
-        is $fingerprint_ipv4, $fingerprint, 'fingerprints should match';
+        is $encoded_params_ipv4, $expected_encoded_params_v4_true, 'add ipv4: the encoded strings should match';
+        isnt $fingerprint_ipv4, $fingerprint, 'fingerprints should not match';
     };
 
     subtest 'array properties' => sub {
@@ -121,7 +121,7 @@ subtest 'encoding and fingerprint' => sub {
     };
 
     subtest 'garbage properties set' => sub {
-        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}';
+        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":null,"ipv6":null,"nameservers":[],"profile":"default"}';
         my %params1 = (
             domain => "example.com",
         );
@@ -174,6 +174,8 @@ subtest 'encoding and fingerprint' => sub {
         my $expected_fingerprint = '8c64f7feaa3f13b77e769720991f2a79';
 
         my %params = ( domain => "café.example" );
+        $params{ipv4} = JSON::PP->true;
+        $params{ipv6} = JSON::PP->true;
 
         my ( $encoded_params, $fingerprint ) = encode_and_fingerprint( \%params );
         is $encoded_params, $expected_encoded_params, 'IDN domain: the encoded strings should match';
@@ -184,7 +186,7 @@ subtest 'encoding and fingerprint' => sub {
         subtest 'in domain' => sub {
             my %params1 = ( domain => "example.com" );
             my %params2 = ( domain => "example.com." );
-            my $expected_encoded_params = encode_utf8( '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}' );
+            my $expected_encoded_params = encode_utf8( '{"domain":"example.com","ds_info":[],"ipv4":null,"ipv6":null,"nameservers":[],"profile":"default"}' );
 
             my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
             my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
@@ -196,7 +198,7 @@ subtest 'encoding and fingerprint' => sub {
         subtest 'in nameserver' => sub {
             my %params1 = ( domain => "example.com", nameservers => [ { ns => "ns1.example.com." } ] );
             my %params2 = ( domain => "example.com", nameservers => [ { ns => "ns1.example.com" } ] );
-            my $expected_encoded_params = encode_utf8( '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[{"ns":"ns1.example.com"}],"profile":"default"}' );
+            my $expected_encoded_params = encode_utf8( '{"domain":"example.com","ds_info":[],"ipv4":null,"ipv6":null,"nameservers":[{"ns":"ns1.example.com"}],"profile":"default"}' );
 
             my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
             my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
@@ -207,7 +209,7 @@ subtest 'encoding and fingerprint' => sub {
 
         subtest 'root is not modified' => sub {
             my %params = ( domain => "." );
-            my $expected_encoded_params = encode_utf8( '{"domain":".","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}' );
+            my $expected_encoded_params = encode_utf8( '{"domain":".","ds_info":[],"ipv4":null,"ipv6":null,"nameservers":[],"profile":"default"}' );
 
             my ( $encoded_params, $fingerprint ) = encode_and_fingerprint( \%params );
             is $encoded_params, $expected_encoded_params, 'the encoded strings should match';


### PR DESCRIPTION
## Purpose

Prevents default profile to override IPv4 or IPv6 setting in additional profile. This can happen when the `ipv4` or `ipv6` parameter keys are unset and the additional profile has a different setting from the default profile.

## Context

Resolves #1039. The resolution was proposed by @pnax in an email.

A side affect of this solution is that two tests with the same effective values can get different "fingerprints". That will happen if the IPv4 and IPv6 parameters are unset in one test and at least one of them is set to the same value as the effective profile in the other.

## How to test this PR

1. Keep the default profile with both IPv4 and IPv6 enabled ("true").
2. Create an additional profile with IPv6 disabled ("false").
3. Make the additional profile available via backend_config.ini.
4. Create a test with zmb with IPv4 and IPv6 unset and select that other profile.
5. Verfiy that the test was run with IPv6 disabled.
