### PR TITLE
Unit test for PO files

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -91,6 +91,7 @@ t/idn.data
 t/idn.t
 t/lifecycle.t
 t/parameters_validation.t
+t/po-files.t
 t/test01.data
 t/test01.t
 t/test_profile.json

--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -33,6 +33,9 @@ new-po: extract-pot
 		-e 's/^("Content-Type:.+charset=)CHARSET/$${1}UTF-8/;' $(POLANG).po
 	@perl -ni -e 'print unless /^#( |$$)/' $(POLANG).po
 
+# Check the msgid/msgstr pair for some inconsistencies between them in the
+# selected PO file and report on standard error any errors found. The PO file
+# is not updated.
 check-po:
 	@for f in $(POFILES) ; do msgfmt -c $$f ; done
 

--- a/share/GNUmakefile
+++ b/share/GNUmakefile
@@ -1,6 +1,6 @@
 .POSIX:
 .SUFFIXES: .po .mo
-.PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy update-po new-po
+.PHONY: all check-msg-args dist extract-pot tidy-po show-fuzzy update-po new-po check-po
 
 POFILES := $(shell find . -maxdepth 1 -type f -name '*.po' -exec basename {} \;)
 MOFILES := $(POFILES:%.po=%.mo)
@@ -32,6 +32,9 @@ new-po: extract-pot
 		-e 's/^"Language: /$$&$(POLANG)/;' \
 		-e 's/^("Content-Type:.+charset=)CHARSET/$${1}UTF-8/;' $(POLANG).po
 	@perl -ni -e 'print unless /^#( |$$)/' $(POLANG).po
+
+check-po:
+	@for f in $(POFILES) ; do msgfmt -c $$f ; done
 
 extract-pot:
 	@xgettext --output $(POTFILE) --sort-by-file --add-comments --language=Perl --from-code=UTF-8 -k__ -k\$$__ -k%__ -k__x -k__n:1,2 -k__nx:1,2 -k__xn:1,2 -kN__ -kN__n:1,2 -k__p:1c,2 -k__np:1c,2,3 -kN__p:1c,2 -kN__np:1c,2,3 $(PMFILES)

--- a/t/po-files.t
+++ b/t/po-files.t
@@ -1,0 +1,62 @@
+#!perl
+use v5.14.2;
+use strict;
+use warnings;
+use utf8;
+use Test::More; # see done_testing()
+
+use File::Basename qw( dirname );
+
+chdir dirname( dirname( __FILE__ ) ) or BAIL_OUT( "chdir: $!" );
+chdir 'share' or BAIL_OUT( "chdir: $!" );
+
+my $makebin = 'make';
+
+sub make {
+    my @make_args = @_;
+
+    undef $ENV{MAKEFLAGS};
+
+    my $command = join( ' ', $makebin, '--silent', '--no-print-directory', @make_args );
+    my $output = `$command`;
+
+    if ( $? == -1 ) {
+        BAIL_OUT( "failed to execute: $!" );
+    }
+    elsif ( $? & 127 ) {
+        BAIL_OUT( "child died with signal %d, %s coredump\n", ( $? & 127 ), ( $? & 128 ) ? 'with' : 'without' );
+    }
+
+    return $output, $? >> 8;
+}
+
+subtest "no fuzzy marks" => sub {
+    my ( $output, $status ) = make "show-fuzzy";
+    is $status, 0,  $makebin . ' show-fuzzy exits with value 0';
+    is $output, "", $makebin . ' show-fuzzy gives empty output';
+};
+
+subtest "check po files" => sub {
+    my ( $output, $status ) = make "check-po";
+    is $status, 0,  $makebin . ' check-po exits with value 0';
+    is $output, "", $makebin . ' check-po gives empty output';
+};
+
+subtest "tidy po files" => sub {
+    SKIP: {
+        my ( $output, $status );
+
+        $output = `git diff --numstat`;
+
+        skip 'git repo should be clean to run this test', 3 if $output ne '';
+
+        ( $output, $status ) = make "tidy-po";
+        is $status, 0,  $makebin . ' tidy-po exits with value 0';
+        is $output, "", $makebin . ' tidy-po gives empty output';
+
+        $output = `git diff --numstat`;
+        is $output, "", 'all files are tidied (if not run "make tidy-po")';
+    }
+};
+
+done_testing();


### PR DESCRIPTION
## Purpose

New unit test to verify that PO files are correct regarding some rules:
* no fuzzy marks
* all PO files are tidied
* PO files msgid/msgstr format should be consistent 

## Context

Same checks as in Zonemaster-Engine and Zonemaster-CLI (https://github.com/zonemaster/zonemaster-cli/pull/314)

## Changes

new t/po-files.t

## How to test this PR

Unit test should pass.