### PR TITLE
Fix wrong schema for deprecated method

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -357,7 +357,7 @@ sub job_status {
 }
 
 # Deprecated
-$json_schemas{test_progress} = $json_schemas{job_create};
+$json_schemas{test_progress} = $json_schemas{job_status};
 sub test_progress {
     my $result = job_status( @_ );
     return $result->{progress};


### PR DESCRIPTION
## Purpose

Fix wrong schema for method `test_progress`.

## Context

\-

## Changes

Use `job_status` schema instead of `job_create` schema, as it should be.

## How to test this PR

Querying for a test progress (even a non existent test) should not return a `Invalid method parameter(s).` error.
```
$ curl 'http://localhost:5000' --data '{"jsonrpc":"2.0","id":0,"method":"test_progress","params":{"test_id":"0000000000000000"}}
{"jsonrpc":"2.0","id":0,"result":null}
```
