### PR TITLE
RPCAPI apply new methods in code, scripts and tests

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1582,77 +1582,78 @@ If the `batch_id` is undefined the following error is returned:
 ### API method: `version_info`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`system_versions`][API system_versions].
+Replaced by [`system_versions`][API system_versions].
 
 
 ### API method: `profile_names`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`conf_profiles`][API conf_profiles].
+Replaced by [`conf_profiles`][API conf_profiles].
 
 
 ### API method: `get_language_tags`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`conf_languages`][API conf_languages].
+Replaced by [`conf_languages`][API conf_languages].
 
 ### API method: `get_host_by_name`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`lookup_address_records`][API lookup_address_records].
+Replaced by [`lookup_address_records`][API lookup_address_records].
 
 
 ### API method: `get_data_from_parent_zone`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`lookup_delegation_data`][API lookup_delegation_data].
+Replaced by [`lookup_delegation_data`][API lookup_delegation_data].
 
 
 ### API method: `start_domain_test`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`job_create`][API job_create].
+Replaced by [`job_create`][API job_create].
 
 
 ### API method: `test_progress`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`job_status`][API job_status].
+Replaced by [`job_status`][API job_status].
 
 
 ### API method: `get_test_results`
 
 **Deprecated** (planned removal: v2024.1).
+Replaced by [`job_results`][API job_results].
 
 
 ### API method: `get_test_history`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`domain_history`][API domain_history].
+Replaced by [`domain_history`][API domain_history].
 
 
 ### API method: `add_api_user`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`user_create`][API user_create].
+Replaced by [`user_create`][API user_create].
 
 
 ### API method: `add_batch_job`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`batch_create`][API batch_create].
+Replaced by [`batch_create`][API batch_create].
 
 
 ### API method: `get_batch_job_result`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`batch_status`][API batch_status].
+Replaced by [`batch_status`][API batch_status].
 
 
 ### API method: `get_test_params`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`job_params`][API job_params].
+Replaced by [`job_params`][API job_params].
 
 
 [API add_api_user]:                   #api-method-add_api_user

--- a/docs/API.md
+++ b/docs/API.md
@@ -1161,7 +1161,6 @@ Example response:
       {
         "id": "32dd4bc0582b6bf9",
         "undelegated": false,
-        "creation_time": "2016-11-14 08:46:41.532047",
         "created_at": "2016-11-14T08:46:41Z",
         "overall_result": "error",
       },

--- a/docs/API.md
+++ b/docs/API.md
@@ -344,9 +344,9 @@ with this type, it returns the following error message:
     }
 }
 ```
-The error code is "009" (as above) if method [`start_domain_test`][API start_domain_test]
+The error code is "009" (as above) if method [`job_create`][API job_create]
 was requested.
-Instead it will be "015" if method [`add_batch_job`][add_batch_job] is requested.
+Instead it will be "015" if method [`batch_create`][API batch_create] is requested.
 
 
 ### Progress percentage
@@ -956,7 +956,7 @@ Example request:
 }
 ```
 
-The `id` parameter must match the `result` in the response to a [`start_domain_test`][start_domain_test]
+The `id` parameter must match the `result` in the response to a [`job_create`][API job_create]
 call, and that test must have been completed.
 
 Example response:
@@ -1031,22 +1031,21 @@ An object with the following properties:
   was created.
 * `"hash_id"`: A [*test id*][Test id]. The *test* in question.
 * `"params"`: See below.
-  `start_domain_test` when the *test* was started.
 * `"results"`: A list of [*test result*][Test result] objects.
 * `"testcase_descriptions"`: A map with the *[Test Case Identifiers]* as keys and the
   translated *Test Case Description* of the corresponding *[Test Cases]* as values.
 
-If the test was created by [`start_domain_test`][start_domain_test] then `"params"`
-is a normalized version `"params"` object sent to [`start_domain_test`][start_domain_test]
+If the test was created by [`job_create`][API job_create] then `"params"`
+is a normalized version `"params"` object sent to [`job_create`][API job_create]
 when the *test* was created.
 
-If the test was created with [`add_batch_job`][add_batch_job] then `"params"`
+If the test was created with [`batch_create`][API batch_create] then `"params"`
 is a normalized version of an object created from the following parts:
-* The keys from the`"test_params"` object sent to [`add_batch_job`][add_batch_job]
+* The keys from the`"test_params"` object sent to [`batch_create`][API batch_create]
   when the *test* was created as part of a batch.
 * The `"domain"` key holding the specific [*domain name*][Domain name] for this
   test result from the `"domains"` object included in the call to
-  [`add_batch_job`][add_batch_job].
+  [`batch_create`][API batch_create].
 
 >
 > TODO: Change name in the API of `"hash_id"` to `"test_id"`
@@ -1113,8 +1112,8 @@ An object with the property:
 
 #### `"result"`
 
-The `"params"` object sent to [`start_domain_test`][start_domain_test] or
-[`add_batch_job`][add_batch_job] when the *test* was started.
+The `"params"` object sent to [`job_create`][API job_create] or
+[`batch_create`][API batch_create] when the *test* was started.
 
 
 #### `"error"`
@@ -1179,7 +1178,7 @@ Example response:
 ### Undelegated and delegated
 
 A test is considered to be `"delegated"` below if the test was started, by
-[`start_domain_test`][start_domain_test] or [`add_batch_job`][add_batch_job]
+[`job_create`][API job_create] or [`batch_create`][API batch_create]
 without specifying neither `"nameserver"` nor `"ds_info"`. Else it is considered to
 be `"undelegated"`.
 
@@ -1225,10 +1224,10 @@ An object with the following properties:
 
 ### API method: `user_create`
 
-In order to use the [`add_batch_job`][add_batch_job] method a
+In order to use the [`batch_create`][API batch_create] method a
 [*username*][Username] and its [*api key*][Api key] must be added by this method.
 
-This method is not available if [`RPCAPI.enable_add_api_user`][RPCAPI.enable_add_api_user]
+This method is not available if [`RPCAPI.enable_user_create`][RPCAPI.enable_user_create]
 is disabled (disabled by default). This method is not available unless the connection to
 RPCAPI is over localhost (*administrative* method).
 
@@ -1341,7 +1340,7 @@ Trying to add a user over non-localhost:
     "data": {
       "remote_ip": "10.0.0.1"
     },
-    "message": "Call to \"add_api_user\" method not permitted from a remote IP"
+    "message": "Call to \"user_create\" method not permitted from a remote IP"
   }
 }
 ```
@@ -1351,7 +1350,7 @@ Trying to add a user when the method is disabled:
 {
   "error": {
     "code": -32601,
-    "message": "Procedure 'add_api_user' not found"
+    "message": "Procedure 'user_create' not found"
   }
 }
 ```
@@ -1361,11 +1360,11 @@ Trying to add a user when the method is disabled:
 Add a new *batch test* composed by a set of [*domain name*][Domain name] and a *params* object.
 All the domains will be tested using identical parameters.
 
-This method is not available if [`RPCAPI.enable_add_batch_job`][RPCAPI.enable_add_batch_job]
+This method is not available if [`RPCAPI.enable_batch_create`][RPCAPI.enable_batch_create]
 is disabled (enabled by default).
 
 A [*username*][Username] and its [*api key*][Api key] can be added with the
-[`add_api_user`][add_api_user] method. A [*username*][Username] can only have
+[`user_create`][API user_create] method. A [*username*][Username] can only have
 one un-finished *batch* at a time.
 
 *Tests* enqueud using this method are assigned a [*priority*][Priority] of 5.
