### PR TITLE
Fix recursor init

### DIFF
--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -42,6 +42,7 @@ $SIG{__WARN__} = sub {
 my $config = Zonemaster::Backend::Config->load_config();
 
 Zonemaster::Backend::Metrics->setup($config->METRICS_statsd_host, $config->METRICS_statsd_port);
+Zonemaster::Engine::init_engine();
 
 builder {
     enable sub {


### PR DESCRIPTION
## Purpose

Fix `get_data_from_parent_zone` method.

## Context

Depends on https://github.com/zonemaster/zonemaster-engine/pull/1151

## Changes

Manually call init method in engine.

## How to test this PR

```
% curl "localhost:5000/api" -H 'Accept: application/json' --data '{"method":"get_data_from_parent_zone","params":{"domain": "rd.nic.fr"},"id":1,"jsonrpc":"2.0"}' | jq 
```
```json
{
  "jsonrpc": "2.0",
  "result": {
    "ns_list": [
      {
        "ip": "192.134.4.81",
        "ns": "ns2.rd.nic.fr"
      },
      {
        "ip": "2001:67c:2218:3::1:7",
        "ns": "ns2.rd.nic.fr"
      },
      {
        "ip": "192.134.0.49",
        "ns": "ns3.nic.fr"
      },
      {
        "ns": "ns3.nic.fr",
        "ip": "2001:660:3006:1::1:1"
      }
    ],
    "ds_list": [
      {
        "digtype": 1,
        "digest": "3858865db3b40bad8f00716d023ee570a8f5da8a",
        "keytag": 26298,
        "algorithm": 10
      },
      {
        "algorithm": 10,
        "keytag": 26298,
        "digest": "470880f44c8dec620175e12fefb1ec161731520b0e8be2e6bcf9dd40e36dfd43",
        "digtype": 2
      }
    ]
  },
  "id": 1
}
```
