### PR TITLE
Add testcase results

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -386,6 +386,7 @@ The object has three keys, `"module"`, `"message"` and `"level"`.
 * `"module"`: a string. The *test module* that produced the result.
 * `"message"`: a string. A human-readable *message* describing that particular result.
 * `"level"`: a [*severity level*][Severity level]. The severity of the message.
+* `"testcase"`: a string. The *test case ID* of the *test case* that produced the result.
 
 Sometimes additional keys are present.
 
@@ -953,6 +954,11 @@ Example response:
       "ipv4": true,
       "client_id": "Zonemaster Dancer Frontend"
     },
+    "testcase_descriptions": {
+      "ZONE08": "MX is not an alias",
+      "SYNTAX05": "Misuse of '@' character in the SOA RNAME field",
+      ...
+    },
     "results": [
       {
         "module": "SYSTEM",
@@ -995,6 +1001,8 @@ An object with the following properties:
 * `"params"`: See below.
   `start_domain_test` when the *test* was started.
 * `"results"`: A list of [*test result*][Test result] objects.
+* `"testcase_descriptions"`: A map with the test case IDs as keys and the
+  translated descriptions of the corresponding the test cases as values.
 
 If the test was created by [`start_domain_test`][start_domain_test] then `"params"`
 is a normalized version `"params"` object sent to [`start_domain_test`][start_domain_test]
@@ -1015,9 +1023,9 @@ is a normalized version of an object created from the following parts:
 
 #### `"error"`
 
->
-> TODO: List all possible error codes and describe what they mean enough for clients to know how react to them.
->
+  >
+  > TODO: List all possible error codes and describe what they mean enough for clients to know how react to them.
+  >
 
 
 ## API method: `get_test_history`

--- a/docs/API.md
+++ b/docs/API.md
@@ -386,7 +386,7 @@ The object has four keys, `"module"`, `"message"`, `"level"` and `"testcase"`.
 * `"module"`: a string. The *test module* that produced the result.
 * `"message"`: a string. A human-readable *message* describing that particular result.
 * `"level"`: a [*severity level*][Severity level]. The severity of the message.
-* `"testcase"`: a string. The *test case ID* of the *test case* that produced the result.
+* `"testcase"`: a string. The *[Test Case Identifier][Test Case Identifiers]* of the *[Test Case][Test Cases]* that produced the result.
 
 Sometimes additional keys are present.
 
@@ -1001,8 +1001,8 @@ An object with the following properties:
 * `"params"`: See below.
   `start_domain_test` when the *test* was started.
 * `"results"`: A list of [*test result*][Test result] objects.
-* `"testcase_descriptions"`: A map with the [Test Case Identifiers] as keys and the
-  translated *Test Case Description* of the corresponding [test cases] as values.
+* `"testcase_descriptions"`: A map with the *[Test Case Identifiers]* as keys and the
+  translated *Test Case Description* of the corresponding *[Test Cases]* as values.
 
 If the test was created by [`start_domain_test`][start_domain_test] then `"params"`
 is a normalized version `"params"` object sent to [`start_domain_test`][start_domain_test]
@@ -1566,7 +1566,7 @@ The `"params"` object sent to [`start_domain_test`][start_domain_test] or
 [Severity Level Definitions]:         https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
 [Severity level]:                     #severity-level
 [start_domain_test]:                  #api-method-start_domain_test
-[test cases]:                         https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
+[Test Cases]:                         https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
 [Test Case Identifiers]:              https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
 [Test id]:                            #test-id
 [Test result]:                        #test-result

--- a/docs/API.md
+++ b/docs/API.md
@@ -381,7 +381,7 @@ Each *test* has a unique *test id*.
 
 Basic data type: object
 
-The object has three keys, `"module"`, `"message"` and `"level"`.
+The object has four keys, `"module"`, `"message"`, `"level"` and `"testcase"`.
 
 * `"module"`: a string. The *test module* that produced the result.
 * `"message"`: a string. A human-readable *message* describing that particular result.
@@ -1001,8 +1001,8 @@ An object with the following properties:
 * `"params"`: See below.
   `start_domain_test` when the *test* was started.
 * `"results"`: A list of [*test result*][Test result] objects.
-* `"testcase_descriptions"`: A map with the test case IDs as keys and the
-  translated descriptions of the corresponding the test cases as values.
+* `"testcase_descriptions"`: A map with the [Test Case Identifiers] as keys and the
+  translated *Test Case Description* of the corresponding [test cases] as values.
 
 If the test was created by [`start_domain_test`][start_domain_test] then `"params"`
 is a normalized version `"params"` object sent to [`start_domain_test`][start_domain_test]
@@ -1566,6 +1566,8 @@ The `"params"` object sent to [`start_domain_test`][start_domain_test] or
 [Severity Level Definitions]:         https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
 [Severity level]:                     #severity-level
 [start_domain_test]:                  #api-method-start_domain_test
+[test cases]:                         https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
+[Test Case Identifiers]:              https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
 [Test id]:                            #test-id
 [Test result]:                        #test-result
 [Timestamp]:                          #timestamp

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -345,6 +345,7 @@ sub get_test_results {
         eval { $translator->data } if $translator; # Provoke lazy loading of translation data
 
         my @zm_results;
+        my %testcases;
 
         my $test_info = $self->{db}->test_results( $params->{id} );
         foreach my $test_res ( @{ $test_info->{results} } ) {
@@ -365,6 +366,7 @@ sub get_test_results {
             $res->{message} =~ s/;/; /isg;
             $res->{level} = $test_res->{level};
             $res->{testcase} = $test_res->{testcase};
+            $testcases{$res->{testcase}} = $translator->test_case_description($test_res->{testcase});
 
             if ( $test_res->{module} eq 'SYSTEM' ) {
                 if ( $res->{message} =~ /policy\.json/ ) {
@@ -395,6 +397,7 @@ sub get_test_results {
         }
 
         $result = $test_info;
+        $result->{testcase_descriptions} = \%testcases;
         $result->{results} = \@zm_results;
 
         $translator->locale( $previous_locale );

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -364,6 +364,7 @@ sub get_test_results {
             $res->{message} =~ s/,/, /isg;
             $res->{message} =~ s/;/; /isg;
             $res->{level} = $test_res->{level};
+            $res->{testcase} = $test_res->{testcase};
 
             if ( $test_res->{module} eq 'SYSTEM' ) {
                 if ( $res->{message} =~ /policy\.json/ ) {

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -24,4 +24,7 @@ sub translate_tag {
     return decode_utf8( $octets );
 }
 
+sub test_case_description {
+    return decode_utf8(Zonemaster::Engine::Translator::test_case_description(@_));
+}
 1;


### PR DESCRIPTION
## Purpose

Make test case available in test result.

## Context

Related PR: https://github.com/zonemaster/zonemaster-gui/pull/341
Depends on: https://github.com/zonemaster/zonemaster-engine/pull/1144

## Changes

* Add a `testcase` field in the object of the results array containing test case ids.
* Add a `testcase_descriptions` to map test case ids to the translated test case descriptions.

## How to test this PR

```
% ./script/zmb --server http://127.0.0.1:5000 get_test_results --test-id <testid> --lang en | jq .result.testcase_descriptions
```
```jsonc
{
  "ZONE08": "MX is not an alias",
  "SYNTAX05": "Misuse of '@' character in the SOA RNAME field",
  "NAMESERVER06": "NS can be resolved",
  "DELEGATION03": "No truncation of referrals",
  "SYNTAX06": "No illegal characters in the SOA RNAME field",
  "CONSISTENCY03": "SOA timers consistency",
  "DNSSEC15": "Existence of CDS and CDNSKEY",
  "DELEGATION01": "Minimum number of name servers",
  "DELEGATION04": "Name server is authoritative",
  // ...
}
```