### PR TITLE
Provide human readable messages for backend messages

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -365,7 +365,7 @@ sub get_test_results {
             $res->{message} =~ s/,/, /isg;
             $res->{message} =~ s/;/; /isg;
             $res->{level} = $test_res->{level};
-            $res->{testcase} = $test_res->{testcase};
+            $res->{testcase} = $test_res->{testcase} // 'UNSPECIFIED';
             $testcases{$res->{testcase}} = $translator->test_case_description($test_res->{testcase});
 
             if ( $test_res->{module} eq 'SYSTEM' ) {

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -6,7 +6,9 @@ use 5.14.2;
 
 use Moose;
 use Encode;
+use Readonly;
 use POSIX qw[setlocale LC_MESSAGES LC_CTYPE];
+use Locale::TextDomain qw[Zonemaster-Backend];
 use Zonemaster::Backend::Config;
 
 # Zonemaster Modules
@@ -14,6 +16,19 @@ require Zonemaster::Engine::Translator;
 require Zonemaster::Engine::Logger::Entry;
 
 extends 'Zonemaster::Engine::Translator';
+
+Readonly my %TAG_DESCRIPTIONS => (
+    UNABLE_TO_FINISH_TEST => sub {
+        __x    # BACKEND_TEST_AGENT:UNABLE_TO_FINISH_TEST
+          "Zonemaster was unable to start or finish the test.", @_;
+    },
+);
+
+sub _build_all_tag_descriptions {
+    my $all_tag_descriptions = Zonemaster::Engine::Translator::_build_all_tag_descriptions();
+    $all_tag_descriptions->{BACKEND_TEST_AGENT} = \%TAG_DESCRIPTIONS;
+    return $all_tag_descriptions;
+}
 
 sub translate_tag {
     my ( $self, $hashref ) = @_;


### PR DESCRIPTION
## Purpose

Provide human readable message for backend generated messages.

## Context

When a test times out or dies this is how the new result UI would present the error.

![Screenshot 2022-11-24 at 13-29-14 samsung com · Zonemaster](https://user-images.githubusercontent.com/19394895/203784825-e05460fc-0e8b-4860-9700-ca45898349b3.png)


## Changes

* use `UNSPECIFIED` test case when no test case has been provided in message.
* convert backend message tags to human readable messages, allowing for message translation.

UI with the changes:
![Screenshot 2022-11-24 at 13-31-32 samsung com · Zonemaster](https://user-images.githubusercontent.com/19394895/203785286-1cf0ab1e-8e87-492d-ad6d-996225e44294.png)


## How to test this PR

* Create a test and make it timeout (set timeout to a small value in backend.ini)
* Query for the test results:
   ```
   % ./script/zmb --server http://127.0.0.1:5000 get_test_results --test-id 8c8b436b5b890c8c --lang en | jq '.result.results'
   [
     {
       "module": "BACKEND_TEST_AGENT",
       "testcase": "UNSPECIFIED",
       "message": "The test was unabled to finish.\n",
       "level": "CRITICAL"
     }
   ]
   ```
For reference here is the ouput of this command on develop:
```
[
  {
    "testcase": null,
    "module": "BACKEND_TEST_AGENT",
    "message": "BACKEND_TEST_AGENT:UNSPECIFIED:UNABLE_TO_FINISH_TEST \n",
    "level": "CRITICAL"
  }
]
```
