### PR TITLE
Removes the deprecated use of empty value for locale tag key

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -203,16 +203,13 @@ The LANGUAGE section has one key, `locale`.
 
 ### locale
 
-A string matching one of the following descriptions:
+A string matching the following descriptions:
 * A space separated list of one or more `locale tags` where each tag matches the
   regular expression `/^[a-z]{2}_[A-Z]{2}$/`.
-* The empty string. **Deprecated**, remove the LANGUAGE.locale entry or specify
-  LANGUAGE.locale = en_US instead.
 
 It is an error to repeat the same `locale tag`.
 
-If the `locale` key is empty or absent, the `locale tag` value
-"en_US" is set by default.
+If the `locale` key is absent, the `locale tag` value "en_US" is set by default.
 
 #### Design
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -236,7 +236,7 @@ sub parse {
 
     if ( defined( my $value = $ini->val( 'LANGUAGE', 'locale' ) ) ) {
         if ( $value eq "" ) {
-            push @warnings, "Use of empty LANGUAGE.locale property is deprecated. Remove the LANGUAGE.locale entry or specify LANGUAGE.locale = en_US instead.";
+            die "config: Use of empty LANGUAGE.locale property is not permitted. Remove the LANGUAGE.locale entry or specify LANGUAGE.locale = en_US instead.";
         }
     }
 
@@ -308,11 +308,9 @@ sub parse {
         $obj->_set_RPCAPI_enable_add_batch_job( $value );
     }
     if ( defined( my $value = $get_and_clear->( 'LANGUAGE', 'locale' ) ) ) {
-        if ( $value ne "" ) {
-            $obj->_reset_LANGUAGE_locale();
-            for my $locale_tag ( split / +/, $value ) {
-                $obj->_add_LANGUAGE_locale( $locale_tag );
-            }
+        $obj->_reset_LANGUAGE_locale();
+        for my $locale_tag ( split / +/, $value ) {
+            $obj->_add_LANGUAGE_locale( $locale_tag );
         }
     }
 

--- a/t/config.t
+++ b/t/config.t
@@ -113,20 +113,6 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->ZONEMASTER_age_reuse_previous_test,                  600, 'default: ZONEMASTER.age_reuse_previous_test';
     };
 
-    subtest 'Deprecated values and fallbacks that are unconditional' => sub {
-        $log->clear();
-        my $text = q{
-            [DB]
-            engine = SQLite
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
-            [LANGUAGE]
-            locale =
-        };
-        my $config = Zonemaster::Backend::Config->parse( $text );
-        $log->contains_ok( qr/deprecated.*LANGUAGE\.locale/, 'deprecated empty LANGUAGE.locale' );
-    };
-
     subtest 'Warnings' => sub {
         $log->clear();
         my $text = q{
@@ -145,6 +131,20 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->MYSQL_host, 'localhost', 'set: MYSQL.host';
         is $config->MYSQL_port, 3333,        'set: MYSQL.port';
     };
+
+    throws_ok {
+        $log->clear();
+        my $text = q{
+            [DB]
+            engine = SQLite
+            [SQLITE]
+            database_file = /var/db/zonemaster.sqlite
+            [LANGUAGE]
+            locale =
+        };
+        my $config = Zonemaster::Backend::Config->parse( $text );
+    }
+    qr/Use of empty LANGUAGE.locale property is not permitted/, 'die: Invalid empty locale tag';
 
     throws_ok {
         my $text = '{"this":"is","not":"a","valid":"ini","file":"!"}';


### PR DESCRIPTION
## Purpose

From the release notes of v9.0.0 (v2022.1):

>The use of an empty string in the "LANGUAGE.locale" setting is deprecated and will be made illegal in the
v2022.2 release. See [docs/Configuration.md#language-section](https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#LANGUAGE-section).

This PR makes the empty string illegal.

## How to test this PR

In `backend_config.ini` add the following line in the `LANGUAGE` section and backend should refuse to start:
```
locale =
```
