### PR TITLE
Removes meaningless PO file tests from distribution package (Backend)

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -91,7 +91,6 @@ t/idn.data
 t/idn.t
 t/lifecycle.t
 t/parameters_validation.t
-t/po-files.t
 t/test01.data
 t/test01.t
 t/test_profile.json

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -12,6 +12,8 @@
 ^share/[^/]*\.mo$
 ^share/Zonemaster-Backend.pot$
 ^share/update-po$
+# PO files are not present in the distribution package, tests of those are irrelevant there.
+^t/po-files.t
 
 #!start included /usr/share/perl/5.20/ExtUtils/MANIFEST.SKIP
 # Avoid version control files.

--- a/t/po-files.t
+++ b/t/po-files.t
@@ -1,4 +1,8 @@
 #!perl
+
+# This file is not included in the distribution package and not run
+# at installation with cpanm().
+
 use v5.14.2;
 use strict;
 use warnings;


### PR DESCRIPTION
## Purpose

Unit tests for PO files are only relevant for CI tests, not for tests at installation. This PR removes the PO file tests from the distribution package.

## Context

Compare with https://github.com/zonemaster/zonemaster-cli/pull/320

## Changes

Makes t/po-files.t not being included in the distribution package. Add comment to t/po-files.t

## How to test this PR

Make sure that Travis passes and installation works.
