### PR TITLE
Use Net::IP::XS directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ addons:
       - liblocale-msgfmt-perl
       - libmail-rfc822-address-perl
       - libmodule-find-perl
-      - libnet-ip-perl
+      - libnet-ip-xs-perl
       - libpod-coverage-perl
       - libreadonly-perl
       - libreadonly-xs-perl

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,6 +26,7 @@ requires
   'LWP::UserAgent'              => 0,
   'Mojolicious'                 => 7.28,
   'Moose'                       => 2.04,
+  'Net::IP::XS'                 => 0,
   'Parallel::ForkManager'       => 1.12,
   'Plack::Builder'              => 0,
   'Role::Tiny'                  => 1.001003,

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -11,7 +11,7 @@ use File::Spec::Functions qw( file_name_is_absolute );
 use JSON::Validator::Joi;
 use Readonly;
 use Locale::TextDomain qw[Zonemaster-Backend];
-use Zonemaster::Engine::Net::IP;
+use Net::IP::XS;
 use Zonemaster::Engine::Logger::Entry;
 use Zonemaster::LDNS;
 
@@ -450,7 +450,7 @@ Accepts an IPv4 address.
 sub untaint_ipv4_address {
     my ( $value ) = @_;
     if ( $value =~ /($IPV4_RE)/
-        && Zonemaster::Engine::Net::IP::ip_is_ipv4( $value ) )
+        && Net::IP::XS::ip_is_ipv4( $value ) )
     {
         return $1;
     }
@@ -466,7 +466,7 @@ Accepts an IPv6 address.
 sub untaint_ipv6_address {
     my ( $value ) = @_;
     if ( $value =~ /($IPV6_RE)/
-        && Zonemaster::Engine::Net::IP::ip_is_ipv6( $value ) )
+        && Net::IP::XS::ip_is_ipv6( $value ) )
     {
         return $1;
     }


### PR DESCRIPTION
## Purpose

Remove dependency on (to be deprecated) Zonemaster::Engine::Net::IP.

## Context

In zonemaster/zonemaster-engine#1119 Zonemaster::Engine::Net::IP we're dropping support for Net::IP.
The issue zonemaster/zonemaster-engine#1129 has been created to deprecate Zonemaster::Engine::Net::IP, with the intended migration path being to use Net::IP::XS directly.

## Changes

Calls into Zonemaster::Engine::Net::IP are replaced with calls into Net::IP::XS.

## How to test this PR

This change is covered by existing tests in `t/validator.t`.