### PR TITLE
Add systemd support

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -66,10 +66,11 @@ share/travis_mysql_backend_config.ini
 share/travis_postgresql_backend_config.ini
 share/travis_sqlite_backend_config.ini
 share/zm-rpcapi.lsb
+share/zm-rpcapi.service
 share/zm-testagent.lsb
+share/zm-testagent.service
 share/zm_rpcapi-bsd
 share/zm_testagent-bsd
-t/TestUtil.pm
 t/00-load.t
 t/batches.t
 t/config.t
@@ -82,4 +83,5 @@ t/test01.data
 t/test01.t
 t/test_profile.json
 t/test_validate_syntax.t
+t/TestUtil.pm
 t/validator.t

--- a/share/zm-rpcapi.service
+++ b/share/zm-rpcapi.service
@@ -1,10 +1,12 @@
 [Unit]
 Description=RPC server for Zonemaster Backend
 After=network.target mariadb.service postgresql.service
+Wants=mariadb.service postgresql.service
 
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/starman --listen=127.0.0.1:5000 --preload-app --user=zonemaster --group=zonemaster --pid=/run/zonemaster/zm-rpcapi.pid --error-log=/var/log/zonemaster/zm-rpcapi.log --daemonize /usr/local/bin/zonemaster_backend_rpcapi.psgi
+KillSignal=SIGQUIT
 PIDFile=/run/zonemaster/zm-rpcapi.pid
 
 [Install]

--- a/share/zm-rpcapi.service
+++ b/share/zm-rpcapi.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=RPC server for Zonemaster Backend
+After=network.target mariadb.service postgresql.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/starman --listen=127.0.0.1:5000 --preload-app --user=zonemaster --group=zonemaster --pid=/run/zonemaster/zm-rpcapi.pid --error-log=/var/log/zonemaster/zm-rpcapi.log --daemonize /usr/local/bin/zonemaster_backend_rpcapi.psgi
+PIDFile=/run/zonemaster/zm-rpcapi.pid
+
+[Install]
+WantedBy=multi-user.target

--- a/share/zm-testagent.service
+++ b/share/zm-testagent.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=test agent for Zonemaster Backend
 After=network.target mariadb.service postgresql.service
+Wants=mariadb.service postgresql.service
 
 [Service]
 Type=simple

--- a/share/zm-testagent.service
+++ b/share/zm-testagent.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=test agent for Zonemaster Backend
+After=network.target mariadb.service postgresql.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/zonemaster_backend_testagent --logfile=/var/log/zonemaster/zm-testagent.log --outfile=/var/log/zonemaster/zm-testagent.out --pidfile=/run/zonemaster/zm-testagent.pid --user=zonemaster --group=zonemaster start
+ExecStop=/usr/local/bin/zonemaster_backend_testagent --logfile=/var/log/zonemaster/zm-testagent.log --outfile=/var/log/zonemaster/zm-testagent.out --pidfile=/run/zonemaster/zm-testagent.pid --user=zonemaster --group=zonemaster stop
+PIDFile=/run/zonemaster/zm-testagent.pid
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Purpose

This PR adds Systemd support.

## Context

* Rocky Linux 9 has dropped support for LSB.
* The unit files are compatible with Rocky Linux 8 and 9. They can be adapted for other operating systems later on as needed.
* While the old LSB init files are quite configurable with environment variables, the new Systemd unit files have everything hard coded. They can be updated for configurability later on as needed.

## Changes

New Systemd unit files for zm-rpcapi and zm-testagent are added.

## How to test this PR

Follow the installation instruction for Zonemaster Backend in release 2023.1 on both Rocky Linux 8 and 9.