@@ -1495,7 +1494,7 @@ Trying to add a batch when the method has been disabled.
 ```
 {
   "error": {
-    "message": "Procedure 'add_batch_job' not found",
+    "message": "Procedure 'batch_create' not found",
     "code": -32601
   }
 }
@@ -1583,42 +1582,42 @@ If the `batch_id` is undefined the following error is returned:
 ### API method: `version_info`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`system_versions`][system_versions].
+Same as [`system_versions`][API system_versions].
 
 
 ### API method: `profile_names`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`conf_profiles`][conf_profiles].
+Same as [`conf_profiles`][API conf_profiles].
 
 
 ### API method: `get_language_tags`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`conf_languages`][conf_languages].
+Same as [`conf_languages`][API conf_languages].
 
 ### API method: `get_host_by_name`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`lookup_address_records`][lookup_address_records].
+Same as [`lookup_address_records`][API lookup_address_records].
 
 
 ### API method: `get_data_from_parent_zone`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`lookup_delegation_data`][lookup_delegation_data].
+Same as [`lookup_delegation_data`][API lookup_delegation_data].
 
 
 ### API method: `start_domain_test`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`job_create`][job_create].
+Same as [`job_create`][API job_create].
 
 
 ### API method: `test_progress`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`job_status`][job_status].
+Same as [`job_status`][API job_status].
 
 
 ### API method: `get_test_results`
@@ -1629,62 +1628,65 @@ Same as [`job_status`][job_status].
 ### API method: `get_test_history`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`domain_history`][domain_history].
+Same as [`domain_history`][API domain_history].
 
 
 ### API method: `add_api_user`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`user_create`][user_create].
+Same as [`user_create`][API user_create].
 
 
 ### API method: `add_batch_job`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`batch_create`][batch_create].
+Same as [`batch_create`][API batch_create].
 
 
 ### API method: `get_batch_job_result`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`batch_status`][batch_status].
+Same as [`batch_status`][API batch_status].
 
 
 ### API method: `get_test_params`
 
 **Deprecated** (planned removal: v2024.1).
-Same as [`job_params`][job_params].
+Same as [`job_params`][API job_params].
 
 
-[add_api_user]:                       #api-method-add_api_user
-[add_batch_job]:                      #api-method-add_batch_job
-[API v10.0.0]:                        https://github.com/zonemaster/zonemaster-backend/blob/v10.0.0/docs/API.md
+[API add_api_user]:                   #api-method-add_api_user
+[API add_batch_job]:                  #api-method-add_batch_job
+[API batch_create]:                   #api-method-batch_create
+[API batch_status]:                   #api-method-batch_status
+[API conf_languages]:                 #api-method-conf_languages
+[API conf_profiles]:                  #api-method-conf_profiles
+[API domain_history]:                 #api-method-domain_history
+[API job_create]:                     #api-method-job_create
+[API job_params]:                     #api-method-job_params
+[API job_results]:                    #api-method-job_results
+[API job_status]:                     #api-method-job_status
 [API key]:                            #api-key
+[API lookup_address_records]:         #api-method-lookup_address_records
+[API lookup_delegation_data]:         #api-method-lookup_delegation_data
+[API start_domain_test]:              #api-method-start_domain_test
+[API system_versions]:                #api-method-system_versions
+[API user_create]:                    #api-method-user_create
+[API v10.0.0]:                        https://github.com/zonemaster/zonemaster-backend/blob/v10.0.0/docs/API.md
 [Batch id]:                           #batch-id
-[batch_create]:                       #api-method-batch_create
-[batch_status]:                       #api-method-batch_status
 [Client id]:                          #client-id
 [Client version]:                     #client-version
-[conf_languages]:                     #api-method-conf_languages
-[conf_profiles]:                      #api-method-conf_profiles
 [Delegation Signer]:                  https://datatracker.ietf.org/doc/html/rfc4034#section-5
 [Domain name]:                        #domain-name
-[domain_history]:                     #api-method-domain_history
 [Dot-decimal notation]:               https://en.wikipedia.org/wiki/Dot-decimal_notation
 [DS info]:                            #ds-info
 [IP address]:                         #ip-address
 [ISO 3166-1 alpha-2]:                 https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [ISO 639-1]:                          https://en.wikipedia.org/wiki/ISO_639-1
-[job_create]:                         #api-method-job_create
-[job_params]:                         #api-method-job_params
-[job_results]:                        #api-method-job_results
-[job_status]:                         #api-method-job_status
 [JSON Pointer]:                       https://datatracker.ietf.org/doc/html/rfc6901
 [JSON-RPC 2.0]:                       https://www.jsonrpc.org/specification
 [Language tag]:                       #language-tag
 [LANGUAGE.locale]:                    Configuration.md#locale
-[lookup_address_records]:             #api-method-lookup_address_records
-[lookup_delegation_data]:             #api-method-lookup_delegation_data
 [Name server]:                        #name-server
 [net.ipv4]:                           https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv4
 [net.ipv6]:                           https://metacpan.org/pod/Zonemaster::Engine::Profile#net.ipv6
@@ -1698,16 +1700,15 @@ Same as [`job_params`][job_params].
 [RFC 5952]:                           https://datatracker.ietf.org/doc/html/rfc5952
 [RPCAPI.enable_add_api_user]:         Configuration.md#enable_add_api_user
 [RPCAPI.enable_add_batch_job]:        Configuration.md#enable_add_batch_job
+[RPCAPI.enable_batch_create]:         Configuration.md#enable_batch_create
+[RPCAPI.enable_user_create]:          Configuration.md#enable_user_create
 [Severity Level Definitions]:         https://github.com/zonemaster/zonemaster/blob/master/docs/specifications/tests/SeverityLevelDefinitions.md
 [Severity level]:                     #severity-level
-[start_domain_test]:                  #api-method-start_domain_test
-[system_versions]:                    #api-method-system_versions
 [Test Cases]:                         https://github.com/zonemaster/zonemaster/tree/master/docs/specifications/tests#list-of-defined-test-cases
 [Test Case Identifiers]:              https://github.com/zonemaster/zonemaster/blob/master/docs/internal-documentation/templates/specifications/tests/TestCaseIdentifierSpecification.md
 [Test id]:                            #test-id
 [Test result]:                        #test-result
 [Timestamp]:                          #timestamp
-[user_create]:                        #api-method-user_create
 [Username]:                           #username
 [Validation error data]:              #validation-error-data
 [ZONEMASTER.age_reuse_previous_test]: Configuration.md#age_reuse_previous_test

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -85,16 +85,16 @@ default to `no` (disabled).
 Deprecated (planned removal: v2024.1). Use
 [enable_batch_create][RPCAPI.enable_batch_create] instead.
 
-The [enable_batch_create][RPCAPI.enable_batch_create] property takes
-precedence over this.
+If defined, the [enable_batch_create][RPCAPI.enable_batch_create]
+property takes precedence over this.
 
 ### enable_add_api_user
 
 Deprecated (planned removal: v2024.1). Use
 [enable_user_create][RPCAPI.enable_user_create] instead.
 
-The [enable_user_create][RPCAPI.enable_user_create] property takes
-precedence over this.
+If defined, the [enable_user_create][RPCAPI.enable_user_create] property
+takes precedence over this.
 
 
 ## DB section

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -217,8 +217,8 @@ sub parse {
     $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
     $obj->_set_RPCAPI_enable_user_create( 'no' );
     $obj->_set_RPCAPI_enable_batch_create( 'yes' );
-    $obj->_set_RPCAPI_enable_add_api_user( 'no' );
-    $obj->_set_RPCAPI_enable_add_batch_job( 'yes' );
+    $obj->_set_RPCAPI_enable_add_api_user( 'no' ); # deprecated
+    $obj->_set_RPCAPI_enable_add_batch_job( 'yes' ); # deprecated
     $obj->_add_LANGUAGE_locale( 'en_US' );
     $obj->_add_public_profile( 'default', undef );
     $obj->_set_METRICS_statsd_port( '8125' );
@@ -240,6 +240,12 @@ sub parse {
         if ( $value eq "" ) {
             push @warnings, "Use of empty LANGUAGE.locale property is deprecated. Remove the LANGUAGE.locale entry or specify LANGUAGE.locale = en_US instead.";
         }
+    }
+    if ( defined( my $value = $ini->val( 'RPCAPI', 'enable_add_api_user' ) ) ) {
+        push @warnings, "Use of deprecated config property RPCAPI.enable_add_api_user. Use RPCAPI.enable_user_create instead.";
+    }
+    if ( defined( my $value = $ini->val( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
+        push @warnings, "Use of deprecated config property RPCAPI.enable_add_batch_job. Use RPCAPI.enable_batch_create instead.";
     }
 
     # Assign property values (part 2/2)
@@ -303,11 +309,29 @@ sub parse {
     if ( defined( my $value = $get_and_clear->( 'METRICS', 'statsd_port' ) ) ) {
         $obj->_set_METRICS_statsd_port( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
-        $obj->_set_RPCAPI_enable_add_api_user( $value );
+    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_user_create' ) ) ) {
+        $obj->_set_RPCAPI_enable_user_create( $value );
+        if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
+            $obj->_set_RPCAPI_enable_add_api_user( $value );
+        }
     }
-    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
-        $obj->_set_RPCAPI_enable_add_batch_job( $value );
+    else {
+        if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
+            $obj->_set_RPCAPI_enable_user_create( $value );
+            $obj->_set_RPCAPI_enable_add_api_user( $value );
+        }
+    }
+    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_batch_create' ) ) ) {
+        $obj->_set_RPCAPI_enable_batch_create( $value );
+        if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
+            $obj->_set_RPCAPI_enable_add_batch_job( $value );
+        }
+    }
+    else {
+        if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
+            $obj->_set_RPCAPI_enable_batch_create( $value );
+            $obj->_set_RPCAPI_enable_add_batch_job( $value );
+        }
     }
     if ( defined( my $value = $get_and_clear->( 'LANGUAGE', 'locale' ) ) ) {
         if ( $value ne "" ) {
@@ -668,8 +692,8 @@ sub METRICS_statsd_host                                 { return $_[0]->{_METRIC
 sub METRICS_statsd_port                                 { return $_[0]->{_METRICS_statsd_port}; }
 sub RPCAPI_enable_user_create                           { return $_[0]->{_RPCAPI_enable_user_create}; }
 sub RPCAPI_enable_batch_create                          { return $_[0]->{_RPCAPI_enable_batch_create}; }
-sub RPCAPI_enable_add_api_user                          { return $_[0]->{_RPCAPI_enable_add_api_user}; }
-sub RPCAPI_enable_add_batch_job                         { return $_[0]->{_RPCAPI_enable_add_batch_job}; }
+sub RPCAPI_enable_add_api_user                          { return $_[0]->{_RPCAPI_enable_add_api_user}; } # deprecated
+sub RPCAPI_enable_add_batch_job                         { return $_[0]->{_RPCAPI_enable_add_batch_job}; } # deprecated
 
 # Compile time generation of setters for the properties documented above
 UNITCHECK {
@@ -694,8 +718,8 @@ UNITCHECK {
     _create_setter( '_set_METRICS_statsd_port',                                 '_METRICS_statsd_port',                                 \&untaint_strictly_positive_int );
     _create_setter( '_set_RPCAPI_enable_user_create',                           '_RPCAPI_enable_user_create',                           \&untaint_bool );
     _create_setter( '_set_RPCAPI_enable_batch_create',                          '_RPCAPI_enable_batch_create',                          \&untaint_bool );
-    _create_setter( '_set_RPCAPI_enable_add_api_user',                          '_RPCAPI_enable_add_api_user',                          \&untaint_bool );
-    _create_setter( '_set_RPCAPI_enable_add_batch_job',                         '_RPCAPI_enable_add_batch_job',                         \&untaint_bool );
+    _create_setter( '_set_RPCAPI_enable_add_api_user',                          '_RPCAPI_enable_add_api_user',                          \&untaint_bool ); #deprecated
+    _create_setter( '_set_RPCAPI_enable_add_batch_job',                         '_RPCAPI_enable_add_batch_job',                         \&untaint_bool ); #deprecated
 }
 
 =head2 new_DB

--- a/script/add-batch-job.pl
+++ b/script/add-batch-job.pl
@@ -14,7 +14,7 @@ binmode STDOUT, ':utf8';
 
 my $e = Zonemaster::Backend::RPCAPI->new;
 
-say "Starting add_batch_job";
+say "Starting batch_create";
 my @domains;
 for (my $i = 0; $i < 100; $i++) {
     push(@domains, substr(md5_hex(rand(10000)), 0, 5).".fr");
@@ -22,9 +22,9 @@ for (my $i = 0; $i < 100; $i++) {
 
 #die Dumper(\@domains);
 
-$e->add_api_user({ username => 'test_user', api_key => 'API_KEY_01'});
+$e->user_create({ username => 'test_user', api_key => 'API_KEY_01'});
 
-$e->add_batch_job(
+$e->batch_create(
     {
         client_id      => 'Add Script',
         client_version => '1.0',

--- a/script/zmb
+++ b/script/zmb
@@ -95,51 +95,51 @@ sub cmd_non_existing_method {
 }
 
 
-=head2 version_info
+=head2 system_versions
 
- zmb [GLOBAL OPTIONS] version_info
+ zmb [GLOBAL OPTIONS] system_versions
 
 =cut
 
-sub cmd_version_info {
+sub cmd_system_versions {
     return to_jsonrpc(
         id     => 1,
-        method => 'version_info',
+        method => 'system_versions',
     );
 }
 
 
-=head2 profile_names
+=head2 conf_profiles
 
- zmb [GLOBAL OPTIONS] profile_names
+ zmb [GLOBAL OPTIONS] conf_profiles
 
 =cut
 
-sub cmd_profile_names {
+sub cmd_conf_profiles {
     return to_jsonrpc(
         id     => 1,
-        method => 'profile_names',
+        method => 'conf_profiles',
     );
 }
 
 
-=head2 get_language_tags
+=head2 conf_languages
 
- zmb [GLOBAL OPTIONS] get_language_tags
+ zmb [GLOBAL OPTIONS] conf_languages
 
 =cut
 
-sub cmd_get_language_tags {
+sub cmd_conf_languages {
     return to_jsonrpc(
         id     => 1,
-        method => 'get_language_tags',
+        method => 'conf_languages',
     );
 }
 
 
-=head2 start_domain_test
+=head2 job_create
 
- zmb [GLOBAL OPTIONS] start_domain_test [OPTIONS]
+ zmb [GLOBAL OPTIONS] job_create [OPTIONS]
 
  Options:
 
@@ -164,7 +164,7 @@ sub cmd_get_language_tags {
 
 =cut
 
-sub cmd_start_domain_test {
+sub cmd_job_create {
     my @opts = @_;
 
     my @opt_nameserver;
@@ -252,7 +252,7 @@ sub cmd_start_domain_test {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'start_domain_test',
+        method => 'job_create',
         params => \%params,
     );
 }
@@ -260,16 +260,16 @@ sub cmd_start_domain_test {
 
 
 
-=head2 test_progress
+=head2 job_status
 
- zmb [GLOBAL OPTIONS] test_progress [OPTIONS]
+ zmb [GLOBAL OPTIONS] job_status [OPTIONS]
 
  Options:
    --test-id TEST_ID
 
 =cut
 
-sub cmd_test_progress {
+sub cmd_job_status {
     my @opts = @_;
 
     my $opt_test_id;
@@ -280,7 +280,7 @@ sub cmd_test_progress {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'test_progress',
+        method => 'job_status',
         params => {
             test_id => $opt_test_id,
         },
@@ -288,16 +288,16 @@ sub cmd_test_progress {
 }
 
 
-=head2 get_test_params
+=head2 job_params
 
- zmb [GLOBAL OPTIONS] get_test_params [OPTIONS]
+ zmb [GLOBAL OPTIONS] job_params [OPTIONS]
 
  Options:
    --test-id TEST_ID
 
 =cut
 
-sub cmd_get_test_params {
+sub cmd_job_params {
     my @opts = @_;
 
     my $opt_test_id;
@@ -308,7 +308,7 @@ sub cmd_get_test_params {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'get_test_params',
+        method => 'job_params',
         params => {
             test_id => $opt_test_id,
         },
@@ -316,9 +316,9 @@ sub cmd_get_test_params {
 }
 
 
-=head2 get_test_results
+=head2 job_results
 
- zmb [GLOBAL OPTIONS] get_test_results [OPTIONS]
+ zmb [GLOBAL OPTIONS] job_results [OPTIONS]
 
  Options:
    --test-id TEST_ID
@@ -326,7 +326,7 @@ sub cmd_get_test_params {
 
 =cut
 
-sub cmd_get_test_results {
+sub cmd_job_results {
     my @opts = @_;
 
     my $opt_lang;
@@ -339,7 +339,7 @@ sub cmd_get_test_results {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'get_test_results',
+        method => 'job_results',
         params => {
             id       => $opt_test_id,
             language => $opt_lang,
@@ -348,9 +348,9 @@ sub cmd_get_test_results {
 }
 
 
-=head2 get_test_history
+=head2 domain_history
 
- zmb [GLOBAL OPTIONS] get_test_history [OPTIONS]
+ zmb [GLOBAL OPTIONS] domain_history [OPTIONS]
 
  Options:
    --domain DOMAIN_NAME
@@ -360,7 +360,7 @@ sub cmd_get_test_results {
 
 =cut
 
-sub cmd_get_test_history {
+sub cmd_domain_history {
     my @opts = @_;
     my $opt_filter;
     my $opt_domain;
@@ -398,15 +398,15 @@ sub cmd_get_test_history {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'get_test_history',
+        method => 'domain_history',
         params => \%params,
     );
 }
 
 
-=head2 add_api_user
+=head2 user_create
 
- zmb [GLOBAL OPTIONS] add_api_user [OPTIONS]
+ zmb [GLOBAL OPTIONS] user_create [OPTIONS]
 
  Options:
    --username USERNAME
@@ -414,7 +414,7 @@ sub cmd_get_test_history {
 
 =cut
 
-sub cmd_add_api_user {
+sub cmd_user_create {
     my @opts = @_;
 
     my $opt_username;
@@ -427,7 +427,7 @@ sub cmd_add_api_user {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'add_api_user',
+        method => 'user_create',
         params => {
             username => $opt_username,
             api_key  => $opt_api_key,
@@ -436,9 +436,9 @@ sub cmd_add_api_user {
 }
 
 
-=head2 add_batch_job
+=head2 batch_create
 
- zmb [GLOBAL OPTIONS] add_batch_job [OPTIONS]
+ zmb [GLOBAL OPTIONS] batch_create [OPTIONS]
 
  Options:
     --username USERNAME
@@ -467,7 +467,7 @@ sub cmd_add_api_user {
 
 =cut
 
-sub cmd_add_batch_job {
+sub cmd_batch_create {
     my @opts = @_;
 
     my $opt_username;
@@ -558,22 +558,22 @@ sub cmd_add_batch_job {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'add_batch_job',
+        method => 'batch_create',
         params => \%params,
     );
 }
 
 
-=head2 get_batch_job_result
+=head2 batch_status
 
- zmb [GLOBAL OPTIONS] get_batch_job_result [OPTIONS]
+ zmb [GLOBAL OPTIONS] batch_status [OPTIONS]
 
  Options:
    --batch-id BATCH-ID
 
 =cut
 
-sub cmd_get_batch_job_result {
+sub cmd_batch_status {
     my @opts = @_;
 
     my $opt_batch_id;
@@ -584,7 +584,7 @@ sub cmd_get_batch_job_result {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'get_batch_job_result',
+        method => 'batch_status',
         params => {
             batch_id => $opt_batch_id,
         },

--- a/script/zmtest
+++ b/script/zmtest
@@ -64,19 +64,19 @@ done
 [ -n "${domain}" ] || usage 2 "No domain specified"
 
 # Start test
-output="$(zmb "${server_url}" start_domain_test --domain "${domain}" ${ipv4} ${ipv6} --profile "${profile}")" || exit $?
-testid="$(printf "%s" "${output}" | "${JQ}" -r .result)" || exit $?
+output="$(zmb "${server_url}" job_create --domain "${domain}" ${ipv4} ${ipv6} --profile "${profile}")" || exit $?
+testid="$(printf "%s" "${output}" | "${JQ}" -r .result.job_id)" || exit $?
 printf "testid: %s\n" "${testid}" >&2
 
 if echo "${testid}" | grep -qE '[^0-9a-fA-F]' ; then
-    error 1 "start_domain_test did not return a testid: ${testid}"
+    error 1 "job_create did not return a testid: ${testid}"
 fi
 
 # Wait for test to finish
 while true
 do
-    output="$(zmb "${server_url}" test_progress --test-id "${testid}")" || exit $?
-    progress="$(printf "%s" "${output}" | "${JQ}" -r .result)" || exit $?
+    output="$(zmb "${server_url}" job_status --test-id "${testid}")" || exit $?
+    progress="$(printf "%s" "${output}" | "${JQ}" -r .result.progress)" || exit $?
     printf "\r${progress}%% done" >&2
     if [ "${progress}" -eq 100 ] ; then
         echo >&2
@@ -86,4 +86,4 @@ do
 done
 
 # Get test results
-zmb "${server_url}" get_test_results --test-id "${testid}" --lang "${lang}"
+zmb "${server_url}" job_results --test-id "${testid}" --lang "${lang}"

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -181,26 +181,28 @@ my $router = router {
     };
 };
 
-if ( $config->RPCAPI_enable_user_create or $config->RPCAPI_enable_add_api_user ) {
-    $log->info('Enabling user_create method');
+if ( $config->RPCAPI_enable_user_create ) {
     #Deprecated
+    $log->info('Enabling add_api_user method. Deprecated, use user_create method.');
     $router->connect("add_api_user", {
         handler => $handler,
         action => "add_api_user"
     });
+    $log->info('Enabling user_create method');
     $router->connect("user_create", {
         handler => $handler,
         action => "user_create"
     });
 }
 
-if ( $config->RPCAPI_enable_batch_create or $config->RPCAPI_enable_add_batch_job ) {
-    $log->info('Enabling batch_create method');
+if ( $config->RPCAPI_enable_batch_create ) {
     #Deprecated
+    $log->info('Enabling add_batch_job method. Deprecated, use batch_create method.');
     $router->connect("add_batch_job", {
         handler => $handler,
         action => "add_batch_job"
     });
+    $log->info('Enabling batch_create method');
     $router->connect("batch_create", {
         handler => $handler,
         action => "batch_create"

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -29,10 +29,10 @@ database_file = /var/lib/zonemaster/db.sqlite
 
 [RPCAPI]
 
-# Uncomment to enable API method "add_api_user"
-#enable_add_api_user = yes
-# Uncomment to disable API method "add_batch_job"
-#enable_add_batch_job = no
+# Uncomment to enable API method "user_create"
+#enable_user_create = yes
+# Uncomment to disable API method "batch_create"
+#enable_batch_create = no
 
 [LANGUAGE]
 locale = da_DK en_US es_ES fi_FI fr_FR nb_NO sv_SE

--- a/t/TestUtil.pm
+++ b/t/TestUtil.pm
@@ -109,9 +109,9 @@ sub init_db {
 sub create_rpcapi {
     my ( $config ) = @_;
 
-    my $backend;
+    my $rpcapi;
     eval {
-        $backend = Zonemaster::Backend::RPCAPI->new(
+        $rpcapi = Zonemaster::Backend::RPCAPI->new(
             {
                 dbtype => $db_backend,
                 config => $config,
@@ -123,13 +123,13 @@ sub create_rpcapi {
         BAIL_OUT( 'Could not connect to database' );
     }
 
-    if ( not $backend->isa('Zonemaster::Backend::RPCAPI' ) ) {
+    if ( not $rpcapi->isa('Zonemaster::Backend::RPCAPI' ) ) {
         BAIL_OUT( 'Not a Zonemaster::Backend::RPCAPI object' );
     }
 
-    prepare_db( $backend->{db} );
+    prepare_db( $rpcapi->{db} );
 
-    return $backend;
+    return $rpcapi;
 }
 
 sub create_testagent {

--- a/t/config.t
+++ b/t/config.t
@@ -122,9 +122,40 @@ subtest 'Everything but NoWarnings' => sub {
             database_file = /var/db/zonemaster.sqlite
             [LANGUAGE]
             locale =
+            [RPCAPI]
+            enable_add_api_user = yes
+            enable_add_batch_job = no
         };
         my $config = Zonemaster::Backend::Config->parse( $text );
         $log->contains_ok( qr/deprecated.*LANGUAGE\.locale/, 'deprecated empty LANGUAGE.locale' );
+        $log->contains_ok( qr/deprecated.*RPCAPI\.enable_add_api_user/, 'deprecated: RPCAPI.enable_add_api_user' );
+        $log->contains_ok( qr/deprecated.*RPCAPI\.enable_add_batch_job/, 'deprecated: RPCAPI.enable_add_batch_job' );
+
+        is $config->RPCAPI_enable_add_api_user,  1, 'set: RPCAPI.enable_add_api_user';
+        is $config->RPCAPI_enable_add_batch_job, 0, 'set: RPCAPI.enable_add_batch_job';
+        is $config->RPCAPI_enable_user_create,   1, 'apply: RPCAPI.enable_user_create';
+        is $config->RPCAPI_enable_batch_create,  0, 'apply: RPCAPI.enable_batch_create';
+
+        subtest 'Deprecated RPCAPI properties and precedence' => sub {
+            $log->clear();
+            my $text = q{
+                [DB]
+                engine = SQLite
+                [SQLITE]
+                database_file = /var/db/zonemaster.sqlite
+                [RPCAPI]
+                enable_add_api_user = yes
+                enable_add_batch_job = no
+                enable_user_create = no
+                enable_batch_create = yes
+            };
+            my $config = Zonemaster::Backend::Config->parse( $text );
+
+            is $config->RPCAPI_enable_add_api_user,  1, 'set: RPCAPI.enable_add_api_user';
+            is $config->RPCAPI_enable_add_batch_job, 0, 'set: RPCAPI.enable_add_batch_job';
+            is $config->RPCAPI_enable_user_create,   0, 'precedence: RPCAPI.enable_user_create';
+            is $config->RPCAPI_enable_batch_create,  1, 'precedence: RPCAPI.enable_batch_create';
+        };
     };
 
     subtest 'Warnings' => sub {

--- a/t/test01.t
+++ b/t/test01.t
@@ -86,38 +86,39 @@ my $hash_id;
 # This is the first test added to the DB, its 'id' is 1
 my $test_id = 1;
 subtest 'add a first test' => sub {
-    $hash_id = $rpcapi->start_domain_test( $params );
+    my $res_job_id = $rpcapi->job_create( $params );
+    $hash_id = $res_job_id->{job_id};
 
-    ok( $hash_id, "API start_domain_test OK" );
+    ok( $hash_id, "API job_create OK" );
     is( length($hash_id), 16, "Test has a 16 characters length hash ID (hash_id=$hash_id)" );
 
     my ( $test_id_db, $hash_id_db ) = $dbh->selectrow_array( "SELECT id, hash_id FROM test_results WHERE id=?", undef, $test_id );
-    is( $test_id_db, $test_id , 'API start_domain_test -> Test inserted in the DB' );
+    is( $test_id_db, $test_id , 'API job_create -> Test inserted in the DB' );
     is( $hash_id_db, $hash_id , 'Correct hash_id in database' );
 
-    # test test_progress API
-    my $progress = $rpcapi->test_progress( { test_id => $hash_id } );
-    is( $progress, 0 , 'Test has been created, its progress is 0' );
+    # test job_status API
+    my $res_job_status = $rpcapi->job_status( { test_id => $hash_id } );
+    is( $res_job_status->{progress}, 0 , 'Test has been created, its progress is 0' );
 };
 
 subtest 'get and run test' => sub {
     my ( $hash_id_from_db ) = $rpcapi->{db}->get_test_request();
     is( $hash_id_from_db, $hash_id, 'Get correct test to run' );
 
-    my $progress = $rpcapi->test_progress( { test_id => $hash_id } );
-    is( $progress, 1, 'Test has been picked, its progress is 1' );
+    my $res_job_status = $rpcapi->job_status( { test_id => $hash_id } );
+    is( $res_job_status->{progress}, 1, 'Test has been picked, its progress is 1' );
 
     diag "running the agent on test $hash_id";
     $agent->run( $hash_id ); # blocking call
 
-    $progress = $rpcapi->test_progress( { test_id => $hash_id } );
-    is( $progress, 100 , 'Test has finished, its progress is 100' );
+    $res_job_status = $rpcapi->job_status( { test_id => $hash_id } );
+    is( $res_job_status->{progress}, 100 , 'Test has finished, its progress is 100' );
 };
 
 subtest 'API calls' => sub {
 
-    subtest 'get_test_results' => sub {
-        my $res = $rpcapi->get_test_results( { id => $hash_id, language => 'en_US' } );
+    subtest 'job_results' => sub {
+        my $res = $rpcapi->job_results( { id => $hash_id, language => 'en_US' } );
         ok( ! defined $res->{id}, 'Do not expose primary key' );
         is( $res->{hash_id}, $hash_id, 'Retrieve the correct "hash_id"' );
         ok( defined $res->{params}, 'Value "params" properly defined' );
@@ -132,8 +133,8 @@ subtest 'API calls' => sub {
         }
     };
 
-    subtest 'get_test_params' => sub {
-        my $res = $rpcapi->get_test_params( { test_id => $hash_id } );
+    subtest 'job_params' => sub {
+        my $res = $rpcapi->job_params( { test_id => $hash_id } );
         is( $res->{domain}, $params->{domain}, 'Retrieve the correct "domain" value' );
         is( $res->{profile}, $params->{profile}, 'Retrieve the correct "profile" value' );
         is( $res->{client_id}, $params->{client_id}, 'Retrieve the correct "client_id" value' );
@@ -144,33 +145,34 @@ subtest 'API calls' => sub {
         is_deeply( $res->{ds_info}, $params->{ds_info}, 'Retrieve the correct "ds_info" value' );
     };
 
-    subtest 'add_api_user' => sub {
+    subtest 'user_create' => sub {
         my $res;
         eval {
-            $res = $rpcapi->add_api_user( { username => "zonemaster_test", api_key => "zonemaster_test's api key" } );
+            $res = $rpcapi->user_create( { username => "zonemaster_test", api_key => "zonemaster_test's api key" } );
         };
-        is( $res, 1, 'API add_api_user success');
+        is( $res->{success}, 1, 'API user_create success');
 
         my $user_check_query = q/SELECT * FROM users WHERE username = 'zonemaster_test'/;
-        is( scalar( $dbh->selectrow_array( $user_check_query ) ), 1 ,'API add_api_user user created' );
+        is( scalar( $dbh->selectrow_array( $user_check_query ) ), 1 ,'API user_create user created' );
     };
 
-    subtest 'version_info' => sub {
-        my $res = $rpcapi->version_info();
+    subtest 'system_versions' => sub {
+        my $res = $rpcapi->system_versions();
         ok( defined( $res->{zonemaster_ldns} ), 'Has a "zonemaster_ldns" key' );
         ok( defined( $res->{zonemaster_engine} ), 'Has a "zonemaster_engine" key' );
         ok( defined( $res->{zonemaster_backend} ), 'Has a "zonemaster_backend" key' );
     };
 
-    subtest 'profile_names' => sub {
-        my $res = $rpcapi->profile_names();
-        is( scalar( @$res ), 2, 'There are exactly 2 public profiles' );
-        ok( grep( /default/, @$res ), 'The profile "default" is defined' );
-        ok( grep( /test_profile/, @$res ), 'The profile "test_profile" is defined' );
+    subtest 'conf_profiles' => sub {
+        my $res = $rpcapi->conf_profiles();
+        my $profiles = $res->{profiles};
+        is( scalar( @$profiles ), 2, 'There are exactly 2 public profiles' );
+        ok( grep( /default/, @$profiles ), 'The profile "default" is defined' );
+        ok( grep( /test_profile/, @$profiles ), 'The profile "test_profile" is defined' );
     };
 
-    subtest 'get_data_from_parent_zone' => sub {
-        my $res = $rpcapi->get_data_from_parent_zone( { domain => "fr" } );
+    subtest 'lookup_delegation_data' => sub {
+        my $res = $rpcapi->lookup_delegation_data( { domain => "fr" } );
         #diag explain( $res );
         ok( defined( $res->{ns_list} ), 'Has a list of nameservers' );
         ok( defined( $res->{ds_list} ), 'Has a list of DS records' );
@@ -205,22 +207,23 @@ subtest 'API calls' => sub {
 
 # start a second test with IPv6 disabled
 $params->{ipv6} = 0;
-$hash_id = $rpcapi->start_domain_test( $params );
+my $job_res = $rpcapi->job_create( $params );
+$hash_id = $job_res->{job_id};
 diag "running the agent on test $hash_id";
 $agent->run($hash_id);
 
 subtest 'second test has IPv6 disabled' => sub {
-    my $res = $rpcapi->get_test_params( { test_id => $hash_id } );
+    my $res = $rpcapi->job_params( { test_id => $hash_id } );
     is( $res->{ipv4}, $params->{ipv4}, 'Retrieve the correct "ipv4" value' );
     is( $res->{ipv6}, $params->{ipv6}, 'Retrieve the correct "ipv6" value' );
 
-    $res = $rpcapi->get_test_results( { id => $hash_id, language => 'en_US' } );
+    $res = $rpcapi->job_results( { id => $hash_id, language => 'en_US' } );
     my @msg_basic = map { $_->{message} if $_->{module} eq 'BASIC' } @{ $res->{results} };
     ok( grep( /IPv6 is disabled/, @msg_basic ), 'Results contain an "IPv6 is disabled" message' );
 };
 
-my $test_history;
-subtest 'get_test_history' => sub {
+my $domain_history;
+subtest 'domain_history' => sub {
     my $offset = 0;
     my $limit  = 10;
     my $method_params = {
@@ -229,11 +232,11 @@ subtest 'get_test_history' => sub {
         limit => $limit
     };
 
-    $test_history = $rpcapi->get_test_history( $method_params );
-    #diag explain( $test_history );
-    is( scalar( @$test_history ), 2, 'Two tests created' );
+    my $res_domain_history = $rpcapi->domain_history( $method_params );
+    $domain_history = $res_domain_history->{history};
+    is( scalar( @$domain_history ), 2, 'Two tests created' );
 
-    foreach my $res (@$test_history) {
+    foreach my $res (@$domain_history) {
         is( length($res->{id}), 16, 'Test has 16 characters length hash ID' );
         is( $res->{undelegated}, JSON::PP::true, 'Test is undelegated' );
         ok( ! exists $res->{creation_time}, 'Key "creation_time" should be missing' );
@@ -247,19 +250,21 @@ subtest 'get_test_history' => sub {
         $params->{ipv4} = 0;
 
         # create the test, retrieve its id but we don't run it
-        $rpcapi->start_domain_test( $params );
+        $rpcapi->job_create( $params );
         ( $hash_id ) = $rpcapi->{db}->get_test_request();
 
-        $test_history = $rpcapi->get_test_history( $method_params );
-        #diag explain( $test_history );
-        is( scalar( @$test_history ), 2, 'Only 2 tests should be retrieved' );
+        my $res_domain_history;
+        $res_domain_history = $rpcapi->domain_history( $method_params );
+        $domain_history = $res_domain_history->{history};
+        is( scalar( @$domain_history ), 2, 'Only 2 tests should be retrieved' );
 
         # now run the test
         diag "running the agent on test $hash_id";
         $agent->run( $hash_id );
 
-        $test_history = $rpcapi->get_test_history( $method_params );
-        is( scalar( @$test_history ), 3, 'Now 3 tests should be retrieved' );
+        $res_domain_history = $rpcapi->domain_history( $method_params );
+        $domain_history = $res_domain_history->{history};
+        is( scalar( @$domain_history ), 3, 'Now 3 tests should be retrieved' );
     }
 };
 
@@ -267,12 +272,13 @@ subtest 'mock another client (i.e. reuse a previous test)' => sub {
     $params->{client_id} = 'Another Client';
     $params->{client_version} = '0.1';
 
-    my $new_hash_id = $rpcapi->start_domain_test( $params );
+    my $res = $rpcapi->job_create( $params );
+    my $new_hash_id = $res->{job_id};
 
     is( $new_hash_id, $hash_id, 'Has the same hash than previous test' );
 
     subtest 'check test_params values' => sub {
-        my $res = $rpcapi->get_test_params( { test_id => "$hash_id" } );
+        my $res = $rpcapi->job_params( { test_id => "$hash_id" } );
         # the following values are part of the fingerprint
         is( $res->{domain}, $params->{domain}, 'Retrieve the correct "domain" value' );
         is( $res->{profile}, $params->{profile}, 'Retrieve the correct "profile" value' );
@@ -289,10 +295,10 @@ subtest 'mock another client (i.e. reuse a previous test)' => sub {
 
 subtest 'check historic tests' => sub {
     # Verifies that delegated and undelegated tests are coded correctly when started
-    # and that the filter option in "get_test_history" works correctly
+    # and that the filter option in "domain_history" works correctly
 
     my $domain          = 'xa';
-    # Non-batch for "start_domain_test":
+    # Non-batch for "job_create":
     my $params_un1      = { # undelegated, non-batch
         domain          => $domain,
         nameservers     => [
@@ -308,7 +314,7 @@ subtest 'check historic tests' => sub {
     my $params_dn1 = { # delegated, non-batch
         domain          => $domain,
     };
-    # Batch for "add_batch_job"
+    # Batch for "batch_create"
     my $domain2         = 'xb';
     my $params_ub1      = { # undelegated, batch
         domains         => [ $domain, $domain2 ],
@@ -332,51 +338,57 @@ subtest 'check historic tests' => sub {
     # The batch jobs, $params_ub1, $params_ub2 and $params_db1, cannot be run from here due to limitation in the API. See issue #827.
 
     foreach my $param ($params_un1, $params_un2, $params_dn1) {
-        my $testid = $rpcapi->start_domain_test( $param );
-        ok( $testid, "API start_domain_test ID OK" );
+        my $job_res = $rpcapi->job_create( $param );
+        my $testid = $job_res->{job_id};
+        ok( $testid, "API job_create ID OK" );
         diag "running the agent on test $testid";
         $agent->run( $testid );
-        is( $rpcapi->test_progress( { test_id => $testid } ), 100 , 'API test_progress -> Test finished' );
+        my $res_job_status = $rpcapi->job_status( { test_id => $testid } );
+        is( $res_job_status->{progress}, 100 , 'API job_status -> Test finished' );
     };
 
-    my $test_history_delegated = $rpcapi->get_test_history(
+    my $res_domain_history_delegated = $rpcapi->domain_history(
         {
             filter => 'delegated',
             frontend_params => {
                 domain => $domain,
             }
         } );
-    my $test_history_undelegated = $rpcapi->get_test_history(
+    my $res_domain_history_undelegated = $rpcapi->domain_history(
         {
             filter => 'undelegated',
             frontend_params => {
                 domain => $domain,
             }
         } );
+    my $domain_history_delegated = $res_domain_history_delegated->{history};
+    my $domain_history_undelegated = $res_domain_history_undelegated->{history};
 
-    # diag explain( $test_history_delegated );
-    is( scalar( @$test_history_delegated ), 1, 'One delegated test created' );
-    # diag explain( $test_history_undelegated );
-    is( scalar( @$test_history_undelegated ), 2, 'Two undelegated tests created' );
+    # diag explain( $domain_history_delegated );
+    is( scalar( @$domain_history_delegated ), 1, 'One delegated test created' );
+    # diag explain( $domain_history_undelegated );
+    is( scalar( @$domain_history_undelegated ), 2, 'Two undelegated tests created' );
 
     subtest 'domain is case and trailing dot insensitive' => sub {
-        my $test_history_delegated = $rpcapi->get_test_history(
+        my $res_domain_history_delegated = $rpcapi->domain_history(
             {
                 filter => 'delegated',
                 frontend_params => {
                     domain => $domain . '.',
                 }
             } );
-        my $test_history_undelegated = $rpcapi->get_test_history(
+        my $res_domain_history_undelegated = $rpcapi->domain_history(
             {
                 filter => 'undelegated',
                 frontend_params => {
                     domain => ucfirst( $domain ),
                 }
             } );
+        my $domain_history_delegated = $res_domain_history_delegated->{history};
+        my $domain_history_undelegated = $res_domain_history_undelegated->{history};
 
-        is( scalar( @$test_history_delegated ), 1, 'One delegated test created' );
-        is( scalar( @$test_history_undelegated ), 2, 'Two undelegated tests created' );
+        is( scalar( @$domain_history_delegated ), 1, 'One delegated test created' );
+        is( scalar( @$domain_history_undelegated ), 2, 'Two undelegated tests created' );
     };
 };
 
@@ -395,7 +407,8 @@ subtest 'normalize "domain" column' => sub {
     while ( my ($domain, $expected) = each (%domains_to_test) ) {
         $test_params->{domain} = $domain;
 
-        $hash_id = $rpcapi->start_domain_test( $test_params );
+        my $job_res = $rpcapi->job_create( $test_params );
+        $hash_id = $job_res->{job_id};
         my ( $db_domain ) = $dbh->selectrow_array( "SELECT domain FROM test_results WHERE hash_id=?", undef, $hash_id );
         is( $db_domain, $expected, 'stored domain name is normalized' );
     }

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -33,8 +33,8 @@ my $engine = Zonemaster::Backend::RPCAPI->new(
     }
 );
 
-sub start_domain_validate_params {
-    return $engine->validate_params( $Zonemaster::Backend::RPCAPI::json_schemas{start_domain_test}, @_ );
+sub job_create_validate_params {
+    return $engine->validate_params( $Zonemaster::Backend::RPCAPI::json_schemas{job_create}, @_ );
 }
 
 subtest 'Everything but NoWarnings' => sub {
@@ -52,7 +52,7 @@ subtest 'Everything but NoWarnings' => sub {
     ];
 
     subtest 'domain present' => sub {
-        my @res = start_domain_validate_params(
+        my @res = job_create_validate_params(
             {
                 %$frontend_params, domain => 'afnic.fr'
             }
@@ -62,7 +62,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest 'consecutive dots' => sub {
-        my @res = start_domain_validate_params(
+        my @res = job_create_validate_params(
             {
                 %$frontend_params, domain => 'afnic..fr'
             }
@@ -72,7 +72,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest encode_utf8( 'idn domain=[é]' ) => sub {
-        my @res = start_domain_validate_params(
+        my @res = job_create_validate_params(
             {
                 %$frontend_params, domain => 'é'
             }
@@ -83,7 +83,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest encode_utf8( 'idn domain=[éé]' ) => sub {
-        my @res = start_domain_validate_params(
+        my @res = job_create_validate_params(
             {
                 %$frontend_params, domain => 'éé'
             }
@@ -94,7 +94,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest '253 characters long domain without dot' => sub {
-        my @res = start_domain_validate_params(
+        my @res = job_create_validate_params(
             {
                 %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com'
             }
@@ -105,7 +105,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest '254 characters long domain with trailing dot' => sub {
-        my @res = start_domain_validate_params(
+        my @res = job_create_validate_params(
             {
                 %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.'
             }
@@ -116,7 +116,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest '254 characters long domain without trailing dot' => sub {
-        my @res = start_domain_validate_params(
+        my @res = job_create_validate_params(
             {
                 %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club'
             }
@@ -127,7 +127,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest '63 characters long domain label' => sub {
-        my @res = start_domain_validate_params(
+        my @res = job_create_validate_params(
             {
                 %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789-63.fr'
             }
@@ -138,7 +138,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest '64 characters long domain label' => sub {
-        my @res = start_domain_validate_params(
+        my @res = job_create_validate_params(
             {
                 %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789--64.fr'
             }
@@ -154,81 +154,81 @@ subtest 'Everything but NoWarnings' => sub {
 
     # domain present?
     $frontend_params->{nameservers}->[0]->{ns} = 'afnic.fr';
-    is( scalar start_domain_validate_params( $frontend_params ), 0, 'domain present' );
+    is( scalar job_create_validate_params( $frontend_params ), 0, 'domain present' );
 
     # idn
     $frontend_params->{nameservers}->[0]->{ns} = 'é';
-    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'idn domain=[é]' ) )
-        or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'idn domain=[é]' ) )
+        or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     # idn
     $frontend_params->{nameservers}->[0]->{ns} = 'éé';
-    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'idn domain=[éé]' ) )
-        or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'idn domain=[éé]' ) )
+        or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     # 253 characters long domain without dot
     $frontend_params->{nameservers}->[0]->{ns} =
     '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com';
     is(
-        scalar start_domain_validate_params( $frontend_params ), 0,
+        scalar job_create_validate_params( $frontend_params ), 0,
         encode_utf8( '253 characters long domain without dot' )
-    ) or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    ) or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     # 254 characters long domain with trailing dot
     $frontend_params->{nameservers}->[0]->{ns} =
     '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.';
     is(
-        scalar start_domain_validate_params( $frontend_params ), 0,
+        scalar job_create_validate_params( $frontend_params ), 0,
         encode_utf8( '254 characters long domain with trailing dot' )
-    ) or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    ) or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     # 254 characters long domain without trailing
     $frontend_params->{nameservers}->[0]->{ns} =
     '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club';
     cmp_ok(
-        scalar start_domain_validate_params( $frontend_params ), '>', 0,
+        scalar job_create_validate_params( $frontend_params ), '>', 0,
         encode_utf8( '254 characters long domain without trailing dot' )
-    ) or diag( encode_jsonstart_domain_validate_params( $frontend_params ) );
+    ) or diag( encode_jsonjob_create_validate_params( $frontend_params ) );
 
     # 63 characters long domain label
     $frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-63.fr';
     is(
-        scalar start_domain_validate_params( $frontend_params ), 0,
+        scalar job_create_validate_params( $frontend_params ), 0,
         encode_utf8( '63 characters long domain label' )
-    ) or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    ) or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     # 64 characters long domain label
     $frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-64-.fr';
-    cmp_ok( scalar start_domain_validate_params( $frontend_params ), '>', 0,
+    cmp_ok( scalar job_create_validate_params( $frontend_params ), '>', 0,
         encode_utf8( '64 characters long domain label' ) )
-        or diag(encode_json start_domain_validate_params( $frontend_params ) );
+        or diag(encode_json job_create_validate_params( $frontend_params ) );
 
     # DELEGATED TEST
     delete( $frontend_params->{nameservers} );
 
     $frontend_params->{domain} = 'afnic.fr';
-    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'delegated domain exists' ) )
-        or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'delegated domain exists' ) )
+        or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     # IP ADDRESS FORMAT
     $frontend_params->{domain} = 'afnic.fr';
     $frontend_params->{nameservers}->[0]->{ns} = 'ns1.nic.fr';
 
     $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
-    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'Valid IPV4' ) )
-        or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'Valid IPV4' ) )
+        or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4444';
-    cmp_ok( scalar start_domain_validate_params( $frontend_params ), '>', 0, encode_utf8( 'Invalid IPV4' ) )
-        or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    cmp_ok( scalar job_create_validate_params( $frontend_params ), '>', 0, encode_utf8( 'Invalid IPV4' ) )
+        or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     $frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bb';
-    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'Valid IPV6' ) )
-        or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'Valid IPV6' ) )
+        or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     $frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bbffffff';
-    cmp_ok( start_domain_validate_params( $frontend_params ), '>', 0, encode_utf8( 'Invalid IPV6' ) )
-        or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    cmp_ok( job_create_validate_params( $frontend_params ), '>', 0, encode_utf8( 'Invalid IPV6' ) )
+        or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     # DS
     $frontend_params->{domain}                 = 'afnic.fr';
@@ -240,50 +240,50 @@ subtest 'Everything but NoWarnings' => sub {
     $frontend_params->{ds_info}->[0]->{digtype}   = 1;
     $frontend_params->{ds_info}->[0]->{keytag}   = 5000;
 
-    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'Valid Algorithm Type [numeric format]' ) )
-        or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'Valid Algorithm Type [numeric format]' ) )
+        or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{algorithm} = 'a';
     $frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
-    is( scalar start_domain_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid Algorithm Type' ) )
-        or diag(  encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid Algorithm Type' ) )
+        or diag(  encode_json job_create_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{algorithm} = 1;
     $frontend_params->{ds_info}->[0]->{digest}    = '01234567890123456789012345678901234567890';
-    is( scalar start_domain_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest length' ) )
-        or diag( encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest length' ) )
+        or diag( encode_json job_create_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{digest}    = 'Z123456789012345678901234567890123456789';
-    is( scalar start_domain_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest format' ) )
-        or diag(  encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest format' ) )
+        or diag(  encode_json job_create_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
     $frontend_params->{ds_info}->[0]->{digtype} = -1;
-    is( scalar start_domain_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest type' ) )
-        or diag(  encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest type' ) )
+        or diag(  encode_json job_create_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{digtype} = 1;
     $frontend_params->{ds_info}->[0]->{keytag} = 'not a int';
-    is( scalar start_domain_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid keytag' ) )
-        or diag(  encode_json start_domain_validate_params( $frontend_params ) );
+    is( scalar job_create_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid keytag' ) )
+        or diag(  encode_json job_create_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{keytag} = 5000;
 
     {
         local $frontend_params->{language} = "zz";
-        my @res = start_domain_validate_params( $frontend_params );
+        my @res = job_create_validate_params( $frontend_params );
         is( scalar @res, 1, 'Invalid language, "zz" unknown' ) or diag(  explain \@res );
     }
 
     {
         local $frontend_params->{language} = "fr-FR";
-        my @res = start_domain_validate_params( $frontend_params );
+        my @res = job_create_validate_params( $frontend_params );
         is( scalar @res, 1, 'Invalid language, should be underscore not hyphen' ) or diag(  explain \@res );
     }
 
     {
         local $frontend_params->{language} = "nb_NO";
-        my @res = start_domain_validate_params( $frontend_params );
+        my @res = job_create_validate_params( $frontend_params );
         is( scalar @res, 0, 'Valid language' ) or diag( explain \@res );
     }
 };


### PR DESCRIPTION
## Purpose

Second stage in the update of the RPCAPI methods. This PR updates the code and tests to use the new methods from #1054.

## Context

Follow up #1054 

## Changes

* Scripts
* Unit tests
* Deprecate RPCAPI.enable_add_api_user and RPCAPI.enable_add_batch_job properties in the INI file. Emit warning if used.
* Add unit tests
* Documentation

## How to test this PR

Unit tests should pass.