### PR TITLE
Reinstate old RPC API methods

### DIFF
--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -615,7 +615,6 @@ Return 0 or 1
 
 =head2 RPCAPI_enable_add_api_user
 
-Deprecated (planned removal: v2024.1).
 Get the value of
 L<RPCAPI.enable_add_api_user|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#enable_add_api_user>.
 
@@ -624,7 +623,6 @@ Return 0 or 1
 
 =head2 RPCAPI_enable_add_batch_job
 
-Deprecated (planned removal: v2024.1).
 Get the value of
 L<RPCAPI.enable_add_batch_job|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#enable_add_batch_job>.
 

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -215,8 +215,8 @@ sub parse {
     $obj->_set_ZONEMASTER_number_of_processes_for_batch_testing( '20' );
     $obj->_set_ZONEMASTER_lock_on_queue( '0' );
     $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
-    $obj->_set_RPCAPI_enable_user_create( 'no' );
-    $obj->_set_RPCAPI_enable_batch_create( 'yes' );
+    $obj->_set_RPCAPI_enable_user_create( 'no' ); # experimental
+    $obj->_set_RPCAPI_enable_batch_create( 'yes' ); # experimental
     $obj->_set_RPCAPI_enable_add_api_user( 'no' );
     $obj->_set_RPCAPI_enable_add_batch_job( 'yes' );
     $obj->_set_locales( 'en_US' );
@@ -599,6 +599,7 @@ Returns a number.
 
 =head2 RPCAPI_enable_user_create
 
+Experimental.
 Get the value of
 L<RPCAPI.enable_user_create|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#enable_user_create>.
 
@@ -607,6 +608,7 @@ Return 0 or 1
 
 =head2 RPCAPI_enable_batch_create
 
+Experimental.
 Get the value of
 L<RPCAPI.enable_batch_create|https://github.com/zonemaster/zonemaster/blob/master/docs/public/configuration/backend.md#enable_batch_create>.
 
@@ -653,8 +655,8 @@ sub ZONEMASTER_number_of_processes_for_batch_testing    { return $_[0]->{_ZONEMA
 sub ZONEMASTER_age_reuse_previous_test                  { return $_[0]->{_ZONEMASTER_age_reuse_previous_test}; }
 sub METRICS_statsd_host                                 { return $_[0]->{_METRICS_statsd_host}; }
 sub METRICS_statsd_port                                 { return $_[0]->{_METRICS_statsd_port}; }
-sub RPCAPI_enable_user_create                           { return $_[0]->{_RPCAPI_enable_user_create}; }
-sub RPCAPI_enable_batch_create                          { return $_[0]->{_RPCAPI_enable_batch_create}; }
+sub RPCAPI_enable_user_create                           { return $_[0]->{_RPCAPI_enable_user_create}; } # experimental
+sub RPCAPI_enable_batch_create                          { return $_[0]->{_RPCAPI_enable_batch_create}; } # experimental
 sub RPCAPI_enable_add_api_user                          { return $_[0]->{_RPCAPI_enable_add_api_user}; }
 sub RPCAPI_enable_add_batch_job                         { return $_[0]->{_RPCAPI_enable_add_batch_job}; }
 
@@ -679,8 +681,8 @@ UNITCHECK {
     _create_setter( '_set_ZONEMASTER_age_reuse_previous_test',                  '_ZONEMASTER_age_reuse_previous_test',                  \&untaint_strictly_positive_int );
     _create_setter( '_set_METRICS_statsd_host',                                 '_METRICS_statsd_host',                                 \&untaint_host );
     _create_setter( '_set_METRICS_statsd_port',                                 '_METRICS_statsd_port',                                 \&untaint_strictly_positive_int );
-    _create_setter( '_set_RPCAPI_enable_user_create',                           '_RPCAPI_enable_user_create',                           \&untaint_bool );
-    _create_setter( '_set_RPCAPI_enable_batch_create',                          '_RPCAPI_enable_batch_create',                          \&untaint_bool );
+    _create_setter( '_set_RPCAPI_enable_user_create',                           '_RPCAPI_enable_user_create',                           \&untaint_bool ); # experimental
+    _create_setter( '_set_RPCAPI_enable_batch_create',                          '_RPCAPI_enable_batch_create',                          \&untaint_bool ); # experimental
     _create_setter( '_set_RPCAPI_enable_add_api_user',                          '_RPCAPI_enable_add_api_user',                          \&untaint_bool );
     _create_setter( '_set_RPCAPI_enable_add_batch_job',                         '_RPCAPI_enable_add_batch_job',                         \&untaint_bool );
 }

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -217,8 +217,8 @@ sub parse {
     $obj->_set_ZONEMASTER_age_reuse_previous_test( '600' );
     $obj->_set_RPCAPI_enable_user_create( 'no' );
     $obj->_set_RPCAPI_enable_batch_create( 'yes' );
-    $obj->_set_RPCAPI_enable_add_api_user( 'no' ); # deprecated
-    $obj->_set_RPCAPI_enable_add_batch_job( 'yes' ); # deprecated
+    $obj->_set_RPCAPI_enable_add_api_user( 'no' );
+    $obj->_set_RPCAPI_enable_add_batch_job( 'yes' );
     $obj->_set_locales( 'en_US' );
     $obj->_add_public_profile( 'default', undef );
     $obj->_set_METRICS_statsd_port( '8125' );
@@ -235,13 +235,7 @@ sub parse {
 
     # Check deprecated properties and assign fallback values
     my @warnings;
-
-    if ( defined( my $value = $ini->val( 'RPCAPI', 'enable_add_api_user' ) ) ) {
-        push @warnings, "Use of deprecated config property RPCAPI.enable_add_api_user. Use RPCAPI.enable_user_create instead.";
-    }
-    if ( defined( my $value = $ini->val( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
-        push @warnings, "Use of deprecated config property RPCAPI.enable_add_batch_job. Use RPCAPI.enable_batch_create instead.";
-    }
+    #currently no deprecation warnings
 
     # Assign property values (part 2/2)
     if ( defined( my $value = $get_and_clear->( 'DB', 'polling_interval' ) ) ) {
@@ -304,29 +298,17 @@ sub parse {
     if ( defined( my $value = $get_and_clear->( 'METRICS', 'statsd_port' ) ) ) {
         $obj->_set_METRICS_statsd_port( $value );
     }
+    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
+        $obj->_set_RPCAPI_enable_add_api_user( $value );
+    }
     if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_user_create' ) ) ) {
         $obj->_set_RPCAPI_enable_user_create( $value );
-        if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
-            $obj->_set_RPCAPI_enable_add_api_user( $value );
-        }
     }
-    else {
-        if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
-            $obj->_set_RPCAPI_enable_user_create( $value );
-            $obj->_set_RPCAPI_enable_add_api_user( $value );
-        }
+    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
+        $obj->_set_RPCAPI_enable_add_batch_job( $value );
     }
     if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_batch_create' ) ) ) {
         $obj->_set_RPCAPI_enable_batch_create( $value );
-        if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
-            $obj->_set_RPCAPI_enable_add_batch_job( $value );
-        }
-    }
-    else {
-        if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
-            $obj->_set_RPCAPI_enable_batch_create( $value );
-            $obj->_set_RPCAPI_enable_add_batch_job( $value );
-        }
     }
     if ( defined( my $value = $get_and_clear->( 'LANGUAGE', 'locale' ) ) ) {
         $obj->_set_locales( $value );
@@ -675,8 +657,8 @@ sub METRICS_statsd_host                                 { return $_[0]->{_METRIC
 sub METRICS_statsd_port                                 { return $_[0]->{_METRICS_statsd_port}; }
 sub RPCAPI_enable_user_create                           { return $_[0]->{_RPCAPI_enable_user_create}; }
 sub RPCAPI_enable_batch_create                          { return $_[0]->{_RPCAPI_enable_batch_create}; }
-sub RPCAPI_enable_add_api_user                          { return $_[0]->{_RPCAPI_enable_add_api_user}; } # deprecated
-sub RPCAPI_enable_add_batch_job                         { return $_[0]->{_RPCAPI_enable_add_batch_job}; } # deprecated
+sub RPCAPI_enable_add_api_user                          { return $_[0]->{_RPCAPI_enable_add_api_user}; }
+sub RPCAPI_enable_add_batch_job                         { return $_[0]->{_RPCAPI_enable_add_batch_job}; }
 
 # Compile time generation of setters for the properties documented above
 UNITCHECK {
@@ -701,8 +683,8 @@ UNITCHECK {
     _create_setter( '_set_METRICS_statsd_port',                                 '_METRICS_statsd_port',                                 \&untaint_strictly_positive_int );
     _create_setter( '_set_RPCAPI_enable_user_create',                           '_RPCAPI_enable_user_create',                           \&untaint_bool );
     _create_setter( '_set_RPCAPI_enable_batch_create',                          '_RPCAPI_enable_batch_create',                          \&untaint_bool );
-    _create_setter( '_set_RPCAPI_enable_add_api_user',                          '_RPCAPI_enable_add_api_user',                          \&untaint_bool ); #deprecated
-    _create_setter( '_set_RPCAPI_enable_add_batch_job',                         '_RPCAPI_enable_add_batch_job',                         \&untaint_bool ); #deprecated
+    _create_setter( '_set_RPCAPI_enable_add_api_user',                          '_RPCAPI_enable_add_api_user',                          \&untaint_bool );
+    _create_setter( '_set_RPCAPI_enable_add_batch_job',                         '_RPCAPI_enable_add_batch_job',                         \&untaint_bool );
 }
 
 =head2 new_DB

--- a/lib/Zonemaster/Backend/Config.pm
+++ b/lib/Zonemaster/Backend/Config.pm
@@ -298,17 +298,29 @@ sub parse {
     if ( defined( my $value = $get_and_clear->( 'METRICS', 'statsd_port' ) ) ) {
         $obj->_set_METRICS_statsd_port( $value );
     }
-    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
-        $obj->_set_RPCAPI_enable_add_api_user( $value );
-    }
     if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_user_create' ) ) ) {
+        if ( defined( $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
+            die "Error: cannot specify both RPCAPI.enable_add_api_user and RPCAPI.enable_user_create\n";
+        }
+        $obj->_set_RPCAPI_enable_add_api_user( $value );
         $obj->_set_RPCAPI_enable_user_create( $value );
-    }
-    if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
-        $obj->_set_RPCAPI_enable_add_batch_job( $value );
+    } else {
+        if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_api_user' ) ) ) {
+            $obj->_set_RPCAPI_enable_add_api_user( $value );
+            $obj->_set_RPCAPI_enable_user_create( $value );
+        }
     }
     if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_batch_create' ) ) ) {
+        if ( defined( $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
+            die "Error: cannot specify both RPCAPI.enable_add_batch_job and RPCAPI.enable_batch_create\n";
+        }
+        $obj->_set_RPCAPI_enable_add_batch_job( $value );
         $obj->_set_RPCAPI_enable_batch_create( $value );
+    } else {
+        if ( defined( my $value = $get_and_clear->( 'RPCAPI', 'enable_add_batch_job' ) ) ) {
+            $obj->_set_RPCAPI_enable_add_batch_job( $value );
+            $obj->_set_RPCAPI_enable_batch_create( $value );
+        }
     }
     if ( defined( my $value = $get_and_clear->( 'LANGUAGE', 'locale' ) ) ) {
         $obj->_set_locales( $value );

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -100,13 +100,7 @@ sub handle_exception {
     die $exception->as_hash;
 }
 
-# Experimental
-$json_schemas{system_versions} = joi->object->strict;
-sub system_versions {
-    return version_info( @_ );
-}
-
-$json_schemas{version_info} = $json_schemas{system_versions};
+$json_schemas{version_info} = joi->object->strict;
 sub version_info {
     my ( $self ) = @_;
 
@@ -124,15 +118,12 @@ sub version_info {
 }
 
 # Experimental
-$json_schemas{conf_profiles} = joi->object->strict;
-sub conf_profiles {
-    my $result = {
-        profiles => profile_name( @_ )
-    };
-    return $result;
+$json_schemas{system_versions} = $json_schemas{version_info};
+sub system_versions {
+    return version_info( @_ );
 }
 
-$json_schemas{profile_names} = $json_schemas{conf_profiles};
+$json_schemas{profile_names} = joi->object->strict;
 sub profile_names {
     my ( $self ) = @_;
 
@@ -146,17 +137,17 @@ sub profile_names {
 }
 
 # Experimental
-$json_schemas{conf_languages} = joi->object->strict;
-sub conf_languages {
+$json_schemas{conf_profiles} = $json_schemas{profile_names};
+sub conf_profiles {
     my $result = {
-        languages => get_language_tags( @_ )
+        profiles => profile_name( @_ )
     };
     return $result;
 }
 
 # Return the list of language tags supported by get_test_results(). The tags are
 # derived from the locale tags set in the configuration file.
-$json_schemas{get_language_tags} = $json_schemas{conf_languages};
+$json_schemas{get_language_tags} = joi->object->strict;
 sub get_language_tags {
     my ( $self ) = @_;
 
@@ -174,7 +165,15 @@ sub get_language_tags {
 }
 
 # Experimental
-$json_schemas{lookup_address_records} = {
+$json_schemas{conf_languages} = $json_schemas{get_language_tags};
+sub conf_languages {
+    my $result = {
+        languages => get_language_tags( @_ )
+    };
+    return $result;
+}
+
+$json_schemas{get_host_by_name} = {
     type => 'object',
     additionalProperties => 0,
     required => [ 'hostname' ],
@@ -182,14 +181,6 @@ $json_schemas{lookup_address_records} = {
         hostname => $zm_validator->domain_name
     }
 };
-sub lookup_address_records {
-    my $result = {
-        address_records => get_host_by_name( @_ )
-    };
-    return $result;
-}
-
-$json_schemas{get_host_by_name} = $json_schemas{lookup_address_records};
 sub get_host_by_name {
     my ( $self, $params ) = @_;
     my @adresses;
@@ -209,7 +200,15 @@ sub get_host_by_name {
 }
 
 # Experimental
-$json_schemas{lookup_delegation_data} = {
+$json_schemas{lookup_address_records} = $json_schemas{get_host_by_name};
+sub lookup_address_records {
+    my $result = {
+        address_records => get_host_by_name( @_ )
+    };
+    return $result;
+}
+
+$json_schemas{get_data_from_parent_zone} = {
     type => 'object',
     additionalProperties => 0,
     required => [ 'domain' ],
@@ -218,11 +217,6 @@ $json_schemas{lookup_delegation_data} = {
         language => $zm_validator->language_tag,
     }
 };
-sub lookup_delegation_data {
-    return get_data_from_parent_zone( @_ );
-}
-
-$json_schemas{get_data_from_parent_zone} = $json_schemas{lookup_delegation_data};
 sub get_data_from_parent_zone {
     my ( $self, $params ) = @_;
 
@@ -262,7 +256,12 @@ sub get_data_from_parent_zone {
 }
 
 # Experimental
-$json_schemas{job_create} = {
+$json_schemas{lookup_delegation_data} = $json_schemas{get_data_from_parent_zone};
+sub lookup_delegation_data {
+    return get_data_from_parent_zone( @_ );
+}
+
+$json_schemas{start_domain_test} = {
     type => 'object',
     additionalProperties => 0,
     required => [ 'domain' ],
@@ -287,14 +286,6 @@ $json_schemas{job_create} = {
         language => $zm_validator->language_tag,
     }
 };
-sub job_create {
-    my $result = {
-        job_id => start_domain_test( @_ )
-    };
-    return $result;
-}
-
-$json_schemas{start_domain_test} = $json_schemas{job_create};
 sub start_domain_test {
     my ( $self, $params ) = @_;
 
@@ -322,17 +313,17 @@ sub start_domain_test {
 }
 
 # Experimental
-$json_schemas{job_status} = joi->object->strict->props(
-    test_id => $zm_validator->test_id->required
-);
-sub job_status {
+$json_schemas{job_create} = $json_schemas{start_domain_test};
+sub job_create {
     my $result = {
-        progress => test_progress( @_ )
+        job_id => start_domain_test( @_ )
     };
     return $result;
 }
 
-$json_schemas{test_progress} = $json_schemas{job_status};
+$json_schemas{test_progress} = joi->object->strict->props(
+    test_id => $zm_validator->test_id->required
+);
 sub test_progress {
     my ( $self, $params ) = @_;
 
@@ -349,14 +340,17 @@ sub test_progress {
 }
 
 # Experimental
-$json_schemas{job_params} = joi->object->strict->props(
-    test_id => $zm_validator->test_id->required
-);
-sub job_params {
-    return get_test_params( @_ );
+$json_schemas{job_status} = $json_schemas{test_progress};
+sub job_status {
+    my $result = {
+        progress => test_progress( @_ )
+    };
+    return $result;
 }
 
-$json_schemas{get_test_params} = $json_schemas{job_params};
+$json_schemas{get_test_params} = joi->object->strict->props(
+    test_id => $zm_validator->test_id->required
+);
 sub get_test_params {
     my ( $self, $params ) = @_;
 
@@ -374,7 +368,12 @@ sub get_test_params {
 }
 
 # Experimental
-$json_schemas{job_results} = {
+$json_schemas{job_params} = $json_schemas{get_test_params};
+sub job_params {
+    return get_test_params( @_ );
+}
+
+$json_schemas{get_test_results} = {
     type => 'object',
     additionalProperties => 0,
     required => [ 'id', 'language' ],
@@ -383,11 +382,6 @@ $json_schemas{job_results} = {
         language => $zm_validator->language_tag,
     }
 };
-sub job_results {
-    return get_test_results( @_ );
-}
-
-$json_schemas{get_test_results} = $json_schemas{job_results};
 sub get_test_results {
     my ( $self, $params ) = @_;
 
@@ -475,7 +469,12 @@ sub get_test_results {
 }
 
 # Experimental
-$json_schemas{domain_history} = {
+$json_schemas{job_results} = $json_schemas{get_test_results};
+sub job_results {
+    return get_test_results( @_ );
+}
+
+$json_schemas{get_test_history} = {
     type => 'object',
     additionalProperties => 0,
     required => [ 'frontend_params' ],
@@ -493,14 +492,6 @@ $json_schemas{domain_history} = {
         }
     }
 };
-sub domain_history {
-    my $result = {
-        history => get_test_history( @_ )
-    };
-    return $result;
-}
-
-$json_schemas{get_test_history} = $json_schemas{domain_history};
 sub get_test_history {
     my ( $self, $params ) = @_;
 
@@ -524,18 +515,18 @@ sub get_test_history {
 }
 
 # Experimental
-$json_schemas{user_create} = joi->object->strict->props(
-    username => $zm_validator->username->required,
-    api_key => $zm_validator->api_key->required,
-);
-sub user_create {
+$json_schemas{domain_history} = $json_schemas{get_test_history};
+sub domain_history {
     my $result = {
-        success => add_api_user( @_ )
+        history => get_test_history( @_ )
     };
     return $result;
 }
 
-$json_schemas{add_api_user} = $json_schemas{user_create};
+$json_schemas{add_api_user} = joi->object->strict->props(
+    username => $zm_validator->username->required,
+    api_key => $zm_validator->api_key->required,
+);
 sub add_api_user {
     my ( $self, $params, undef, $remote_ip ) = @_;
 
@@ -568,7 +559,15 @@ sub add_api_user {
 }
 
 # Experimental
-$json_schemas{batch_create} = {
+$json_schemas{user_create} = $json_schemas{add_api_user};
+sub user_create {
+    my $result = {
+        success => add_api_user( @_ )
+    };
+    return $result;
+}
+
+$json_schemas{add_batch_job} = {
     type => 'object',
     additionalProperties => 0,
     required => [ 'username', 'api_key', 'domains' ],
@@ -605,14 +604,6 @@ $json_schemas{batch_create} = {
         }
     }
 };
-sub batch_create {
-    my $result = {
-        batch_id => add_batch_job( @_ )
-    };
-    return $result;
-}
-
-$json_schemas{add_batch_job} = $json_schemas{batch_create};
 sub add_batch_job {
     my ( $self, $params ) = @_;
 
@@ -636,14 +627,17 @@ sub add_batch_job {
 }
 
 # Experimental
-$json_schemas{batch_status} = joi->object->strict->props(
-    batch_id => $zm_validator->batch_id->required
-);
-sub batch_status {
-    return get_batch_job_result( @_ );
+$json_schemas{batch_create} = $json_schemas{add_batch_job};
+sub batch_create {
+    my $result = {
+        batch_id => add_batch_job( @_ )
+    };
+    return $result;
 }
 
-$json_schemas{get_batch_job_result} = $json_schemas{batch_status};
+$json_schemas{get_batch_job_result} = joi->object->strict->props(
+    batch_id => $zm_validator->batch_id->required
+);
 sub get_batch_job_result {
     my ( $self, $params ) = @_;
 
@@ -658,6 +652,12 @@ sub get_batch_job_result {
     }
 
     return $result;
+}
+
+# Experimental
+$json_schemas{batch_status} = $json_schemas{get_batch_job_result};
+sub batch_status {
+    return get_batch_job_result( @_ );
 }
 
 sub _get_locale {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -140,7 +140,7 @@ sub profile_names {
 $json_schemas{conf_profiles} = $json_schemas{profile_names};
 sub conf_profiles {
     my $result = {
-        profiles => profile_name( @_ )
+        profiles => profile_names( @_ )
     };
     return $result;
 }

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -100,6 +100,7 @@ sub handle_exception {
     die $exception->as_hash;
 }
 
+# Experimental
 $json_schemas{system_versions} = joi->object->strict;
 sub system_versions {
     my ( $self ) = @_;
@@ -134,6 +135,7 @@ sub version_info {
     return \%ver;
 }
 
+# Experimental
 $json_schemas{conf_profiles} = joi->object->strict;
 sub conf_profiles {
     my ( $self ) = @_;
@@ -163,6 +165,7 @@ sub profile_names {
     return [ keys %profiles ];
 }
 
+# Experimental
 # Return the list of language tags supported by get_test_results(). The tags are
 # derived from the locale tags set in the configuration file.
 $json_schemas{conf_languages} = joi->object->strict;
@@ -209,6 +212,7 @@ sub get_language_tags {
     return \@lang_tags;
 }
 
+# Experimental
 $json_schemas{lookup_address_records} = {
     type => 'object',
     additionalProperties => 0,
@@ -258,6 +262,7 @@ sub get_host_by_name {
     return \@adresses;
 }
 
+# Experimental
 $json_schemas{lookup_delegation_data} = {
     type => 'object',
     additionalProperties => 0,
@@ -344,6 +349,7 @@ sub get_data_from_parent_zone {
     }
 }
 
+# Experimental
 $json_schemas{job_create} = {
     type => 'object',
     additionalProperties => 0,
@@ -426,6 +432,7 @@ sub start_domain_test {
     return $result;
 }
 
+# Experimental
 $json_schemas{job_status} = joi->object->strict->props(
     test_id => $zm_validator->test_id->required
 );
@@ -464,6 +471,7 @@ sub test_progress {
     return $result;
 }
 
+# Experimental
 $json_schemas{job_params} = joi->object->strict->props(
     test_id => $zm_validator->test_id->required
 );
@@ -500,6 +508,7 @@ sub get_test_params {
     return $result;
 }
 
+# Experimental
 $json_schemas{job_results} = {
     type => 'object',
     additionalProperties => 0,
@@ -682,6 +691,7 @@ sub get_test_results {
     return $result;
 }
 
+# Experimental
 $json_schemas{domain_history} = {
     type => 'object',
     additionalProperties => 0,
@@ -747,6 +757,7 @@ sub get_test_history {
     return $results;
 }
 
+# Experimental
 $json_schemas{user_create} = joi->object->strict->props(
     username => $zm_validator->username->required,
     api_key => $zm_validator->api_key->required,
@@ -818,6 +829,7 @@ sub add_api_user {
     return $result;
 }
 
+# Experimental
 $json_schemas{batch_create} = {
     type => 'object',
     additionalProperties => 0,
@@ -904,6 +916,7 @@ sub add_batch_job {
     return $results;
 }
 
+# Experimental
 $json_schemas{batch_status} = joi->object->strict->props(
     batch_id => $zm_validator->batch_id->required
 );

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -120,7 +120,19 @@ sub system_versions {
 # Deprecated
 $json_schemas{version_info} = $json_schemas{system_versions};
 sub version_info {
-    return system_versions( @_ );
+    my ( $self ) = @_;
+
+    my %ver;
+    eval {
+        $ver{zonemaster_ldns} = Zonemaster::LDNS->VERSION;
+        $ver{zonemaster_engine} = Zonemaster::Engine->VERSION;
+        $ver{zonemaster_backend} = Zonemaster::Backend->VERSION;
+    };
+    if ($@) {
+        handle_exception( $@ );
+    }
+
+    return \%ver;
 }
 
 $json_schemas{conf_profiles} = joi->object->strict;
@@ -300,7 +312,41 @@ sub lookup_delegation_data {
 # Deprecated
 $json_schemas{get_data_from_parent_zone} = $json_schemas{lookup_delegation_data};
 sub get_data_from_parent_zone {
-    return lookup_delegation_data( @_ );
+    my ( $self, $params ) = @_;
+
+    my $result = eval {
+        my %result;
+        my $domain = $params->{domain};
+
+        my @ns_list;
+        my @ns_names;
+
+        my $zone = Zonemaster::Engine->zone( $domain );
+        push @ns_list, { ns => $_->name->string, ip => $_->address->short} for @{$zone->glue};
+
+        my @ds_list;
+
+        $zone = Zonemaster::Engine->zone($domain);
+        my $ds_p = $zone->parent->query_one( $zone->name, 'DS', { dnssec => 1, cd => 1, recurse => 1 } );
+        if ($ds_p) {
+            my @ds = $ds_p->get_records( 'DS', 'answer' );
+
+            foreach my $ds ( @ds ) {
+                next unless $ds->type eq 'DS';
+                push(@ds_list, { keytag => $ds->keytag, algorithm => $ds->algorithm, digtype => $ds->digtype, digest => $ds->hexdigest });
+            }
+        }
+
+        $result{ns_list} = \@ns_list;
+        $result{ds_list} = \@ds_list;
+        return \%result;
+    };
+    if ($@) {
+        handle_exception( $@ );
+    }
+    elsif ($result) {
+        return $result;
+    }
 }
 
 $json_schemas{job_create} = {
@@ -447,7 +493,19 @@ sub job_params {
 # Deprecated
 $json_schemas{get_test_params} = $json_schemas{job_params};
 sub get_test_params {
-    return job_params( @_ );
+    my ( $self, $params ) = @_;
+
+    my $result;
+    eval {
+        my $test_id = $params->{test_id};
+
+        $result = $self->{db}->get_test_params( $test_id );
+    };
+    if ($@) {
+        handle_exception( $@ );
+    }
+
+    return $result;
 }
 
 $json_schemas{job_results} = {
@@ -548,7 +606,89 @@ sub job_results {
 # Deprecated
 $json_schemas{get_test_results} = $json_schemas{job_results};
 sub get_test_results {
-    return job_results( @_ );
+    my ( $self, $params ) = @_;
+
+    my $result;
+    eval{
+
+        my $locale = $self->_get_locale( $params );
+
+        my $translator;
+        $translator = Zonemaster::Backend::Translator->new;
+
+        my $previous_locale = $translator->locale;
+        if ( !$translator->locale( $locale ) ) {
+            die "Failed to set locale: $locale";
+        }
+
+        eval { $translator->data } if $translator; # Provoke lazy loading of translation data
+
+        my @zm_results;
+        my %testcases;
+
+        my $test_info = $self->{db}->test_results( $params->{id} );
+        foreach my $test_res ( @{ $test_info->{results} } ) {
+            my $res;
+            if ( $test_res->{module} eq 'NAMESERVER' ) {
+                $res->{ns} = ( $test_res->{args}->{ns} ) ? ( $test_res->{args}->{ns} ) : ( 'All' );
+            }
+            elsif ($test_res->{module} eq 'SYSTEM'
+                && $test_res->{tag} eq 'POLICY_DISABLED'
+                && $test_res->{args}->{name} eq 'Example' )
+            {
+                next;
+            }
+
+            $res->{module} = $test_res->{module};
+            $res->{message} = $translator->translate_tag( $test_res ) . "\n";
+            $res->{message} =~ s/,/, /isg;
+            $res->{message} =~ s/;/; /isg;
+            $res->{level} = $test_res->{level};
+            $res->{testcase} = $test_res->{testcase} // 'UNSPECIFIED';
+            $testcases{$res->{testcase}} = $translator->test_case_description($res->{testcase});
+
+            if ( $test_res->{module} eq 'SYSTEM' ) {
+                if ( $res->{message} =~ /policy\.json/ ) {
+                    my ( $policy ) = ( $res->{message} =~ /\s(\/.*)$/ );
+                    if ( $policy ) {
+                        my $policy_description = 'DEFAULT POLICY';
+                        $policy_description = 'SOME OTHER POLICY' if ( $policy =~ /some\/other\/policy\/path/ );
+                        $res->{message} =~ s/$policy/$policy_description/;
+                    }
+                    else {
+                        $res->{message} = 'UNKNOWN POLICY FORMAT';
+                    }
+                }
+                elsif ( $res->{message} =~ /config\.json/ ) {
+                    my ( $config ) = ( $res->{message} =~ /\s(\/.*)$/ );
+                    if ( $config ) {
+                        my $config_description = 'DEFAULT CONFIGURATION';
+                        $config_description = 'SOME OTHER CONFIGURATION' if ( $config =~ /some\/other\/configuration\/path/ );
+                        $res->{message} =~ s/$config/$config_description/;
+                    }
+                    else {
+                        $res->{message} = 'UNKNOWN CONFIG FORMAT';
+                    }
+                }
+            }
+
+            push( @zm_results, $res );
+        }
+
+        $result = $test_info;
+        $result->{testcase_descriptions} = \%testcases;
+        $result->{results} = \@zm_results;
+
+        $translator->locale( $previous_locale );
+
+        $result = $test_info;
+        $result->{results} = \@zm_results;
+    };
+    if ($@) {
+        handle_exception( $@ );
+    }
+
+    return $result;
 }
 
 $json_schemas{domain_history} = {
@@ -798,7 +938,19 @@ sub batch_status {
 # Deprecated
 $json_schemas{get_batch_job_result} = $json_schemas{batch_status};
 sub get_batch_job_result {
-    return batch_status( @_ );
+    my ( $self, $params ) = @_;
+
+    my $result;
+    eval {
+        my $batch_id = $params->{batch_id};
+
+        $result = $self->{db}->get_batch_job_result($batch_id);
+    };
+    if ($@) {
+        handle_exception( $@ );
+    }
+
+    return $result;
 }
 
 sub _get_locale {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -117,7 +117,6 @@ sub system_versions {
     return \%ver;
 }
 
-# Deprecated
 $json_schemas{version_info} = $json_schemas{system_versions};
 sub version_info {
     my ( $self ) = @_;
@@ -151,7 +150,6 @@ sub conf_profiles {
     return $result;
 }
 
-# Deprecated
 $json_schemas{profile_names} = $json_schemas{conf_profiles};
 sub profile_names {
     my ( $self ) = @_;
@@ -188,7 +186,6 @@ sub conf_languages {
     return $result;
 }
 
-# Deprecated
 $json_schemas{get_language_tags} = $json_schemas{conf_languages};
 sub get_language_tags {
     my ( $self ) = @_;
@@ -242,7 +239,6 @@ sub lookup_address_records {
     return $result;
 }
 
-# Deprecated
 $json_schemas{get_host_by_name} = $json_schemas{lookup_address_records};
 sub get_host_by_name {
     my ( $self, $params ) = @_;
@@ -309,7 +305,6 @@ sub lookup_delegation_data {
     }
 }
 
-# Deprecated
 $json_schemas{get_data_from_parent_zone} = $json_schemas{lookup_delegation_data};
 sub get_data_from_parent_zone {
     my ( $self, $params ) = @_;
@@ -404,7 +399,6 @@ sub job_create {
     return $result;
 }
 
-# Deprecated
 $json_schemas{start_domain_test} = $json_schemas{job_create};
 sub start_domain_test {
     my ( $self, $params ) = @_;
@@ -454,7 +448,6 @@ sub job_status {
     return $result;
 }
 
-# Deprecated
 $json_schemas{test_progress} = $json_schemas{job_status};
 sub test_progress {
     my ( $self, $params ) = @_;
@@ -490,7 +483,6 @@ sub job_params {
     return $result;
 }
 
-# Deprecated
 $json_schemas{get_test_params} = $json_schemas{job_params};
 sub get_test_params {
     my ( $self, $params ) = @_;
@@ -603,7 +595,6 @@ sub job_results {
     return $result;
 }
 
-# Deprecated
 $json_schemas{get_test_results} = $json_schemas{job_results};
 sub get_test_results {
     my ( $self, $params ) = @_;
@@ -733,7 +724,6 @@ sub domain_history {
     return $result;
 }
 
-# Deprecated
 $json_schemas{get_test_history} = $json_schemas{domain_history};
 sub get_test_history {
     my ( $self, $params ) = @_;
@@ -796,7 +786,6 @@ sub user_create {
     return $result;
 }
 
-# Deprecated
 $json_schemas{add_api_user} = $json_schemas{user_create};
 sub add_api_user {
     my ( $self, $params, undef, $remote_ip ) = @_;
@@ -892,7 +881,6 @@ sub batch_create {
     return $result;
 }
 
-# Deprecated
 $json_schemas{add_batch_job} = $json_schemas{batch_create};
 sub add_batch_job {
     my ( $self, $params ) = @_;
@@ -935,7 +923,6 @@ sub batch_status {
     return $result;
 }
 
-# Deprecated
 $json_schemas{get_batch_job_result} = $json_schemas{batch_status};
 sub get_batch_job_result {
     my ( $self, $params ) = @_;

--- a/script/add-batch-job.pl
+++ b/script/add-batch-job.pl
@@ -14,7 +14,7 @@ binmode STDOUT, ':utf8';
 
 my $e = Zonemaster::Backend::RPCAPI->new;
 
-say "Starting batch_create";
+say "Starting add_batch_job";
 my @domains;
 for (my $i = 0; $i < 100; $i++) {
     push(@domains, substr(md5_hex(rand(10000)), 0, 5).".fr");
@@ -22,9 +22,9 @@ for (my $i = 0; $i < 100; $i++) {
 
 #die Dumper(\@domains);
 
-$e->user_create({ username => 'test_user', api_key => 'API_KEY_01'});
+$e->add_api_user({ username => 'test_user', api_key => 'API_KEY_01'});
 
-$e->batch_create(
+$e->add_batch_job(
     {
         client_id      => 'Add Script',
         client_version => '1.0',

--- a/script/zmb
+++ b/script/zmb
@@ -95,51 +95,51 @@ sub cmd_non_existing_method {
 }
 
 
-=head2 system_versions
+=head2 version_info
 
- zmb [GLOBAL OPTIONS] system_versions
+ zmb [GLOBAL OPTIONS] version_info
 
 =cut
 
-sub cmd_system_versions {
+sub cmd_version_info {
     return to_jsonrpc(
         id     => 1,
-        method => 'system_versions',
+        method => 'version_info',
     );
 }
 
 
-=head2 conf_profiles
+=head2 profile_names
 
- zmb [GLOBAL OPTIONS] conf_profiles
+ zmb [GLOBAL OPTIONS] profile_names
 
 =cut
 
-sub cmd_conf_profiles {
+sub cmd_profile_names {
     return to_jsonrpc(
         id     => 1,
-        method => 'conf_profiles',
+        method => 'profile_names',
     );
 }
 
 
-=head2 conf_languages
+=head2 get_language_tags
 
- zmb [GLOBAL OPTIONS] conf_languages
+ zmb [GLOBAL OPTIONS] get_language_tags
 
 =cut
 
-sub cmd_conf_languages {
+sub cmd_get_language_tags {
     return to_jsonrpc(
         id     => 1,
-        method => 'conf_languages',
+        method => 'get_language_tags',
     );
 }
 
 
-=head2 job_create
+=head2 start_domain_test
 
- zmb [GLOBAL OPTIONS] job_create [OPTIONS]
+ zmb [GLOBAL OPTIONS] start_domain_test [OPTIONS]
 
  Options:
 
@@ -164,7 +164,7 @@ sub cmd_conf_languages {
 
 =cut
 
-sub cmd_job_create {
+sub cmd_start_domain_test {
     my @opts = @_;
 
     my @opt_nameserver;
@@ -252,7 +252,7 @@ sub cmd_job_create {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'job_create',
+        method => 'start_domain_test',
         params => \%params,
     );
 }
@@ -260,16 +260,16 @@ sub cmd_job_create {
 
 
 
-=head2 job_status
+=head2 test_progress
 
- zmb [GLOBAL OPTIONS] job_status [OPTIONS]
+ zmb [GLOBAL OPTIONS] test_progress [OPTIONS]
 
  Options:
    --test-id TEST_ID
 
 =cut
 
-sub cmd_job_status {
+sub cmd_test_progress {
     my @opts = @_;
 
     my $opt_test_id;
@@ -280,7 +280,7 @@ sub cmd_job_status {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'job_status',
+        method => 'test_progress',
         params => {
             test_id => $opt_test_id,
         },
@@ -288,16 +288,16 @@ sub cmd_job_status {
 }
 
 
-=head2 job_params
+=head2 get_test_params
 
- zmb [GLOBAL OPTIONS] job_params [OPTIONS]
+ zmb [GLOBAL OPTIONS] get_test_params [OPTIONS]
 
  Options:
    --test-id TEST_ID
 
 =cut
 
-sub cmd_job_params {
+sub cmd_get_test_params {
     my @opts = @_;
 
     my $opt_test_id;
@@ -308,7 +308,7 @@ sub cmd_job_params {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'job_params',
+        method => 'get_test_params',
         params => {
             test_id => $opt_test_id,
         },
@@ -316,9 +316,9 @@ sub cmd_job_params {
 }
 
 
-=head2 job_results
+=head2 get_test_results
 
- zmb [GLOBAL OPTIONS] job_results [OPTIONS]
+ zmb [GLOBAL OPTIONS] get_test_results [OPTIONS]
 
  Options:
    --test-id TEST_ID
@@ -326,7 +326,7 @@ sub cmd_job_params {
 
 =cut
 
-sub cmd_job_results {
+sub cmd_get_test_results {
     my @opts = @_;
 
     my $opt_lang;
@@ -339,7 +339,7 @@ sub cmd_job_results {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'job_results',
+        method => 'get_test_results',
         params => {
             id       => $opt_test_id,
             language => $opt_lang,
@@ -348,9 +348,9 @@ sub cmd_job_results {
 }
 
 
-=head2 domain_history
+=head2 get_test_history
 
- zmb [GLOBAL OPTIONS] domain_history [OPTIONS]
+ zmb [GLOBAL OPTIONS] get_test_history [OPTIONS]
 
  Options:
    --domain DOMAIN_NAME
@@ -360,7 +360,7 @@ sub cmd_job_results {
 
 =cut
 
-sub cmd_domain_history {
+sub cmd_get_test_history {
     my @opts = @_;
     my $opt_filter;
     my $opt_domain;
@@ -398,15 +398,15 @@ sub cmd_domain_history {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'domain_history',
+        method => 'get_test_history',
         params => \%params,
     );
 }
 
 
-=head2 user_create
+=head2 add_api_user
 
- zmb [GLOBAL OPTIONS] user_create [OPTIONS]
+ zmb [GLOBAL OPTIONS] add_api_user [OPTIONS]
 
  Options:
    --username USERNAME
@@ -414,7 +414,7 @@ sub cmd_domain_history {
 
 =cut
 
-sub cmd_user_create {
+sub cmd_add_api_user {
     my @opts = @_;
 
     my $opt_username;
@@ -427,7 +427,7 @@ sub cmd_user_create {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'user_create',
+        method => 'add_api_user',
         params => {
             username => $opt_username,
             api_key  => $opt_api_key,
@@ -436,9 +436,9 @@ sub cmd_user_create {
 }
 
 
-=head2 batch_create
+=head2 add_batch_job
 
- zmb [GLOBAL OPTIONS] batch_create [OPTIONS]
+ zmb [GLOBAL OPTIONS] add_batch_job [OPTIONS]
 
  Options:
     --username USERNAME
@@ -467,7 +467,7 @@ sub cmd_user_create {
 
 =cut
 
-sub cmd_batch_create {
+sub cmd_add_batch_job {
     my @opts = @_;
 
     my $opt_username;
@@ -558,22 +558,22 @@ sub cmd_batch_create {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'batch_create',
+        method => 'add_batch_job',
         params => \%params,
     );
 }
 
 
-=head2 batch_status
+=head2 get_batch_job_result
 
- zmb [GLOBAL OPTIONS] batch_status [OPTIONS]
+ zmb [GLOBAL OPTIONS] get_batch_job_result [OPTIONS]
 
  Options:
    --batch-id BATCH-ID
 
 =cut
 
-sub cmd_batch_status {
+sub cmd_get_batch_job_result {
     my @opts = @_;
 
     my $opt_batch_id;
@@ -584,7 +584,7 @@ sub cmd_batch_status {
 
     return to_jsonrpc(
         id     => 1,
-        method => 'batch_status',
+        method => 'get_batch_job_result',
         params => {
             batch_id => $opt_batch_id,
         },

--- a/script/zmtest
+++ b/script/zmtest
@@ -64,19 +64,19 @@ done
 [ -n "${domain}" ] || usage 2 "No domain specified"
 
 # Start test
-output="$(zmb "${server_url}" job_create --domain "${domain}" ${ipv4} ${ipv6} --profile "${profile}")" || exit $?
-testid="$(printf "%s" "${output}" | "${JQ}" -r .result.job_id)" || exit $?
+output="$(zmb "${server_url}" start_domain_test --domain "${domain}" ${ipv4} ${ipv6} --profile "${profile}")" || exit $?
+testid="$(printf "%s" "${output}" | "${JQ}" -r .result)" || exit $?
 printf "testid: %s\n" "${testid}" >&2
 
 if echo "${testid}" | grep -qE '[^0-9a-fA-F]' ; then
-    error 1 "job_create did not return a testid: ${testid}"
+    error 1 "start_domain_test did not return a testid: ${testid}"
 fi
 
 # Wait for test to finish
 while true
 do
-    output="$(zmb "${server_url}" job_status --test-id "${testid}")" || exit $?
-    progress="$(printf "%s" "${output}" | "${JQ}" -r .result.progress)" || exit $?
+    output="$(zmb "${server_url}" test_progress --test-id "${testid}")" || exit $?
+    progress="$(printf "%s" "${output}" | "${JQ}" -r .result)" || exit $?
     printf "\r${progress}%% done" >&2
     if [ "${progress}" -eq 100 ] ; then
         echo >&2
@@ -86,4 +86,4 @@ do
 done
 
 # Get test results
-zmb "${server_url}" job_results --test-id "${testid}" --lang "${lang}"
+zmb "${server_url}" get_test_results --test-id "${testid}" --lang "${lang}"

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -59,7 +59,6 @@ my $handler = Zonemaster::Backend::RPCAPI->new( { config => $config } );
 
 my $router = router {
 ############## FRONTEND ####################
-    # Deprecated
     connect "version_info" => {
         handler => $handler,
         action => "version_info"
@@ -70,7 +69,6 @@ my $router = router {
         action => "system_versions"
     };
 
-    # Deprecated
     connect "profile_names" => {
         handler => $handler,
         action => "profile_names"
@@ -81,7 +79,6 @@ my $router = router {
         action => "conf_profiles"
     };
 
-    # Deprecated
     connect "get_language_tags" => {
         handler => $handler,
         action => "get_language_tags"
@@ -92,7 +89,6 @@ my $router = router {
         action => "conf_languages"
     };
 
-    # Deprecated
     connect "get_host_by_name" => {
         handler => $handler,
         action => "get_host_by_name"
@@ -103,7 +99,6 @@ my $router = router {
         action => "lookup_address_records"
     };
 
-    # Deprecated
     connect "get_data_from_parent_zone" => {
         handler => $handler,
         action => "get_data_from_parent_zone"
@@ -114,7 +109,6 @@ my $router = router {
         action => "lookup_delegation_data"
     };
 
-    # Deprecated
     connect "start_domain_test" => {
         handler => $handler,
         action => "start_domain_test"
@@ -125,7 +119,6 @@ my $router = router {
         action => "job_create"
     };
 
-    # Deprecated
     connect "test_progress" => {
         handler => $handler,
         action => "test_progress"
@@ -136,7 +129,6 @@ my $router = router {
         action => "job_status"
     };
 
-    # Deprecated
     connect "get_test_params" => {
         handler => $handler,
         action => "get_test_params"
@@ -147,7 +139,6 @@ my $router = router {
         action => "job_params"
     };
 
-    # Deprecated
     connect "get_test_results" => {
         handler => $handler,
         action => "get_test_results"
@@ -158,7 +149,6 @@ my $router = router {
         action => "job_results"
     };
 
-    # Deprecated
     connect "get_test_history" => {
         handler => $handler,
         action => "get_test_history"
@@ -169,7 +159,6 @@ my $router = router {
         action => "domain_history"
     };
 
-    # Deprecated
     connect "get_batch_job_result" => {
         handler => $handler,
         action => "get_batch_job_result"
@@ -182,8 +171,7 @@ my $router = router {
 };
 
 if ( $config->RPCAPI_enable_user_create or $config->RPCAPI_enable_add_api_user ) {
-    $log->info('Enabling user_create method');
-    #Deprecated
+    $log->info('Enabling add_api_user method');
     $router->connect("add_api_user", {
         handler => $handler,
         action => "add_api_user"
@@ -195,8 +183,7 @@ if ( $config->RPCAPI_enable_user_create or $config->RPCAPI_enable_add_api_user )
 }
 
 if ( $config->RPCAPI_enable_batch_create or $config->RPCAPI_enable_add_batch_job ) {
-    $log->info('Enabling batch_create method');
-    #Deprecated
+    $log->info('Enabling add_batch_job method');
     $router->connect("add_batch_job", {
         handler => $handler,
         action => "add_batch_job"

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -64,6 +64,7 @@ my $router = router {
         action => "version_info"
     };
 
+    # Experimental
     connect "system_versions" => {
         handler => $handler,
         action => "system_versions"
@@ -74,6 +75,7 @@ my $router = router {
         action => "profile_names"
     };
 
+    # Experimental
     connect "conf_profiles" => {
         handler => $handler,
         action => "conf_profiles"
@@ -84,6 +86,7 @@ my $router = router {
         action => "get_language_tags"
     };
 
+    # Experimental
     connect "conf_languages" => {
         handler => $handler,
         action => "conf_languages"
@@ -94,6 +97,7 @@ my $router = router {
         action => "get_host_by_name"
     };
 
+    # Experimental
     connect "lookup_address_records" => {
         handler => $handler,
         action => "lookup_address_records"
@@ -104,6 +108,7 @@ my $router = router {
         action => "get_data_from_parent_zone"
     };
 
+    # Experimental
     connect "lookup_delegation_data" => {
         handler => $handler,
         action => "lookup_delegation_data"
@@ -114,6 +119,7 @@ my $router = router {
         action => "start_domain_test"
     };
 
+    # Experimental
     connect "job_create" => {
         handler => $handler,
         action => "job_create"
@@ -124,6 +130,7 @@ my $router = router {
         action => "test_progress"
     };
 
+    # Experimental
     connect "job_status" => {
         handler => $handler,
         action => "job_status"
@@ -134,6 +141,7 @@ my $router = router {
         action => "get_test_params"
     };
 
+    # Experimental
     connect "job_params" => {
         handler => $handler,
         action => "job_params"
@@ -144,6 +152,7 @@ my $router = router {
         action => "get_test_results"
     };
 
+    # Experimental
     connect "job_results" => {
         handler => $handler,
         action => "job_results"
@@ -154,6 +163,7 @@ my $router = router {
         action => "get_test_history"
     };
 
+    # Experimental
     connect "domain_history" => {
         handler => $handler,
         action => "domain_history"
@@ -164,6 +174,7 @@ my $router = router {
         action => "get_batch_job_result"
     };
 
+    # Experimental
     connect "batch_status" => {
         handler => $handler,
         action => "batch_status"

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -181,28 +181,26 @@ my $router = router {
     };
 };
 
-if ( $config->RPCAPI_enable_user_create ) {
+if ( $config->RPCAPI_enable_user_create or $config->RPCAPI_enable_add_api_user ) {
+    $log->info('Enabling user_create method');
     #Deprecated
-    $log->info('Enabling add_api_user method. Deprecated, use user_create method.');
     $router->connect("add_api_user", {
         handler => $handler,
         action => "add_api_user"
     });
-    $log->info('Enabling user_create method');
     $router->connect("user_create", {
         handler => $handler,
         action => "user_create"
     });
 }
 
-if ( $config->RPCAPI_enable_batch_create ) {
+if ( $config->RPCAPI_enable_batch_create or $config->RPCAPI_enable_add_batch_job ) {
+    $log->info('Enabling batch_create method');
     #Deprecated
-    $log->info('Enabling add_batch_job method. Deprecated, use batch_create method.');
     $router->connect("add_batch_job", {
         handler => $handler,
         action => "add_batch_job"
     });
-    $log->info('Enabling batch_create method');
     $router->connect("batch_create", {
         handler => $handler,
         action => "batch_create"

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -29,10 +29,10 @@ database_file = /var/lib/zonemaster/db.sqlite
 
 [RPCAPI]
 
-# Uncomment to enable API method "user_create"
-#enable_user_create = yes
-# Uncomment to disable API method "batch_create"
-#enable_batch_create = no
+# Uncomment to enable API method "add_api_user"
+#enable_add_api_user = yes
+# Uncomment to disable API method "add_batch_job"
+#enable_add_batch_job = no
 
 [LANGUAGE]
 locale = da_DK en_US es_ES fi_FI fr_FR nb_NO sv_SE

--- a/t/batches.t
+++ b/t/batches.t
@@ -70,7 +70,7 @@ sub init_backend {
     my $rpcapi = TestUtil::create_rpcapi( $config );
 
     # create a user
-    $rpcapi->user_create( $user );
+    $rpcapi->add_api_user( $user );
 
     return $rpcapi;
 }
@@ -94,14 +94,14 @@ sub check_tolerance {
     cmp_ok( $delta, '<=', $tolerance, $msg);
 }
 
-subtest 'RPCAPI batch_create' => sub {
+subtest 'RPCAPI add_batch_job' => sub {
     my $config = Zonemaster::Backend::Config->parse( $config );
     my $rpcapi = init_backend( $config );
     my $dbh = $rpcapi->{db}->dbh;
 
     my @domains = ( 'afnic.fr' );
 
-    my $res = $rpcapi->batch_create(
+    my $res = $rpcapi->add_batch_job(
         {
             %$user,
             domains => \@domains,
@@ -109,7 +109,7 @@ subtest 'RPCAPI batch_create' => sub {
         }
     );
 
-    is( $res->{batch_id}, 1, 'correct batch job id returned' );
+    is( $res, 1, 'correct batch job id returned' );
 
     subtest 'table "batch_jobs" contains an entry' => sub {
         my ( $count ) = $dbh->selectrow_array( q[ SELECT count(*) FROM batch_jobs ] );
@@ -150,24 +150,23 @@ subtest 'RPCAPI batch_create' => sub {
     };
 };
 
-subtest 'RPCAPI batch_status' => sub {
+subtest 'RPCAPI get_batch_job_result' => sub {
     my $config = Zonemaster::Backend::Config->parse( $config );
     my $rpcapi = init_backend( $config );
     subtest 'batch job exists' => sub {
         my @domains = ( 'afnic.fr' );
 
-        my $res_batch_create = $rpcapi->batch_create(
+        my $batch_id = $rpcapi->add_batch_job(
             {
                 %$user,
                 domains => \@domains,
                 test_params => $params
             }
         );
-        my $batch_id = $res_batch_create->{batch_id};
 
         is( $batch_id, 1, 'correct batch job id returned' );
 
-        my $res = $rpcapi->batch_status( { batch_id => $batch_id } );
+        my $res = $rpcapi->get_batch_job_result( { batch_id => $batch_id } );
 
         is( $res->{nb_running}, @domains, 'correct number of runninng tests' );
         is( $res->{nb_finished}, 0, 'correct number of finished tests' );
@@ -176,7 +175,7 @@ subtest 'RPCAPI batch_status' => sub {
     subtest 'unknown batch' => sub {
         my $unknown_batch = 10;
         dies_ok {
-            $rpcapi->batch_status( { batch_id => $unknown_batch } );
+            $rpcapi->get_batch_job_result( { batch_id => $unknown_batch } );
         } 'getting results for an unknown batch_id should die';
         my $res = $@;
         is( $res->{error}, 'Zonemaster::Backend::Error::ResourceNotFound', 'correct error type' );
@@ -192,7 +191,7 @@ subtest 'batch with several domains' => sub {
 
     my @domains = sort( 'afnic.fr', 'iis.se' );
 
-    my $res = $rpcapi->batch_create(
+    my $res = $rpcapi->add_batch_job(
         {
             %$user,
             domains => \@domains,
@@ -200,9 +199,9 @@ subtest 'batch with several domains' => sub {
         }
     );
 
-    is( $res->{batch_id}, 1, 'correct batch job id returned' );
+    is( $res, 1, 'correct batch job id returned' );
 
-    $res = $rpcapi->batch_status( { batch_id => 1 } );
+    $res = $rpcapi->get_batch_job_result( { batch_id => 1 } );
 
     is( $res->{nb_running}, @domains, 'correct number of runninng tests' );
     is( $res->{nb_finished}, 0, 'correct number of finished tests' );
@@ -247,26 +246,24 @@ subtest 'batch job still running' => sub {
 
     my @domains = ( 'afnic.fr' );
 
-    my $res_batch_create = $rpcapi->batch_create(
+    my $batch_id = $rpcapi->add_batch_job(
         {
             %$user,
             domains => \@domains,
             test_params => $params
         }
     );
-    my $batch_id = $res_batch_create->{batch_id};
 
     is( $batch_id, 1, 'correct batch job id returned' );
 
     dies_ok {
-        my $res = $rpcapi->batch_create(
+        my $new_batch_id = $rpcapi->add_batch_job(
             {
                 %$user,
                 domains => \@domains,
                 test_params => $params
             }
         );
-        my $new_batch_id = $res->{batch_id};
     } 'a batch is already running for the user, new batch creation should fail' ;
     my $res = $@;
     is( $res->{message}, 'Batch job still running', 'correct error message' );
@@ -275,15 +272,14 @@ subtest 'batch job still running' => sub {
 
     subtest 'use another user' => sub {
         my $another_user = { username => 'another', api_key => 'token' };
-        $rpcapi->user_create( $another_user );
-        my $res = $rpcapi->batch_create(
+        $rpcapi->add_api_user( $another_user );
+        my $batch_id = $rpcapi->add_batch_job(
             {
                 %$another_user,
                 domains => \@domains,
                 test_params => $params
             }
         );
-        my $batch_id = $res->{batch_id};
 
         is( $batch_id, 2, 'another_user can create another batch' );
     };
@@ -298,8 +294,8 @@ subtest 'duplicate user should fail' => sub {
     $rpcapi->{db}->dbh->{PrintError} = 0;
 
     dies_ok {
-        $rpcapi->user_create( { username => $user->{username}, api_key => "another api key" } );
-    } 'a user with the same username already exists, user_create should die';
+        $rpcapi->add_api_user( { username => $user->{username}, api_key => "another api key" } );
+    } 'a user with the same username already exists, add_api_user should die';
     my $res = $@;
     is( $res->{error}, 'Zonemaster::Backend::Error::Conflict', 'correct error type' );
     is( $res->{message}, 'User already exists', 'correct error message' );
@@ -321,14 +317,13 @@ subtest 'normalize "domain" column' => sub {
     );
     my @domains = keys %domains_to_test;
 
-    my $res = $rpcapi->batch_create(
+    my $batch_id = $rpcapi->add_batch_job(
         {
             %$user,
             domains => \@domains,
             test_params => $params
         }
     );
-    my $batch_id = $res->{batch_id};
 
     my @db_domain = map { $$_[0] } $dbh->selectall_array( "SELECT domain FROM test_results WHERE batch_id=?", undef, $batch_id );
 

--- a/t/config.t
+++ b/t/config.t
@@ -111,6 +111,9 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->ZONEMASTER_number_of_processes_for_batch_testing,    20,  'default: ZONEMASTER.number_of_processes_for_batch_testing';
         is $config->ZONEMASTER_lock_on_queue,                            0,   'default: ZONEMASTER.lock_on_queue';
         is $config->ZONEMASTER_age_reuse_previous_test,                  600, 'default: ZONEMASTER.age_reuse_previous_test';
+
+        is $config->RPCAPI_enable_add_api_user,  0,   'default: RPCAPI.enable_add_api_user';
+        is $config->RPCAPI_enable_add_batch_job, 1,   'default: RPCAPI.enable_add_batch_job';
     };
 
     SKIP: {

--- a/t/config.t
+++ b/t/config.t
@@ -113,47 +113,20 @@ subtest 'Everything but NoWarnings' => sub {
         is $config->ZONEMASTER_age_reuse_previous_test,                  600, 'default: ZONEMASTER.age_reuse_previous_test';
     };
 
-    subtest 'Deprecated values and fallbacks that are unconditional' => sub {
-        $log->clear();
-        my $text = q{
-            [DB]
-            engine = SQLite
-            [SQLITE]
-            database_file = /var/db/zonemaster.sqlite
-            [RPCAPI]
-            enable_add_api_user = yes
-            enable_add_batch_job = no
-        };
-        my $config = Zonemaster::Backend::Config->parse( $text );
-        $log->contains_ok( qr/deprecated.*RPCAPI\.enable_add_api_user/, 'deprecated: RPCAPI.enable_add_api_user' );
-        $log->contains_ok( qr/deprecated.*RPCAPI\.enable_add_batch_job/, 'deprecated: RPCAPI.enable_add_batch_job' );
+    SKIP: {
+        skip "no more deprecated values", 1;
 
-        is $config->RPCAPI_enable_add_api_user,  1, 'set: RPCAPI.enable_add_api_user';
-        is $config->RPCAPI_enable_add_batch_job, 0, 'set: RPCAPI.enable_add_batch_job';
-        is $config->RPCAPI_enable_user_create,   1, 'apply: RPCAPI.enable_user_create';
-        is $config->RPCAPI_enable_batch_create,  0, 'apply: RPCAPI.enable_batch_create';
-
-        subtest 'Deprecated RPCAPI properties and precedence' => sub {
+        subtest 'Deprecated values and fallbacks that are unconditional' => sub {
             $log->clear();
             my $text = q{
                 [DB]
                 engine = SQLite
                 [SQLITE]
                 database_file = /var/db/zonemaster.sqlite
-                [RPCAPI]
-                enable_add_api_user = yes
-                enable_add_batch_job = no
-                enable_user_create = no
-                enable_batch_create = yes
             };
             my $config = Zonemaster::Backend::Config->parse( $text );
-
-            is $config->RPCAPI_enable_add_api_user,  1, 'set: RPCAPI.enable_add_api_user';
-            is $config->RPCAPI_enable_add_batch_job, 0, 'set: RPCAPI.enable_add_batch_job';
-            is $config->RPCAPI_enable_user_create,   0, 'precedence: RPCAPI.enable_user_create';
-            is $config->RPCAPI_enable_batch_create,  1, 'precedence: RPCAPI.enable_batch_create';
         };
-    };
+    }
 
     subtest 'Warnings' => sub {
         $log->clear();

--- a/t/test01.t
+++ b/t/test01.t
@@ -175,7 +175,7 @@ subtest 'API calls' => sub {
 
     subtest 'get_data_from_parent_zone' => sub {
         my $res = $rpcapi->get_data_from_parent_zone( { domain => "fr" } );
-        #diag explain( $res );
+        note explain( $res );
         ok( defined( $res->{ns_list} ), 'Has a list of nameservers' );
         ok( defined( $res->{ds_list} ), 'Has a list of DS records' );
 
@@ -234,7 +234,7 @@ subtest 'get_test_history' => sub {
     };
 
     $test_history = $rpcapi->get_test_history( $method_params );
-    #diag explain( $test_history );
+    note explain( $test_history );
     is( scalar( @$test_history ), 2, 'Two tests created' );
 
     foreach my $res (@$test_history) {
@@ -255,7 +255,7 @@ subtest 'get_test_history' => sub {
         ( $hash_id ) = $rpcapi->{db}->get_test_request();
 
         $test_history = $rpcapi->get_test_history( $method_params );
-        #diag explain( $test_history );
+        note explain( $test_history );
         is( scalar( @$test_history ), 2, 'Only 2 tests should be retrieved' );
 
         # now run the test
@@ -358,9 +358,9 @@ subtest 'check historic tests' => sub {
             }
         } );
 
-    # diag explain( $test_history_delegated );
+    note explain( $test_history_delegated );
     is( scalar( @$test_history_delegated ), 1, 'One delegated test created' );
-    # diag explain( $test_history_undelegated );
+    note explain( $test_history_undelegated );
     is( scalar( @$test_history_undelegated ), 2, 'Two undelegated tests created' );
 
     subtest 'domain is case and trailing dot insensitive' => sub {

--- a/t/test01.t
+++ b/t/test01.t
@@ -86,40 +86,39 @@ my $hash_id;
 # This is the first test added to the DB, its 'id' is 1
 my $test_id = 1;
 subtest 'add a first test' => sub {
-    my $res_job_id = $rpcapi->job_create( $params );
-    $hash_id = $res_job_id->{job_id};
+    $hash_id = $rpcapi->start_domain_test( $params );
 
-    ok( $hash_id, "API job_create OK" );
+    ok( $hash_id, "API start_domain_test OK" );
     is( length($hash_id), 16, "Test has a 16 characters length hash ID (hash_id=$hash_id)" );
 
     my ( $test_id_db, $hash_id_db ) = $dbh->selectrow_array( "SELECT id, hash_id FROM test_results WHERE id=?", undef, $test_id );
-    is( $test_id_db, $test_id , 'API job_create -> Test inserted in the DB' );
+    is( $test_id_db, $test_id , 'API start_domain_test -> Test inserted in the DB' );
     is( $hash_id_db, $hash_id , 'Correct hash_id in database' );
 
-    # test job_status API
-    my $res_job_status = $rpcapi->job_status( { test_id => $hash_id } );
-    is( $res_job_status->{progress}, 0 , 'Test has been created, its progress is 0' );
+    # test test_progress API
+    my $progress = $rpcapi->test_progress( { test_id => $hash_id } );
+    is( $progress, 0 , 'Test has been created, its progress is 0' );
 };
 
 subtest 'get and run test' => sub {
     my ( $hash_id_from_db ) = $rpcapi->{db}->get_test_request();
     is( $hash_id_from_db, $hash_id, 'Get correct test to run' );
 
-    my $res_job_status = $rpcapi->job_status( { test_id => $hash_id } );
-    is( $res_job_status->{progress}, 1, 'Test has been picked, its progress is 1' );
+    my $progress = $rpcapi->test_progress( { test_id => $hash_id } );
+    is( $progress, 1, 'Test has been picked, its progress is 1' );
 
     diag "running the agent on test $hash_id";
     $agent->run( $hash_id ); # blocking call
 
-    $res_job_status = $rpcapi->job_status( { test_id => $hash_id } );
-    is( $res_job_status->{progress}, 100 , 'Test has finished, its progress is 100' );
+    $progress = $rpcapi->test_progress( { test_id => $hash_id } );
+    is( $progress, 100 , 'Test has finished, its progress is 100' );
 };
 
 subtest 'API calls' => sub {
 
-    subtest 'job_results' => sub {
+    subtest 'get_test_results' => sub {
         local $@ = undef;
-        my $res = eval { $rpcapi->job_results( { id => $hash_id, language => 'en' } ) };
+        my $res = eval { $rpcapi->get_test_results( { id => $hash_id, language => 'en' } ) };
         if ( $@ ) {
             fail 'Crashed while fetching job results: ' . Dumper( $@ );
         }
@@ -137,8 +136,8 @@ subtest 'API calls' => sub {
         }
     };
 
-    subtest 'job_params' => sub {
-        my $res = $rpcapi->job_params( { test_id => $hash_id } );
+    subtest 'get_test_params' => sub {
+        my $res = $rpcapi->get_test_params( { test_id => $hash_id } );
         is( $res->{domain}, $params->{domain}, 'Retrieve the correct "domain" value' );
         is( $res->{profile}, $params->{profile}, 'Retrieve the correct "profile" value' );
         is( $res->{client_id}, $params->{client_id}, 'Retrieve the correct "client_id" value' );
@@ -149,34 +148,33 @@ subtest 'API calls' => sub {
         is_deeply( $res->{ds_info}, $params->{ds_info}, 'Retrieve the correct "ds_info" value' );
     };
 
-    subtest 'user_create' => sub {
+    subtest 'add_api_user' => sub {
         my $res;
         eval {
-            $res = $rpcapi->user_create( { username => "zonemaster_test", api_key => "zonemaster_test's api key" } );
+            $res = $rpcapi->add_api_user( { username => "zonemaster_test", api_key => "zonemaster_test's api key" } );
         };
-        is( $res->{success}, 1, 'API user_create success');
+        is( $res, 1, 'API add_api_user success');
 
         my $user_check_query = q/SELECT * FROM users WHERE username = 'zonemaster_test'/;
-        is( scalar( $dbh->selectrow_array( $user_check_query ) ), 1 ,'API user_create user created' );
+        is( scalar( $dbh->selectrow_array( $user_check_query ) ), 1 ,'API add_api_user user created' );
     };
 
-    subtest 'system_versions' => sub {
-        my $res = $rpcapi->system_versions();
+    subtest 'version_info' => sub {
+        my $res = $rpcapi->version_info();
         ok( defined( $res->{zonemaster_ldns} ), 'Has a "zonemaster_ldns" key' );
         ok( defined( $res->{zonemaster_engine} ), 'Has a "zonemaster_engine" key' );
         ok( defined( $res->{zonemaster_backend} ), 'Has a "zonemaster_backend" key' );
     };
 
-    subtest 'conf_profiles' => sub {
-        my $res = $rpcapi->conf_profiles();
-        my $profiles = $res->{profiles};
-        is( scalar( @$profiles ), 2, 'There are exactly 2 public profiles' );
-        ok( grep( /default/, @$profiles ), 'The profile "default" is defined' );
-        ok( grep( /test_profile/, @$profiles ), 'The profile "test_profile" is defined' );
+    subtest 'profile_names' => sub {
+        my $res = $rpcapi->profile_names();
+        is( scalar( @$res ), 2, 'There are exactly 2 public profiles' );
+        ok( grep( /default/, @$res ), 'The profile "default" is defined' );
+        ok( grep( /test_profile/, @$res ), 'The profile "test_profile" is defined' );
     };
 
-    subtest 'lookup_delegation_data' => sub {
-        my $res = $rpcapi->lookup_delegation_data( { domain => "fr" } );
+    subtest 'get_data_from_parent_zone' => sub {
+        my $res = $rpcapi->get_data_from_parent_zone( { domain => "fr" } );
         #diag explain( $res );
         ok( defined( $res->{ns_list} ), 'Has a list of nameservers' );
         ok( defined( $res->{ds_list} ), 'Has a list of DS records' );
@@ -211,23 +209,22 @@ subtest 'API calls' => sub {
 
 # start a second test with IPv6 disabled
 $params->{ipv6} = 0;
-my $job_res = $rpcapi->job_create( $params );
-$hash_id = $job_res->{job_id};
+$hash_id = $rpcapi->start_domain_test( $params );
 diag "running the agent on test $hash_id";
 $agent->run($hash_id);
 
 subtest 'second test has IPv6 disabled' => sub {
-    my $res = $rpcapi->job_params( { test_id => $hash_id } );
+    my $res = $rpcapi->get_test_params( { test_id => $hash_id } );
     is( $res->{ipv4}, $params->{ipv4}, 'Retrieve the correct "ipv4" value' );
     is( $res->{ipv6}, $params->{ipv6}, 'Retrieve the correct "ipv6" value' );
 
-    $res = $rpcapi->job_results( { id => $hash_id, language => 'en' } );
+    $res = $rpcapi->get_test_results( { id => $hash_id, language => 'en' } );
     my @msgs = map { $_->{message} } @{ $res->{results} };
     ok( grep( /IPv6 is disabled/, @msgs ), 'Results contain an "IPv6 is disabled" message' );
 };
 
-my $domain_history;
-subtest 'domain_history' => sub {
+my $test_history;
+subtest 'get_test_history' => sub {
     my $offset = 0;
     my $limit  = 10;
     my $method_params = {
@@ -236,11 +233,11 @@ subtest 'domain_history' => sub {
         limit => $limit
     };
 
-    my $res_domain_history = $rpcapi->domain_history( $method_params );
-    $domain_history = $res_domain_history->{history};
-    is( scalar( @$domain_history ), 2, 'Two tests created' );
+    $test_history = $rpcapi->get_test_history( $method_params );
+    #diag explain( $test_history );
+    is( scalar( @$test_history ), 2, 'Two tests created' );
 
-    foreach my $res (@$domain_history) {
+    foreach my $res (@$test_history) {
         is( length($res->{id}), 16, 'Test has 16 characters length hash ID' );
         is( $res->{undelegated}, JSON::PP::true, 'Test is undelegated' );
         ok( ! exists $res->{creation_time}, 'Key "creation_time" should be missing' );
@@ -254,21 +251,19 @@ subtest 'domain_history' => sub {
         $params->{ipv4} = 0;
 
         # create the test, retrieve its id but we don't run it
-        $rpcapi->job_create( $params );
+        $rpcapi->start_domain_test( $params );
         ( $hash_id ) = $rpcapi->{db}->get_test_request();
 
-        my $res_domain_history;
-        $res_domain_history = $rpcapi->domain_history( $method_params );
-        $domain_history = $res_domain_history->{history};
-        is( scalar( @$domain_history ), 2, 'Only 2 tests should be retrieved' );
+        $test_history = $rpcapi->get_test_history( $method_params );
+        #diag explain( $test_history );
+        is( scalar( @$test_history ), 2, 'Only 2 tests should be retrieved' );
 
         # now run the test
         diag "running the agent on test $hash_id";
         $agent->run( $hash_id );
 
-        $res_domain_history = $rpcapi->domain_history( $method_params );
-        $domain_history = $res_domain_history->{history};
-        is( scalar( @$domain_history ), 3, 'Now 3 tests should be retrieved' );
+        $test_history = $rpcapi->get_test_history( $method_params );
+        is( scalar( @$test_history ), 3, 'Now 3 tests should be retrieved' );
     }
 };
 
@@ -276,13 +271,12 @@ subtest 'mock another client (i.e. reuse a previous test)' => sub {
     $params->{client_id} = 'Another Client';
     $params->{client_version} = '0.1';
 
-    my $res = $rpcapi->job_create( $params );
-    my $new_hash_id = $res->{job_id};
+    my $new_hash_id = $rpcapi->start_domain_test( $params );
 
     is( $new_hash_id, $hash_id, 'Has the same hash than previous test' );
 
     subtest 'check test_params values' => sub {
-        my $res = $rpcapi->job_params( { test_id => "$hash_id" } );
+        my $res = $rpcapi->get_test_params( { test_id => "$hash_id" } );
         # the following values are part of the fingerprint
         is( $res->{domain}, $params->{domain}, 'Retrieve the correct "domain" value' );
         is( $res->{profile}, $params->{profile}, 'Retrieve the correct "profile" value' );
@@ -299,10 +293,10 @@ subtest 'mock another client (i.e. reuse a previous test)' => sub {
 
 subtest 'check historic tests' => sub {
     # Verifies that delegated and undelegated tests are coded correctly when started
-    # and that the filter option in "domain_history" works correctly
+    # and that the filter option in "get_test_history" works correctly
 
     my $domain          = 'xa';
-    # Non-batch for "job_create":
+    # Non-batch for "start_domain_test":
     my $params_un1      = { # undelegated, non-batch
         domain          => $domain,
         nameservers     => [
@@ -318,7 +312,7 @@ subtest 'check historic tests' => sub {
     my $params_dn1 = { # delegated, non-batch
         domain          => $domain,
     };
-    # Batch for "batch_create"
+    # Batch for "add_batch_job"
     my $domain2         = 'xb';
     my $params_ub1      = { # undelegated, batch
         domains         => [ $domain, $domain2 ],
@@ -342,57 +336,51 @@ subtest 'check historic tests' => sub {
     # The batch jobs, $params_ub1, $params_ub2 and $params_db1, cannot be run from here due to limitation in the API. See issue #827.
 
     foreach my $param ($params_un1, $params_un2, $params_dn1) {
-        my $job_res = $rpcapi->job_create( $param );
-        my $testid = $job_res->{job_id};
-        ok( $testid, "API job_create ID OK" );
+        my $testid = $rpcapi->start_domain_test( $param );
+        ok( $testid, "API start_domain_test ID OK" );
         diag "running the agent on test $testid";
         $agent->run( $testid );
-        my $res_job_status = $rpcapi->job_status( { test_id => $testid } );
-        is( $res_job_status->{progress}, 100 , 'API job_status -> Test finished' );
+        is( $rpcapi->test_progress( { test_id => $testid } ), 100 , 'API test_progress -> Test finished' );
     };
 
-    my $res_domain_history_delegated = $rpcapi->domain_history(
+    my $test_history_delegated = $rpcapi->get_test_history(
         {
             filter => 'delegated',
             frontend_params => {
                 domain => $domain,
             }
         } );
-    my $res_domain_history_undelegated = $rpcapi->domain_history(
+    my $test_history_undelegated = $rpcapi->get_test_history(
         {
             filter => 'undelegated',
             frontend_params => {
                 domain => $domain,
             }
         } );
-    my $domain_history_delegated = $res_domain_history_delegated->{history};
-    my $domain_history_undelegated = $res_domain_history_undelegated->{history};
 
-    # diag explain( $domain_history_delegated );
-    is( scalar( @$domain_history_delegated ), 1, 'One delegated test created' );
-    # diag explain( $domain_history_undelegated );
-    is( scalar( @$domain_history_undelegated ), 2, 'Two undelegated tests created' );
+    # diag explain( $test_history_delegated );
+    is( scalar( @$test_history_delegated ), 1, 'One delegated test created' );
+    # diag explain( $test_history_undelegated );
+    is( scalar( @$test_history_undelegated ), 2, 'Two undelegated tests created' );
 
     subtest 'domain is case and trailing dot insensitive' => sub {
-        my $res_domain_history_delegated = $rpcapi->domain_history(
+        my $test_history_delegated = $rpcapi->get_test_history(
             {
                 filter => 'delegated',
                 frontend_params => {
                     domain => $domain . '.',
                 }
             } );
-        my $res_domain_history_undelegated = $rpcapi->domain_history(
+        my $test_history_undelegated = $rpcapi->get_test_history(
             {
                 filter => 'undelegated',
                 frontend_params => {
                     domain => ucfirst( $domain ),
                 }
             } );
-        my $domain_history_delegated = $res_domain_history_delegated->{history};
-        my $domain_history_undelegated = $res_domain_history_undelegated->{history};
 
-        is( scalar( @$domain_history_delegated ), 1, 'One delegated test created' );
-        is( scalar( @$domain_history_undelegated ), 2, 'Two undelegated tests created' );
+        is( scalar( @$test_history_delegated ), 1, 'One delegated test created' );
+        is( scalar( @$test_history_undelegated ), 2, 'Two undelegated tests created' );
     };
 };
 
@@ -411,8 +399,7 @@ subtest 'normalize "domain" column' => sub {
     while ( my ($domain, $expected) = each (%domains_to_test) ) {
         $test_params->{domain} = $domain;
 
-        my $job_res = $rpcapi->job_create( $test_params );
-        $hash_id = $job_res->{job_id};
+        $hash_id = $rpcapi->start_domain_test( $test_params );
         my ( $db_domain ) = $dbh->selectrow_array( "SELECT domain FROM test_results WHERE hash_id=?", undef, $hash_id );
         is( $db_domain, $expected, 'stored domain name is normalized' );
     }

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -33,8 +33,8 @@ my $engine = Zonemaster::Backend::RPCAPI->new(
     }
 );
 
-sub job_create_validate_params {
-    return $engine->validate_params( $Zonemaster::Backend::RPCAPI::json_schemas{job_create}, @_ );
+sub start_domain_validate_params {
+    return $engine->validate_params( $Zonemaster::Backend::RPCAPI::json_schemas{start_domain_test}, @_ );
 }
 
 subtest 'Everything but NoWarnings' => sub {
@@ -52,7 +52,7 @@ subtest 'Everything but NoWarnings' => sub {
     ];
 
     subtest 'domain present' => sub {
-        my @res = job_create_validate_params(
+        my @res = start_domain_validate_params(
             {
                 %$frontend_params, domain => 'afnic.fr'
             }
@@ -62,7 +62,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest 'consecutive dots' => sub {
-        my @res = job_create_validate_params(
+        my @res = start_domain_validate_params(
             {
                 %$frontend_params, domain => 'afnic..fr'
             }
@@ -72,7 +72,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest encode_utf8( 'idn domain=[é]' ) => sub {
-        my @res = job_create_validate_params(
+        my @res = start_domain_validate_params(
             {
                 %$frontend_params, domain => 'é'
             }
@@ -83,7 +83,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest encode_utf8( 'idn domain=[éé]' ) => sub {
-        my @res = job_create_validate_params(
+        my @res = start_domain_validate_params(
             {
                 %$frontend_params, domain => 'éé'
             }
@@ -94,7 +94,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest '253 characters long domain without dot' => sub {
-        my @res = job_create_validate_params(
+        my @res = start_domain_validate_params(
             {
                 %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com'
             }
@@ -105,7 +105,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest '254 characters long domain with trailing dot' => sub {
-        my @res = job_create_validate_params(
+        my @res = start_domain_validate_params(
             {
                 %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.'
             }
@@ -116,7 +116,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest '254 characters long domain without trailing dot' => sub {
-        my @res = job_create_validate_params(
+        my @res = start_domain_validate_params(
             {
                 %$frontend_params, domain => '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club'
             }
@@ -127,7 +127,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest '63 characters long domain label' => sub {
-        my @res = job_create_validate_params(
+        my @res = start_domain_validate_params(
             {
                 %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789-63.fr'
             }
@@ -138,7 +138,7 @@ subtest 'Everything but NoWarnings' => sub {
     };
 
     subtest '64 characters long domain label' => sub {
-        my @res = job_create_validate_params(
+        my @res = start_domain_validate_params(
             {
                 %$frontend_params, domain => '012345678901234567890123456789012345678901234567890123456789--64.fr'
             }
@@ -154,81 +154,81 @@ subtest 'Everything but NoWarnings' => sub {
 
     # domain present?
     $frontend_params->{nameservers}->[0]->{ns} = 'afnic.fr';
-    is( scalar job_create_validate_params( $frontend_params ), 0, 'domain present' );
+    is( scalar start_domain_validate_params( $frontend_params ), 0, 'domain present' );
 
     # idn
     $frontend_params->{nameservers}->[0]->{ns} = 'é';
-    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'idn domain=[é]' ) )
-        or diag( encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'idn domain=[é]' ) )
+        or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     # idn
     $frontend_params->{nameservers}->[0]->{ns} = 'éé';
-    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'idn domain=[éé]' ) )
-        or diag( encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'idn domain=[éé]' ) )
+        or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     # 253 characters long domain without dot
     $frontend_params->{nameservers}->[0]->{ns} =
     '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com';
     is(
-        scalar job_create_validate_params( $frontend_params ), 0,
+        scalar start_domain_validate_params( $frontend_params ), 0,
         encode_utf8( '253 characters long domain without dot' )
-    ) or diag( encode_json job_create_validate_params( $frontend_params ) );
+    ) or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     # 254 characters long domain with trailing dot
     $frontend_params->{nameservers}->[0]->{ns} =
     '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.com.';
     is(
-        scalar job_create_validate_params( $frontend_params ), 0,
+        scalar start_domain_validate_params( $frontend_params ), 0,
         encode_utf8( '254 characters long domain with trailing dot' )
-    ) or diag( encode_json job_create_validate_params( $frontend_params ) );
+    ) or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     # 254 characters long domain without trailing
     $frontend_params->{nameservers}->[0]->{ns} =
     '123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.123456789.club';
     cmp_ok(
-        scalar job_create_validate_params( $frontend_params ), '>', 0,
+        scalar start_domain_validate_params( $frontend_params ), '>', 0,
         encode_utf8( '254 characters long domain without trailing dot' )
-    ) or diag( encode_jsonjob_create_validate_params( $frontend_params ) );
+    ) or diag( encode_jsonstart_domain_validate_params( $frontend_params ) );
 
     # 63 characters long domain label
     $frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-63.fr';
     is(
-        scalar job_create_validate_params( $frontend_params ), 0,
+        scalar start_domain_validate_params( $frontend_params ), 0,
         encode_utf8( '63 characters long domain label' )
-    ) or diag( encode_json job_create_validate_params( $frontend_params ) );
+    ) or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     # 64 characters long domain label
     $frontend_params->{nameservers}->[0]->{ns} = '012345678901234567890123456789012345678901234567890123456789-64-.fr';
-    cmp_ok( scalar job_create_validate_params( $frontend_params ), '>', 0,
+    cmp_ok( scalar start_domain_validate_params( $frontend_params ), '>', 0,
         encode_utf8( '64 characters long domain label' ) )
-        or diag(encode_json job_create_validate_params( $frontend_params ) );
+        or diag(encode_json start_domain_validate_params( $frontend_params ) );
 
     # DELEGATED TEST
     delete( $frontend_params->{nameservers} );
 
     $frontend_params->{domain} = 'afnic.fr';
-    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'delegated domain exists' ) )
-        or diag( encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'delegated domain exists' ) )
+        or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     # IP ADDRESS FORMAT
     $frontend_params->{domain} = 'afnic.fr';
     $frontend_params->{nameservers}->[0]->{ns} = 'ns1.nic.fr';
 
     $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4';
-    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'Valid IPV4' ) )
-        or diag( encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'Valid IPV4' ) )
+        or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     $frontend_params->{nameservers}->[0]->{ip} = '1.2.3.4444';
-    cmp_ok( scalar job_create_validate_params( $frontend_params ), '>', 0, encode_utf8( 'Invalid IPV4' ) )
-        or diag( encode_json job_create_validate_params( $frontend_params ) );
+    cmp_ok( scalar start_domain_validate_params( $frontend_params ), '>', 0, encode_utf8( 'Invalid IPV4' ) )
+        or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     $frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bb';
-    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'Valid IPV6' ) )
-        or diag( encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'Valid IPV6' ) )
+        or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     $frontend_params->{nameservers}->[0]->{ip} = 'fe80::6ef0:49ff:fe7b:e4bbffffff';
-    cmp_ok( job_create_validate_params( $frontend_params ), '>', 0, encode_utf8( 'Invalid IPV6' ) )
-        or diag( encode_json job_create_validate_params( $frontend_params ) );
+    cmp_ok( start_domain_validate_params( $frontend_params ), '>', 0, encode_utf8( 'Invalid IPV6' ) )
+        or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     # DS
     $frontend_params->{domain}                 = 'afnic.fr';
@@ -240,50 +240,50 @@ subtest 'Everything but NoWarnings' => sub {
     $frontend_params->{ds_info}->[0]->{digtype}   = 1;
     $frontend_params->{ds_info}->[0]->{keytag}   = 5000;
 
-    is( scalar job_create_validate_params( $frontend_params ), 0, encode_utf8( 'Valid Algorithm Type [numeric format]' ) )
-        or diag( encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 0, encode_utf8( 'Valid Algorithm Type [numeric format]' ) )
+        or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{algorithm} = 'a';
     $frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
-    is( scalar job_create_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid Algorithm Type' ) )
-        or diag(  encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid Algorithm Type' ) )
+        or diag(  encode_json start_domain_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{algorithm} = 1;
     $frontend_params->{ds_info}->[0]->{digest}    = '01234567890123456789012345678901234567890';
-    is( scalar job_create_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest length' ) )
-        or diag( encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest length' ) )
+        or diag( encode_json start_domain_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{digest}    = 'Z123456789012345678901234567890123456789';
-    is( scalar job_create_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest format' ) )
-        or diag(  encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest format' ) )
+        or diag(  encode_json start_domain_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{digest}    = '0123456789012345678901234567890123456789';
     $frontend_params->{ds_info}->[0]->{digtype} = -1;
-    is( scalar job_create_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest type' ) )
-        or diag(  encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid digest type' ) )
+        or diag(  encode_json start_domain_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{digtype} = 1;
     $frontend_params->{ds_info}->[0]->{keytag} = 'not a int';
-    is( scalar job_create_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid keytag' ) )
-        or diag(  encode_json job_create_validate_params( $frontend_params ) );
+    is( scalar start_domain_validate_params( $frontend_params ), 1, encode_utf8( 'Invalid keytag' ) )
+        or diag(  encode_json start_domain_validate_params( $frontend_params ) );
 
     $frontend_params->{ds_info}->[0]->{keytag} = 5000;
 
     {
         local $frontend_params->{language} = "zz";
-        my @res = job_create_validate_params( $frontend_params );
+        my @res = start_domain_validate_params( $frontend_params );
         is( scalar @res, 1, 'Invalid language, "zz" unknown' ) or diag(  explain \@res );
     }
 
     {
         local $frontend_params->{language} = "fr-FR";
-        my @res = job_create_validate_params( $frontend_params );
+        my @res = start_domain_validate_params( $frontend_params );
         is( scalar @res, 1, 'Invalid language tag syntax' ) or diag(  explain \@res );
     }
 
     {
         local $frontend_params->{language} = "nb_NO";
-        my @res = job_create_validate_params( $frontend_params );
+        my @res = start_domain_validate_params( $frontend_params );
         is( scalar @res, 1, 'Invalid language tag syntax' ) or diag(  explain \@res );
     }
 };


### PR DESCRIPTION
## Purpose

Remove deprecation warning and comments to all old RPC API methods and mark the new methods as experimental.
What were the deprecated methods (and old stable) are again the default stable API methods.

## Context

https://github.com/zonemaster/zonemaster/issues/1159

Relates to https://github.com/zonemaster/zonemaster-backend/pull/1054 and https://github.com/zonemaster/zonemaster-backend/pull/1083.

## Changes

Revert commits where old methods were deprecated and based upon new methods. Now the experimental methods are based on the stable one.

## How to test this PR

* Unit tests should pass
* Review the code and verify that the unit tests cover the stable API
* Check that the new experimental API is working (there is currently no unit test)
* Check that changes made in Backend for this release are still working (and have not been inadvertently reverted)
