### PR TITLE
Remove deprecated features related to locale

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -225,44 +225,35 @@ This parameter is a string that is either
 
 Basic data type: string
 
-A string matching one of the following regular expression:
-* `/^[a-z]{2}$/`, preferred format.
-* `/^[a-z]{2}_[A-Z]{2}$/`, **deprecated** format, use the preferred format instead
-  (planned removal: v2023.1).
+A string matching `/^[a-z]{2}$/`.
 
 The set of valid *language tags* is further constrained by the
 [`LANGUAGE.locale`][LANGUAGE.locale] property.
-* If the *language tag* is a five character string, it needs to match a *locale
-  tag* in [`LANGUAGE.locale`][LANGUAGE.locale].
-* If the *language tag* is a two-character string, it needs to match the
-  first two characters of exactly one *locale tag* in [`LANGUAGE.locale`][LANGUAGE.locale].
-  (So that it is unambiguous which *locale tag* is matched.)
+A *language tag* needs to match the first two characters of exactly one *locale
+tag* in [`LANGUAGE.locale`][LANGUAGE.locale].
+(So that it is unambiguous which *locale tag* is matched.)
 
-E.g. if [`LANGUAGE.locale`][LANGUAGE.locale] is "en_US en_UK sv_SE", all the valid *language tags*
-are "en_US", "en_UK", "sv_SE" and "sv".
-
-The use of `language tags` that include the country code is *deprecated* (planned
-removal: v2023.1).
+E.g. if [`LANGUAGE.locale`][LANGUAGE.locale] is "en_US en_UK sv_SE", the only
+valid *language tag* is "sv".
 
 #### Design
 
-The two first characters of the *language tag* are intended to be an
-[ISO 639-1] two-character language code and the optional two last characters
-are intended to be an [ISO 3166-1 alpha-2] two-character country code.
+The *language tag* values are intended to be [ISO 639-1] two-characters language
+codes.
 
 #### Out-of-the box support
 
 A default installation will accept the following *language tags*:
 
-Language | Preferred language tag | Deprecated language tag
----------|------------------------|------------------
-Danish   | da                     | da_DK
-English  | en                     | en_US
-Spanish  | es                     | es_ES
-Finnish  | fi                     | fi_FI
-French   | fr                     | fr_FR
-Norwegian| nb                     | nb_NO
-Swedish  | sv                     | sv_SE
+Language | Language tag
+---------|-------------
+Danish   | da
+English  | en
+Spanish  | es
+Finnish  | fi
+French   | fr
+Norwegian| nb
+Swedish  | sv
 
 
 ### Name server
@@ -527,11 +518,7 @@ An oject with the following property:
 Returns the set of valid [*language tags*][Language tag].
 
 > Note: If there are two [*locale tags*][LANGUAGE.locale] in [LANGUAGE.locale]
-> that would give the same [short language tag][Language tag] then the short tag
-> is excluded from the set of valid [*language tags*][Language tag].
->
-> Note: Language tags that include country code are *deprecated* (planned
-> removal: v2023.1).
+> that would give the same *[language tag]* then is excluded.
 
 Example request:
 ```json
@@ -550,19 +537,12 @@ Example response:
   "result": {
     "languages": [
       "da",
-      "da_DK",
       "en",
-      "en_US",
       "es",
-      "es_ES",
       "fi",
-      "fi_FI",
       "fr",
-      "fr_FR",
       "nb",
-      "nb_NO",
-      "sv",
-      "sv_SE"
+      "sv"
     ]
   }
 }

--- a/docs/API.md
+++ b/docs/API.md
@@ -234,7 +234,7 @@ A *language tag* needs to match the language code of a *locale tag* in
 
 #### Design
 
-The *language tag* values are intended to be [ISO 639-1] two-characters language
+The *language tag* values are intended to be [ISO 639-1] two-character language
 codes.
 
 #### Out-of-the box support
@@ -512,9 +512,6 @@ An oject with the following property:
 ### API method: `conf_languages`
 
 Returns the set of valid [*language tags*][Language tag].
-
-> Note: If there are two [*locale tags*][LANGUAGE.locale] in [LANGUAGE.locale]
-> that would give the same *[language tag]* then is excluded.
 
 Example request:
 ```json

