### PR TITLE
Temporarily set IPV6_DISABLED message to INFO in testing profile

### DIFF
--- a/t/test_profile.json
+++ b/t/test_profile.json
@@ -1,4 +1,16 @@
 {
+    "logfilter": {
+        "BASIC":{
+            "IPV6_DISABLED" : [
+                {
+                    "when": {
+                        "rrtype": [ "SOA", "NS" ]
+                    },
+                    "set": "INFO"
+                }
+            ]
+        }
+    },
     "test_cases": [
         "address01",
         "address02",


### PR DESCRIPTION
## Purpose

Since https://github.com/zonemaster/zonemaster-engine/pull/1117, the IPV6_DISABLED message tag is lowered to DEBUG. This commit updates the testing profile so that the level for this message is always INFO. In this way the test can rely on the message.

## Context

https://github.com/zonemaster/zonemaster-backend/pull/1050#issuecomment-1227159829

## Changes

Add a `logfilter` entry to `t/test_profile.json` so that `IPV6_DISABLED` message have an INFO level.

## How to test this PR

Tests should pass.