### PR TITLE
Remove deprecated "creation_time" key

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -396,16 +396,6 @@ Sometimes additional keys are present.
 This key is added when the module name is `"NAMESERVER"`.
 
 
-### Timestamp (deprecated)
-
-Basic data type: string
-
-**Deprecated representation** (planned removal: v2023.1).
-
-Default database timestamp format: "Y-M-D H:M:S.ms".
-Example: "2017-12-18 07:56:17.156939"
-
-
 ### Timestamp
 
 Basic data type: string
@@ -935,7 +925,6 @@ Example response:
   "jsonrpc": "2.0",
   "id": 6,
   "result": {
-    "creation_time": "2016-11-15 11:53:13.965982",
     "created_at": "2016-11-15T11:53:13Z",
     "hash_id": "c45a3f8256c4a155",
     "params": {
@@ -996,8 +985,6 @@ An object with the following properties:
 
 #### `"result"`
 
-* `"creation_time"`: **Deprecated** (planned removal: v2023.1). A [*deprecated timestamp*][Timestamp deprecated].
-  The time in UTC at which the *test* was created.
 * `"created_at"`: A [*timestamp*][Timestamp]. The time in UTC at which the *test*
   was created.
 * `"hash_id"`: A [*test id*][Test id]. The *test* in question.
@@ -1060,7 +1047,6 @@ Example response:
   "result": [
     {
       "id": "c45a3f8256c4a155",
-      "creation_time": "2016-11-15 11:53:13.965982",
       "created_at": "2016-11-15T11:53:13Z",
       "undelegated": true,
       "overall_result": "error",
@@ -1068,7 +1054,6 @@ Example response:
     {
       "id": "32dd4bc0582b6bf9",
       "undelegated": false,
-      "creation_time": "2016-11-14 08:46:41.532047",
       "created_at": "2016-11-14T08:46:41Z",
       "overall_result": "error",
     },
@@ -1109,8 +1094,6 @@ The value of "frontend_params" is an object with the following properties:
 An object with the following properties:
 
 * `"id"` A *test id*.
-* `"creation_time"`: **Deprecated** (planned removal: v2023.1). A [*deprecated timestamp*][Timestamp deprecated].
-  The time in UTC at which the *test* was created.
 * `"created_at"`: A [*timestamp*][Timestamp]. The time in UTC at which the *test*
   was created.
 * `"overall_result"`: A string. It reflects the most severe problem level among
@@ -1346,7 +1329,6 @@ request:
   "jsonrpc": "2.0",
   "error": {
     "data": {
-      "creation_time": "2021-09-27 07:33:40",
       "created_at": "2021-09-27T07:33:40Z",
       "batch_id": 1
     },
@@ -1574,7 +1556,6 @@ The `"params"` object sent to [`start_domain_test`][start_domain_test] or
 [Test id]:                            #test-id
 [Test result]:                        #test-result
 [Timestamp]:                          #timestamp
-[Timestamp deprecated]:               #timestamp-deprecated
 [Username]:                           #username
 [Validation error data]:              #validation-error-data
 [ZONEMASTER.age_reuse_previous_test]: Configuration.md#age_reuse_previous_test

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -270,7 +270,7 @@ sub select_test_results {
         q[
             SELECT
                 hash_id,
-                created_at AS creation_time,
+                created_at,
                 params,
                 results
             FROM test_results
@@ -286,7 +286,7 @@ sub select_test_results {
     die Zonemaster::Backend::Error::ResourceNotFound->new( message => "Test not found", data => { test_id => $test_id } )
         unless defined $result;
 
-    $result->{created_at} = $self->to_iso8601( $result->{creation_time} );
+    $result->{created_at} = $self->to_iso8601( $result->{created_at} );
 
     return $result;
 }
@@ -384,7 +384,6 @@ sub get_test_history {
             @results,
             {
                 id               => $h->{hash_id},
-                creation_time    => $h->{created_at},
                 created_at       => $self->to_iso8601( $h->{created_at} ),
                 undelegated      => $h->{undelegated},
                 overall_result   => $overall,
@@ -399,7 +398,7 @@ sub create_new_batch_job {
     my ( $self, $username ) = @_;
 
     my $dbh = $self->dbh;
-    my ( $batch_id, $creation_time ) = $dbh->selectrow_array( "
+    my ( $batch_id, $created_at ) = $dbh->selectrow_array( "
             SELECT
                 batch_id,
                 batch_jobs.created_at AS batch_created_at
@@ -413,7 +412,7 @@ sub create_new_batch_job {
             LIMIT 1
             ", undef, $username );
 
-    die Zonemaster::Backend::Error::Conflict->new( message => 'Batch job still running', data => { batch_id => $batch_id, creation_time => $creation_time } )
+    die Zonemaster::Backend::Error::Conflict->new( message => 'Batch job still running', data => { batch_id => $batch_id, created_at => $created_at } )
         if ( $batch_id );
 
     $dbh->do( q[ INSERT INTO batch_jobs (username, created_at) VALUES (?,?) ],

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -173,7 +173,7 @@ sub add_batch_job {
         my $priority    = $test_params->{priority};
         my $queue_label = $test_params->{queue};
 
-        my $creation_time = $self->format_time( time() );
+        my $created_at = $self->format_time( time() );
 
         $dbh->begin_work();
         $dbh->do( "ALTER TABLE test_results DROP CONSTRAINT IF EXISTS test_results_pkey" );
@@ -209,7 +209,7 @@ sub add_batch_job {
 
             my $hash_id = substr(md5_hex(time().rand()), 0, 16);
             $dbh->pg_putcopydata(
-                "$hash_id\t$test_params->{domain}\t$batch_id\t$creation_time\t$priority\t$queue_label\t$fingerprint\t$encoded_params\t$undelegated\n"
+                "$hash_id\t$test_params->{domain}\t$batch_id\t$created_at\t$priority\t$queue_label\t$fingerprint\t$encoded_params\t$undelegated\n"
             );
         }
         $dbh->pg_putcopyend();

--- a/t/batches.t
+++ b/t/batches.t
@@ -268,7 +268,7 @@ subtest 'batch job still running' => sub {
     my $res = $@;
     is( $res->{message}, 'Batch job still running', 'correct error message' );
     is( $res->{data}->{batch_id}, $batch_id, 'error returned current running batch id' );
-    ok( $res->{data}->{creation_time}, 'error data contains batch creation time' );
+    ok( $res->{data}->{created_at}, 'error data contains batch creation time' );
 
     subtest 'use another user' => sub {
         my $another_user = { username => 'another', api_key => 'token' };

--- a/t/test01.t
+++ b/t/test01.t
@@ -121,7 +121,7 @@ subtest 'API calls' => sub {
         ok( ! defined $res->{id}, 'Do not expose primary key' );
         is( $res->{hash_id}, $hash_id, 'Retrieve the correct "hash_id"' );
         ok( defined $res->{params}, 'Value "params" properly defined' );
-        ok( defined $res->{creation_time}, 'Value "creation_time" properly defined' );
+        ok( ! exists $res->{creation_time}, 'Key "creation_time" should be missing' );
         ok( defined $res->{created_at}, 'Value "created_at" properly defined' );
         ok( defined $res->{results}, 'Value "results" properly defined' );
         if ( @{ $res->{results} } > 1 ) {
@@ -236,7 +236,7 @@ subtest 'get_test_history' => sub {
     foreach my $res (@$test_history) {
         is( length($res->{id}), 16, 'Test has 16 characters length hash ID' );
         is( $res->{undelegated}, JSON::PP::true, 'Test is undelegated' );
-        ok( defined $res->{creation_time}, 'Value "creation_time" properly defined' );
+        ok( ! exists $res->{creation_time}, 'Key "creation_time" should be missing' );
         ok( defined $res->{created_at}, 'Value "created_at" properly defined' );
         ok( defined $res->{overall_result}, 'Value "overall_result" properly defined' );
     }


### PR DESCRIPTION
## Purpose

Remove a deprecated key. "creation_time" replaced by "created_at".

## Context

https://github.com/zonemaster/zonemaster-backend/issues/1063

## Changes

* update code (DB.pm, PostgreSQL.pm)
* update documentation (API.pm)
* update tests (test01.t, batches.t)

## How to test this PR

Test should pass.
