### PR TITLE
Dissociate died test from reaching max execution time

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -525,6 +525,14 @@ sub get_batch_job_result {
     return \%result;
 }
 
+=head2 process_unfinished_tests($queue_label, $test_run_timeout)
+
+Append a new log entry C<BACKEND_TEST_AGENT:UNABLE_TO_FINISH_TEST> to all the
+tests started more that $test_run_timeout seconds in the queue $queue_label.
+Then store the results in database.
+
+=cut
+
 sub process_unfinished_tests {
     my ( $self, $queue_label, $test_run_timeout ) = @_;
 
@@ -544,6 +552,13 @@ sub process_unfinished_tests {
         $self->force_end_test($h->{hash_id}, $h->{results}, $msg);
     }
 }
+
+=head2 select_unfinished_tests($queue_label, $test_run_timeout)
+
+Search for all tests started more than $test_run_timeout seconds in the queue
+$queue_label.
+
+=cut
 
 sub select_unfinished_tests {
     my ( $self, $queue_label, $test_run_timeout ) = @_;
@@ -576,6 +591,13 @@ sub select_unfinished_tests {
     }
 }
 
+=head2 force_end_test($hash_id, $results, $msg)
+
+Append the $msg log entry to the $results arrayref and store the results into
+the database.
+
+=cut
+
 sub force_end_test {
     my ( $self, $hash_id, $results, $msg ) = @_;
     my $result;
@@ -589,6 +611,13 @@ sub force_end_test {
 
     $self->store_results( $hash_id, encode_json($result) );
 }
+
+=head2 process_dead_test($hash_id)
+
+Append a new log entry C<BACKEND_TEST_AGENT:TEST_DIED> to the test with $hash_id.
+Then store the results in database.
+
+=cut
 
 sub process_dead_test {
     my ( $self, $hash_id ) = @_;

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -18,9 +18,14 @@ require Zonemaster::Engine::Logger::Entry;
 extends 'Zonemaster::Engine::Translator';
 
 Readonly my %TAG_DESCRIPTIONS => (
+    TEST_DIED => sub {
+        __x    # BACKEND_TEST_AGENT:TEST_DIED
+          'An error occured and Zonemaster could not start or finish the test.', @_;
+    },
     UNABLE_TO_FINISH_TEST => sub {
         __x    # BACKEND_TEST_AGENT:UNABLE_TO_FINISH_TEST
-          "Zonemaster was unable to start or finish the test.", @_;
+          'The test took too long to run (the current limit is {max_execution_time} seconds). '
+          . 'Maybe there are too many name servers or the name servers are either unreachable or not responsive enough.', @_;
     },
 );
 

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -66,6 +66,11 @@ sub count_cancellation_messages {
     return scalar grep { $_->{tag} eq 'UNABLE_TO_FINISH_TEST' } @{ $results->{results} };
 }
 
+sub count_died_messages {
+    my $results = shift;
+    return scalar grep { $_->{tag} eq 'TEST_DIED' } @{ $results->{results} };
+}
+
 subtest 'Everything but Test::NoWarnings' => sub {
     lives_ok {    # Make sure we get to print log messages in case of errors.
         my $db = TestUtil::init_db( $config );
@@ -115,7 +120,7 @@ subtest 'Everything but Test::NoWarnings' => sub {
 
             is $db->test_progress( $testid4 ), 100, 'terminates test';
 
-            is count_cancellation_messages( $db->test_results( $testid4 ) ), 1, 'one cancellation message present after crash';
+            is count_died_messages( $db->test_results( $testid4 ) ), 1, 'one died message present after crash';
         };
 
         subtest 'Do not reuse batch tests' => sub {


### PR DESCRIPTION
## Purpose

Provide better message for both cases (test died or test reached `max_zonemaster_execution_time`) instead of one global message.

## Context

https://github.com/zonemaster/zonemaster/issues/1139

## Changes

* New message tag `TEST_DIED`
* Update msgid for `UNABLE_TO_FINISH_TEST`

## How to test this PR

Try with `corp.ds.fedex.com`, the output should explicitly state that the test was stopped.
```
zmtest corp.ds.fedex.com
```