### PR TITLE
Fix uninitialized value warning in zm-rpcapi.log

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -366,7 +366,7 @@ sub get_test_results {
             $res->{message} =~ s/;/; /isg;
             $res->{level} = $test_res->{level};
             $res->{testcase} = $test_res->{testcase} // 'UNSPECIFIED';
-            $testcases{$res->{testcase}} = $translator->test_case_description($test_res->{testcase});
+            $testcases{$res->{testcase}} = $translator->test_case_description($res->{testcase});
 
             if ( $test_res->{module} eq 'SYSTEM' ) {
                 if ( $res->{message} =~ /policy\.json/ ) {


### PR DESCRIPTION
## Purpose

Looking at the logs in `zm-rpcapi.log`, there are several lines like this one:
```
Use of uninitialized value $test_name in uc at /usr/local/share/perl5/Zonemaster/Engine/Translator.pm line 241. Extra parameters: {'rpc_method' => 'get_test_results'}
```

This comes from a small error in the RPCAPI code.

## Context

n/a

## Changes

Pass the right variable to `test_case_description()` in RPCAPI.pm.

## How to test this PR

...
