### PR TITLE
Corrects the license statement in Backend.pm

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ The Zonemaster Backend documentation is split up into several documents:
 
 ## License
 
-The software is released under the 2-clause BSD license. See separate
-[LICENSE](LICENSE) file.
+This is free software under a 2-clause BSD license. The full text of the license can
+be found in the [LICENSE](LICENSE) file included in this respository.
 
 
 [Configuration documentation]: docs/Configuration.md

--- a/lib/Zonemaster/Backend.pm
+++ b/lib/Zonemaster/Backend.pm
@@ -16,12 +16,8 @@ Michal Toma <toma@nic.fr>
 
 =head1 LICENSE
 
-This is free software, licensed under:
-
-The (three-clause) BSD License
-
-The full text of the license can be found in the
-F<LICENSE> file included with this distribution.
+This is free software. The full text of the license can
+be found in the F<LICENSE> file included with this distribution.
 
 =cut
 

--- a/lib/Zonemaster/Backend.pm
+++ b/lib/Zonemaster/Backend.pm
@@ -16,7 +16,7 @@ Michal Toma <toma@nic.fr>
 
 =head1 LICENSE
 
-This is free software. The full text of the license can
+This is free software under a 2-clause BSD license. The full text of the license can
 be found in the F<LICENSE> file included with this distribution.
 
 =cut


### PR DESCRIPTION
## Purpose

The statement about license in Backend.pm is not correct. In https://github.com/zonemaster/zonemaster-engine/issues/1149 @emollier pointed out the same issue for Zonemaster-LDNS and Zonemaster.Engine.

This PR updates the statement. It also updates that wording in the README file to be consistent.

## How to test this PR

This is documentation change only.
