### PR TITLE
Fix zmtest script

### DIFF
--- a/script/zmtest
+++ b/script/zmtest
@@ -14,7 +14,7 @@ usage () {
     echo "This interface is unstable and may change in a future release." >&2
     echo >&2
     echo "Options:" >&2
-    echo "  -h --help             Shows this usage documentation." >&2
+    echo "  -h --help             Show usage (this documentation)." >&2
     echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
     echo "  --noipv4              Run the test with IPv4 disabled." >&2
     echo "  --noipv6              Run the test with IPv6 disabled." >&2

--- a/script/zmtest
+++ b/script/zmtest
@@ -9,11 +9,12 @@ usage () {
     status="$1"
     message="$2"
     printf "%s" "${message}" >&2
-    echo "Usage: zmtest [OPTIONS] DOMAIN" >&2
+    echo "\nUsage: zmtest [OPTIONS] DOMAIN" >&2
     echo >&2
     echo "This interface is unstable and may change in a future release." >&2
     echo >&2
     echo "Options:" >&2
+    echo "  -h --help             Shows this usage documentation."
     echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
     echo "  --noipv4              Run the test with IPv4 disabled." >&2
     echo "  --noipv6              Run the test with IPv6 disabled." >&2
@@ -51,9 +52,10 @@ lang="en"
 profile="default"
 while [ $# -gt 0 ] ; do
     case "$1" in
+        -h|--help) usage 2; shift 1;;
         -s|--server) server_url="$2"; shift 2;;
-        --noipv4) ipv4='--ipv4 "false"'; shift 1;;
-        --noipv6) ipv6='--ipv6 "false"'; shift 1;;
+        --noipv4) ipv4='--ipv4 false'; shift 1;;
+        --noipv6) ipv6='--ipv6 false'; shift 1;;
         --lang) lang="$2"; shift 2;;
         --profile) profile="$2"; shift 2;;
         *) domain="$1" ; shift 1;;

--- a/script/zmtest
+++ b/script/zmtest
@@ -8,8 +8,8 @@ JQ="$(which jq)"
 usage () {
     status="$1"
     message="$2"
-    printf "%s" "${message}" >&2
-    echo "\nUsage: zmtest [OPTIONS] DOMAIN" >&2
+    printf "%s\n" "${message}" >&2
+    echo "Usage: zmtest [OPTIONS] DOMAIN" >&2
     echo >&2
     echo "This interface is unstable and may change in a future release." >&2
     echo >&2

--- a/script/zmtest
+++ b/script/zmtest
@@ -14,7 +14,7 @@ usage () {
     echo "This interface is unstable and may change in a future release." >&2
     echo >&2
     echo "Options:" >&2
-    echo "  -h --help             Shows this usage documentation."
+    echo "  -h --help             Shows this usage documentation." >&2
     echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2
     echo "  --noipv4              Run the test with IPv4 disabled." >&2
     echo "  --noipv6              Run the test with IPv6 disabled." >&2

--- a/script/zmtest
+++ b/script/zmtest
@@ -8,7 +8,7 @@ JQ="$(which jq)"
 usage () {
     status="$1"
     message="$2"
-    printf "%s\n" "${message}" >&2
+    [ -n "$message" ] && printf "%s\n" "${message}" >&2
     echo "Usage: zmtest [OPTIONS] DOMAIN" >&2
     echo >&2
     echo "This interface is unstable and may change in a future release." >&2


### PR DESCRIPTION
## Purpose

This PR updates script `zmtest`. The main issue was that options `noipv4` and `noipv6` were not working.

```
$ zmtest --noipv4 zonemaster.net
error: method start_domain_test: Illegal value. Expects "true", "false" or "null"  at /usr/local/bin/zmb line 637.
```

## Context

Part of release testing 2022.2

## Changes

Fix usage of option `--noipv4` and `--noipv6`
Add options `--help` and `-h`
Update documentation and formatting

## How to test this PR

```
$ zmtest
No domain specified
Usage: zmtest [OPTIONS] DOMAIN

[...]
```

```
$ zmtest --noipv4 --noipv6 zonemaster.net
[ ... ]
    "results": [
      {
        "level": "INFO",
        "message": "Using version v4.5.1 of the Zonemaster engine.\n",
        "module": "SYSTEM",
        "testcase": "UNSPECIFIED"
      },
      {
        "level": "CRITICAL",
        "message": "Both IPv4 and IPv6 are disabled.\n",
        "module": "SYSTEM",
        "testcase": "UNSPECIFIED"
      }
    ],
    "testcase_descriptions": {
      "UNSPECIFIED": "UNSPECIFIED"
    }
  }
```

```
$ zmtest --help
Usage: zmtest [OPTIONS] DOMAIN

[ ... ]
```

```
$ zmtest -h
Usage: zmtest [OPTIONS] DOMAIN

[ ... ]
```