### PR TITLE
Respect net.ipv4 and net.ipv6

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -14,7 +14,6 @@ use Log::Any qw( $log );
 use POSIX qw( strftime );
 use Try::Tiny;
 
-use Zonemaster::Engine::Profile;
 use Zonemaster::Backend::Errors;
 
 requires qw(
@@ -611,8 +610,6 @@ sub _normalize_domain {
 
 sub _project_params {
     my ( $self, $params ) = @_;
-
-    my $profile = Zonemaster::Engine::Profile->effective;
 
     my %projection = ();
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -617,8 +617,8 @@ sub _project_params {
     my %projection = ();
 
     $projection{domain}   = _normalize_domain( $$params{domain} // "" );
-    $projection{ipv4}     = $$params{ipv4}       // $profile->get( 'net.ipv4' );
-    $projection{ipv6}     = $$params{ipv6}       // $profile->get( 'net.ipv6' );
+    $projection{ipv4}     = $$params{ipv4};
+    $projection{ipv6}     = $$params{ipv6};
     $projection{profile}  = lc( $$params{profile} // "default" );
 
     my $array_ds_info = $$params{ds_info} // [];

--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -40,20 +40,10 @@ sub new {
     my $dbclass = Zonemaster::Backend::DB->get_db_class( $dbtype );
     $self->{_db} = $dbclass->from_config( $config );
 
-    my %all_profiles = ( $config->PUBLIC_PROFILES, $config->PRIVATE_PROFILES );
-    foreach my $name ( keys %all_profiles ) {
-        my $path = $all_profiles{$name};
-
-        my $full_profile = Zonemaster::Engine::Profile->default;
-        if ( defined $path ) {
-            my $json = eval { read_file( $path, err_mode => 'croak' ) }    #
-              // die "Error loading profile '$name': $@";
-            my $named_profile = eval { Zonemaster::Engine::Profile->from_json( $json ) }    #
-              // die "Error loading profile '$name' at '$path': $@";
-            $full_profile->merge( $named_profile );
-        }
-        $self->{_profiles}{$name} = $full_profile;
-    }
+    $self->{_profiles} = Zonemaster::Backend::Config->load_profiles(    #
+        $config->PUBLIC_PROFILES,
+        $config->PRIVATE_PROFILES,
+    );
 
     bless( $self, $class );
     return $self;

--- a/t/db.t
+++ b/t/db.t
@@ -20,18 +20,18 @@ sub encode_and_fingerprint {
 subtest 'encoding and fingerprint' => sub {
 
     subtest 'missing properties' => sub {
-        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}';
-
         my %params = ( domain => "example.com" );
 
+        my $expected_encoded_params = '{"domain":"example.com","ds_info":[],"ipv4":null,"ipv6":null,"nameservers":[],"profile":"default"}';
         my ( $encoded_params, $fingerprint ) = encode_and_fingerprint( \%params );
         is $encoded_params, $expected_encoded_params, 'domain only: the encoded strings should match';
         #diag ($fingerprint);
 
+        my $expected_encoded_params_v4_true = '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":null,"nameservers":[],"profile":"default"}';
         $params{ipv4} = JSON::PP->true;
         my ( $encoded_params_ipv4, $fingerprint_ipv4 ) = encode_and_fingerprint( \%params );
-        is $encoded_params_ipv4, $expected_encoded_params, 'add ipv4: the encoded strings should match';
-        is $fingerprint_ipv4, $fingerprint, 'fingerprints should match';
+        is $encoded_params_ipv4, $expected_encoded_params_v4_true, 'add ipv4: the encoded strings should match';
+        isnt $fingerprint_ipv4, $fingerprint, 'fingerprints should not match';
     };
 
     subtest 'array properties' => sub {
@@ -121,7 +121,7 @@ subtest 'encoding and fingerprint' => sub {
     };
 
     subtest 'garbage properties set' => sub {
-        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}';
+        my $expected_encoded_params = '{"client":"GUI v3.3.0","domain":"example.com","ds_info":[],"ipv4":null,"ipv6":null,"nameservers":[],"profile":"default"}';
         my %params1 = (
             domain => "example.com",
         );
@@ -174,6 +174,8 @@ subtest 'encoding and fingerprint' => sub {
         my $expected_fingerprint = '8c64f7feaa3f13b77e769720991f2a79';
 
         my %params = ( domain => "café.example" );
+        $params{ipv4} = JSON::PP->true;
+        $params{ipv6} = JSON::PP->true;
 
         my ( $encoded_params, $fingerprint ) = encode_and_fingerprint( \%params );
         is $encoded_params, $expected_encoded_params, 'IDN domain: the encoded strings should match';
@@ -184,7 +186,7 @@ subtest 'encoding and fingerprint' => sub {
         subtest 'in domain' => sub {
             my %params1 = ( domain => "example.com" );
             my %params2 = ( domain => "example.com." );
-            my $expected_encoded_params = encode_utf8( '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}' );
+            my $expected_encoded_params = encode_utf8( '{"domain":"example.com","ds_info":[],"ipv4":null,"ipv6":null,"nameservers":[],"profile":"default"}' );
 
             my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
             my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
@@ -196,7 +198,7 @@ subtest 'encoding and fingerprint' => sub {
         subtest 'in nameserver' => sub {
             my %params1 = ( domain => "example.com", nameservers => [ { ns => "ns1.example.com." } ] );
             my %params2 = ( domain => "example.com", nameservers => [ { ns => "ns1.example.com" } ] );
-            my $expected_encoded_params = encode_utf8( '{"domain":"example.com","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[{"ns":"ns1.example.com"}],"profile":"default"}' );
+            my $expected_encoded_params = encode_utf8( '{"domain":"example.com","ds_info":[],"ipv4":null,"ipv6":null,"nameservers":[{"ns":"ns1.example.com"}],"profile":"default"}' );
 
             my ( $encoded_params1, $fingerprint1 ) = encode_and_fingerprint( \%params1 );
             my ( $encoded_params2, $fingerprint2 ) = encode_and_fingerprint( \%params2 );
@@ -207,7 +209,7 @@ subtest 'encoding and fingerprint' => sub {
 
         subtest 'root is not modified' => sub {
             my %params = ( domain => "." );
-            my $expected_encoded_params = encode_utf8( '{"domain":".","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}' );
+            my $expected_encoded_params = encode_utf8( '{"domain":".","ds_info":[],"ipv4":null,"ipv6":null,"nameservers":[],"profile":"default"}' );
 
             my ( $encoded_params, $fingerprint ) = encode_and_fingerprint( \%params );
             is $encoded_params, $expected_encoded_params, 'the encoded strings should match';


### PR DESCRIPTION
## Purpose

Respect profile properties `net.ipv4` and `net.ipv6` in custom profiles.

## Context

* Fixes #1039.
* Meant to replace #1043 - in fact it contains those same commits.

## Changes

* RPCAPI now fills in parameter defaults before recording test requests in the database.
* TestAgent now accepts the profile test parameter explicitly set to default even when it is not explicitly specified in the config.
* The DB module no longer depends on Profile.

## How to test this PR

1. Make sure your installed profile.json file has not been modified.
2. Create a custom profile with the filename `noipv6.profile` and the contents `{"net":{"ipv6":false}}`.
3. Add this line to the PUBLIC_PROFILES of your backend_config.ini: `noipv6 = /path/to/noipv6.profile`.
4. Run `zmb start_domain_test --profile noipv6 --domain alpha.example | jq -r .result`
5. Run `zmb get_test_params --test-id ... | jq -S .` with the test id reported by the above command. Make sure ipv6 is disabled in the output.

Rerun the above commands with a selection of `--ipv4` and `--ipv6` arguments. Make sure they override the profile values.