### PR TITLE
Expose Zonemaster-LDNS version

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -434,7 +434,7 @@ The items of the array are objects with two keys, `"path"` and `"message"`:
 
 ## API method: `version_info`
 
-Returns the version of the Zonemaster Backend and Zonemaster Engine software combination
+Returns the version of the Zonemaster-LDNS, Zonemaster-Engine and Zonemaster-Backend software combination.
 
 Example request:
 ```json
@@ -451,6 +451,7 @@ Example response:
   "jsonrpc": "2.0",
   "id": 1,
   "result": {
+    "zonemaster_ldns": "1.0.1",
     "zonemaster_backend": "1.0.7",
     "zonemaster_engine": "v1.0.14"
   }

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -107,9 +107,9 @@ sub version_info {
 
     my %ver;
     eval {
+        $ver{zonemaster_ldns} = Zonemaster::LDNS->VERSION;
         $ver{zonemaster_engine} = Zonemaster::Engine->VERSION;
         $ver{zonemaster_backend} = Zonemaster::Backend->VERSION;
-
     };
     if ($@) {
         handle_exception( $@ );

--- a/t/test01.t
+++ b/t/test01.t
@@ -157,6 +157,7 @@ subtest 'API calls' => sub {
 
     subtest 'version_info' => sub {
         my $res = $rpcapi->version_info();
+        ok( defined( $res->{zonemaster_ldns} ), 'Has a "zonemaster_ldns" key' );
         ok( defined( $res->{zonemaster_engine} ), 'Has a "zonemaster_engine" key' );
         ok( defined( $res->{zonemaster_backend} ), 'Has a "zonemaster_backend" key' );
     };


### PR DESCRIPTION
## Purpose

This exposes the Zonemaster-LDNS version via the API call `version_info`.

## Context

Addresses https://github.com/zonemaster/zonemaster-backend/issues/790#issuecomment-1194376576

## Changes

Update `version_info` to expose Zonemaster-LDNS version.
Update API.md document.
Update t/test01.t to check that `version_info` returns a value for Zonemaster-LDNS.

## How to test this PR

Make a call to `version_info` and see that the Zonemaster-LDNS version is exposed.
```
zmb version_info | jq
```
