### PR TITLE
Provide a rule "new-po" to create an empty PO file

### DIFF
--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -1,6 +1,6 @@
 .POSIX:
 .SUFFIXES: .po .mo
-.PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy update-po
+.PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy update-po new-po
 
 POFILES := $(shell find . -maxdepth 1 -type f -name '*.po' -exec basename {} \;)
 MOFILES := $(POFILES:%.po=%.mo)
@@ -21,6 +21,17 @@ tidy-po:
 
 update-po: extract-pot
 	@for f in $(POFILES) ; do msgmerge --update --backup=none --quiet --no-location $(MSGMERGE_OPTS) $$f $(POTFILE) ; done
+
+# Create a new empty PO file with basename provided with the POLANG variable
+# Update the Language field in the header
+new-po: extract-pot
+	@[ -n "$(POLANG)" ] || ( echo "Usage: make POLANG=xx new-po" && exit 1 )
+	@cp $(POTFILE) $(POLANG).po
+	@perl -pi -e 's/^("Project-Id-Version:) .+(\\n)/$$1 1.0.0$$2/;' \
+		-e 's/^("Language-Team:) .+(\\n)/$$1 Zonemaster Team$$2/;' \
+		-e 's/^"Language: /$$&$(POLANG)/;' \
+		-e 's/^("Content-Type:.+charset=)CHARSET/$${1}UTF-8/;' $(POLANG).po
+	@perl -ni -e 'print unless /^#( |$$)/' $(POLANG).po
 
 extract-pot:
 	@xgettext --output $(POTFILE) --sort-by-file --add-comments --language=Perl --from-code=UTF-8 -k__ -k\$$__ -k%__ -k__x -k__n:1,2 -k__nx:1,2 -k__xn:1,2 -kN__ -kN__n:1,2 -k__p:1c,2 -k__np:1c,2,3 -kN__p:1c,2 -kN__np:1c,2,3 $(PMFILES)


### PR DESCRIPTION
## Purpose

New Makefile rule to create an empty PO file using the basename provided in the POLANG variable.

## Context

Same changes as in https://github.com/zonemaster/zonemaster-engine/pull/1185 and https://github.com/zonemaster/zonemaster-engine/pull/1191
Addresses https://github.com/zonemaster/zonemaster/issues/1131

## Changes

* Create a new empty PO file
* Set the "Language" field with the language name
* Update the header fields with default value
    * "Project-Id-Version: 1.0.0\n"
    * "Language-Team: Zonemaster Team\n"
    * "Content-Type: text/plain; charset=UTF-8\n"
* Automatically remove comments

## How to test this PR

Run `make POLANG=xx new-po` and check that the fields are automatically set with the default values.