--- a/docs/API.md
+++ b/docs/API.md
@@ -229,12 +229,8 @@ A string matching `/^[a-z]{2}$/`.
 
 The set of valid *language tags* is further constrained by the
 [`LANGUAGE.locale`][LANGUAGE.locale] property.
-A *language tag* needs to match the first two characters of exactly one *locale
-tag* in [`LANGUAGE.locale`][LANGUAGE.locale].
-(So that it is unambiguous which *locale tag* is matched.)
-
-E.g. if [`LANGUAGE.locale`][LANGUAGE.locale] is "en_US en_UK sv_SE", the only
-valid *language tag* is "sv".
+A *language tag* needs to match the language code of a *locale tag* in
+[`LANGUAGE.locale`][LANGUAGE.locale].
 
 #### Design
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -223,7 +223,7 @@ The LANGUAGE section has one key, `locale`.
 ### locale
 
 A string representing a space-separated list of one or more `locale tags`.
-Each tag`consists of a two-lowercase-letter language code, an underscore
+Each tag consists of a two-lowercase-letter language code, an underscore
 character, and a two-uppercase-letter country code (i.e. it matches the regular
 expression `/^[a-z]{2}_[A-Z]{2}$/`).
 Each `locale tag` must have a unique language code.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -222,13 +222,11 @@ The LANGUAGE section has one key, `locale`.
 
 ### locale
 
-A string matching the following descriptions:
-* A space separated list of one or more `locale tags` where each tag matches the
-  regular expression `/^[a-z]{2}_[A-Z]{2}$/`.
-
+A string representing a space-separated list of one or more `locale tags`.
+Each tag matches the regular expression `/^[a-z]{2}_[A-Z]{2}$/`.
 It is an error to repeat the same `locale tag`.
 
-If the `locale` key is absent, the `locale tag` value "en_US" is set by default.
+Default value: `en_US`.
 
 The use of two or more `locale tags` with the same language code is
 **deprecated** and is planned to be illegal from version v2023.1.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -240,9 +240,7 @@ of messages without ".UTF-8", which is implied.
 #### Usage
 
 Removing a language from the configuration file just blocks that
-language from being allowed. If there are more than one `locale tag`
-(with different country codes) for the same language, then
-all those must be removed to block that language.
+language from being allowed.
 
 English is the Zonemaster default language, but it can be blocked
 from being allowed by RPC-API by including some `locale tag` in the

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -223,19 +223,17 @@ The LANGUAGE section has one key, `locale`.
 ### locale
 
 A string representing a space-separated list of one or more `locale tags`.
-Each tag matches the regular expression `/^[a-z]{2}_[A-Z]{2}$/`.
-It is an error to repeat the same `locale tag`.
+Each tag`consists of a two-lowercase-letter language code, an underscore
+character, and a two-uppercase-letter country code (i.e. it matches the regular
+expression `/^[a-z]{2}_[A-Z]{2}$/`).
+Each `locale tag` must have a unique language code.
 
 Default value: `en_US`.
 
-The use of two or more `locale tags` with the same language code is
-**deprecated** and is planned to be illegal from version v2023.1.
-
 #### Design
 
-The two first characters of a `locale tag` are intended to be an
-[ISO 639-1] two-character language code and the two last characters
-are intended to be an [ISO 3166-1 alpha-2] two-character country code.
+The language code of a `locale tag` is intended to be an [ISO 639-1] code.
+The country code is intended to be an [ISO 3166-1 alpha-2] code.
 A `locale tag` is a locale setting for the available translation
 of messages without ".UTF-8", which is implied.
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -530,21 +530,14 @@ Returns a string.
 
 Get the value of L<LANGUAGE.locale|https://github.com/zonemaster/zonemaster-backend/blob/master/docs/Configuration.md#locale>.
 
-Returns a mapping from two-letter locale tag prefixes to sets of full locale
-tags.
-This is represented by a hash of hashrefs where all second level values are
-C<1>.
+Returns a mapping from two-letter locale tag prefixes to full locale tags.
+This is represented by a hash mapping prefix to full locale tag.
 
 E.g.:
 
     (
-        en => {
-            en_GB => 1,
-            en_US => 1,
-        },
-        sv => {
-            sv_SE => 1,
-        },
+        en => "en_US",
+        sv => "sv_SE",
     )
 
 
@@ -845,11 +838,11 @@ sub _set_locales {
 
         my $lang_code = $locale_tag =~ s/_..$//r;
 
-        if ( exists $locales{$lang_code}{$locale_tag} ) {
-            die "Repeated locale tags in LANGUAGE.locale: $locale_tag\n";
+        if ( exists $locales{$lang_code} ) {
+            die "Repeated language code in LANGUAGE.locale: $lang_code\n";
         }
 
-        $locales{$lang_code}{$locale_tag} = 1;
+        $locales{$lang_code} = $locale_tag;
     }
 
     $self->{_LANGUAGE_locale} = \%locales;

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -157,13 +157,7 @@ sub conf_languages {
     eval {
         my %locales = $self->{config}->LANGUAGE_locale;
 
-        for my $lang ( sort keys %locales ) {
-            my @locale_tags = sort keys %{ $locales{$lang} };
-            if ( scalar @locale_tags == 1 ) {
-                push @lang_tags, $lang;
-            }
-            push @lang_tags, @locale_tags;
-        }
+        @lang_tags = sort keys %locales;
     };
     if ( $@ ) {
         handle_exception( $@ );
@@ -685,20 +679,18 @@ sub _get_locale {
     my @error;
 
     my $language = $params->{language};
-    my $locale;
-
     if ( !defined $language ) {
         return undef;
     }
 
     my %locales = $self->{config}->LANGUAGE_locale;
-    ( $locale ) = keys %{ $locales{$language} };
 
-    if (defined $locale) {
-        $locale .= '.UTF-8';
+    my $locale = $locales{$language};
+    if ( !defined $locale ) {
+        return undef;
     }
 
-    return $locale;
+    return $locale . '.UTF-8';
 }
 
 sub _set_error_message_locale {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -691,13 +691,8 @@ sub _get_locale {
         return undef;
     }
 
-    if ( length $language == 2 ) {
-        my %locales = $self->{config}->LANGUAGE_locale;
-        ( $locale ) = keys %{ $locales{$language} };
-    }
-    else {
-        $locale = $language;
-    }
+    my %locales = $self->{config}->LANGUAGE_locale;
+    ( $locale ) = keys %{ $locales{$language} };
 
     if (defined $locale) {
         $locale .= '.UTF-8';

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -320,7 +320,7 @@ Validates a L<https://github.com/zonemaster/zonemaster-backend/blob/master/docs/
 
 =item %locales
 
-Hash of accepted locales, using the same structure than the hash returned by L<PUBLIC_PROFILES|Zonemaster::Bakend::Config/PUBLIC_PROFILES>.
+A hash of configured locales, as returned by L<Zonemaster::Backend::Config::LANGUAGE_locale>.
 
 =back
 
@@ -336,9 +336,6 @@ sub check_language_tag {
     }
     elsif ( !exists $locales{$language} ) {
         return N__ "Unkown language string";
-    }
-    elsif ( scalar keys %{ $locales{$language} } > 1 ) {
-        return N__ "Language string not unique";
     }
 
     return undef;
@@ -367,7 +364,7 @@ Validates a L<profile name|https://github.com/zonemaster/zonemaster-backend/blob
 
 =item %profiles
 
-Hash of accepted profiles, using the same structure than the hash returned by L<LANGUAGE_locale|Zonemaster::Bakend::Config/LANGUAGE_locale>.
+A hash of configured profiles, as returned by L<Zonemaster::Backend::Config::PUBLIC_PROFILES>.
 
 =back
 

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -84,7 +84,7 @@ Readonly my $DIGEST_RE                  => qr/^[a-f0-9]{40}$|^[a-f0-9]{64}$|^[a-
 Readonly my $ENGINE_TYPE_RE             => qr/^(?:mysql|postgresql|sqlite)$/i;
 Readonly my $IPADDR_RE                  => qr/^$|$IPV4_RE|$IPV6_RE/;
 Readonly my $JSONRPC_METHOD_RE          => qr/^[a-z0-9_-]*$/i;
-Readonly my $LANGUAGE_RE                => qr/^[a-z]{2}(_[A-Z]{2})?$/;
+Readonly my $LANGUAGE_RE                => qr/^[a-z]{2}$/;
 Readonly my $LDH_DOMAIN_RE1             => qr{^[a-z0-9_./-]{1,253}[.]?$}i;
 Readonly my $LDH_DOMAIN_RE2             => qr{^(?:[.]|[^.]{1,63}(?:[.][^.]{1,63})*[.]?)$};
 Readonly my $LOCALE_TAG_RE              => qr/^[a-z]{2}_[A-Z]{2}$/;
@@ -334,20 +334,13 @@ sub check_language_tag {
     if ( $language !~ $LANGUAGE_RE ) {
         return N__ 'Invalid language tag format';
     }
+    elsif ( !exists $locales{$language} ) {
+        return N__ "Unkown language string";
+    }
+    elsif ( scalar keys %{ $locales{$language} } > 1 ) {
+        return N__ "Language string not unique";
+    }
 
-    if ( length $language == 2 ) {
-        if ( !exists $locales{$language} ) {
-            return N__ "Unkown language string";
-        }
-        elsif ( scalar keys %{ $locales{$language} } > 1 ) {
-            return N__ "Language string not unique";
-        }
-    }
-    else {
-        if ( !exists $locales{substr $language, 0, 2}{$language} ) {
-            return N__ "Unkown language string";
-        }
-    }
     return undef;
 }
 

--- a/t/config.t
+++ b/t/config.t
@@ -184,7 +184,7 @@ subtest 'Everything but NoWarnings' => sub {
             [LANGUAGE]
             locale =
         };
-        my $config = Zonemaster::Backend::Config->parse( $text );
+        Zonemaster::Backend::Config->parse( $text );
     }
     qr/Use of empty LANGUAGE.locale property is not permitted/, 'die: Invalid empty locale tag';
 

--- a/t/config.t
+++ b/t/config.t
@@ -73,7 +73,7 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->POSTGRESQL_password,  'postgresql_password',       'set: POSTGRESQL.password';
         is $config->POSTGRESQL_database,  'postgresql_database',       'set: POSTGRESQL.database';
         is $config->SQLITE_database_file, '/var/db/zonemaster.sqlite', 'set: SQLITE.database_file';
-        eq_or_diff { $config->LANGUAGE_locale }, { sv => { sv_FI => 1 } }, 'set: LANGUAGE.locale';
+        eq_or_diff { $config->LANGUAGE_locale }, { sv => 'sv_FI' }, 'set: LANGUAGE.locale';
         eq_or_diff { $config->PUBLIC_PROFILES }, {    #
             default => '/path/to/default.profile',
             two     => '/path/to/two.profile'
@@ -103,7 +103,7 @@ subtest 'Everything but NoWarnings' => sub {
         cmp_ok abs( $config->DB_polling_interval - 0.5 ), '<', 0.000001, 'default: DB.polling_interval';
         is $config->MYSQL_port,      3306, 'default: MYSQL.port';
         is $config->POSTGRESQL_port, 5432, 'default: POSTGRESQL.port';
-        eq_or_diff { $config->LANGUAGE_locale }, { en => { en_US => 1 } }, 'default: LANGUAGE.locale';
+        eq_or_diff { $config->LANGUAGE_locale }, { en => 'en_US' }, 'default: LANGUAGE.locale';
         eq_or_diff { $config->PUBLIC_PROFILES }, { default => undef }, 'default: PUBLIC_PROFILES';
         eq_or_diff { $config->PRIVATE_PROFILES }, {}, 'default: PRIVATE_PROFILES';
         is $config->ZONEMASTER_max_zonemaster_execution_time,            600, 'default: ZONEMASTER.max_zonemaster_execution_time';
@@ -684,11 +684,11 @@ subtest 'Everything but NoWarnings' => sub {
             database_file = /var/db/zonemaster.sqlite
 
             [LANGUAGE]
-            locale = en_US en_US
+            locale = en_GB en_US
         };
         Zonemaster::Backend::Config->parse( $text );
     }
-    qr/LANGUAGE\.locale.*en_US/, 'die: Repeated locale_tag in LANGUAGE.locale';
+    qr/LANGUAGE\.locale.*en/, 'die: Repeated language code in LANGUAGE.locale';
 
     lives_and {
         my $text = q{

--- a/t/test01.t
+++ b/t/test01.t
@@ -119,7 +119,7 @@ subtest 'API calls' => sub {
 
     subtest 'job_results' => sub {
         local $@ = undef;
-        my $res = eval { $rpcapi->job_results( { id => $hash_id, language => 'en_US' } ) };
+        my $res = eval { $rpcapi->job_results( { id => $hash_id, language => 'en' } ) };
         if ( $@ ) {
             fail 'Crashed while fetching job results: ' . Dumper( $@ );
         }
@@ -221,7 +221,7 @@ subtest 'second test has IPv6 disabled' => sub {
     is( $res->{ipv4}, $params->{ipv4}, 'Retrieve the correct "ipv4" value' );
     is( $res->{ipv6}, $params->{ipv6}, 'Retrieve the correct "ipv6" value' );
 
-    $res = $rpcapi->job_results( { id => $hash_id, language => 'en_US' } );
+    $res = $rpcapi->job_results( { id => $hash_id, language => 'en' } );
     my @msgs = map { $_->{message} } @{ $res->{results} };
     ok( grep( /IPv6 is disabled/, @msgs ), 'Results contain an "IPv6 is disabled" message' );
 };

--- a/t/test01.t
+++ b/t/test01.t
@@ -118,7 +118,11 @@ subtest 'get and run test' => sub {
 subtest 'API calls' => sub {
 
     subtest 'job_results' => sub {
-        my $res = $rpcapi->job_results( { id => $hash_id, language => 'en_US' } );
+        local $@ = undef;
+        my $res = eval { $rpcapi->job_results( { id => $hash_id, language => 'en_US' } ) };
+        if ( $@ ) {
+            fail 'Crashed while fetching job results: ' . Dumper( $@ );
+        }
         ok( ! defined $res->{id}, 'Do not expose primary key' );
         is( $res->{hash_id}, $hash_id, 'Retrieve the correct "hash_id"' );
         ok( defined $res->{params}, 'Value "params" properly defined' );

--- a/t/test01.t
+++ b/t/test01.t
@@ -218,8 +218,8 @@ subtest 'second test has IPv6 disabled' => sub {
     is( $res->{ipv6}, $params->{ipv6}, 'Retrieve the correct "ipv6" value' );
 
     $res = $rpcapi->job_results( { id => $hash_id, language => 'en_US' } );
-    my @msg_basic = map { $_->{message} if $_->{module} eq 'BASIC' } @{ $res->{results} };
-    ok( grep( /IPv6 is disabled/, @msg_basic ), 'Results contain an "IPv6 is disabled" message' );
+    my @msgs = map { $_->{message} } @{ $res->{results} };
+    ok( grep( /IPv6 is disabled/, @msgs ), 'Results contain an "IPv6 is disabled" message' );
 };
 
 my $domain_history;

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -278,12 +278,12 @@ subtest 'Everything but NoWarnings' => sub {
     {
         local $frontend_params->{language} = "fr-FR";
         my @res = job_create_validate_params( $frontend_params );
-        is( scalar @res, 1, 'Invalid language, should be underscore not hyphen' ) or diag(  explain \@res );
+        is( scalar @res, 1, 'Invalid language tag syntax' ) or diag(  explain \@res );
     }
 
     {
         local $frontend_params->{language} = "nb_NO";
         my @res = job_create_validate_params( $frontend_params );
-        is( scalar @res, 0, 'Valid language' ) or diag( explain \@res );
+        is( scalar @res, 1, 'Invalid language tag syntax' ) or diag(  explain \@res );
     }
 };


### PR DESCRIPTION
## Purpose

This PR cleans up deprecations related to LANGUAGE.locale.

## Context

It fixes #1061. It integrates a commit from #1060 which cleans up one of the deprecations.

## Changes

* Feedback is improved when a unit test fails.
* Specifying languages with country code in the RPC-API is no longer supported.
* Specifying multiple locale tags with the same language code in LANGUAGE.locale is no longer supported.
* Specifying LANGUAGE.locale with an empty value is no longer supported.
* The `_clear_LANGUAGE_locale` and `_add_LANGUAGE_locale` methods are replaced with a `_set_locales` method.

## How to test this PR

* Try starting `zm-rpcapi` with LANGUAGE.locale set to an empty value.
* Try starting `zm-rpcapi` with LANGUAGE.locale including multiple locale tags with the same language code.
* Try calling RPC-API methods with a `language` argument with an exact locale tag present in LANGUAGE.locale.