### PR TITLE
Remove multiple batch restriction

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -398,23 +398,6 @@ sub create_new_batch_job {
     my ( $self, $username ) = @_;
 
     my $dbh = $self->dbh;
-    my ( $batch_id, $created_at ) = $dbh->selectrow_array( "
-            SELECT
-                batch_id,
-                batch_jobs.created_at AS batch_created_at
-            FROM
-                test_results
-            JOIN batch_jobs
-                ON batch_id = batch_jobs.id
-                AND username = ?
-            WHERE
-                test_results.progress <> 100
-            LIMIT 1
-            ", undef, $username );
-
-    die Zonemaster::Backend::Error::Conflict->new( message => 'Batch job still running', data => { batch_id => $batch_id, created_at => $created_at } )
-        if ( $batch_id );
-
     $dbh->do( q[ INSERT INTO batch_jobs (username, created_at) VALUES (?,?) ],
         undef,
         $username,

--- a/t/batches.t
+++ b/t/batches.t
@@ -256,19 +256,18 @@ subtest 'batch job still running' => sub {
 
     is( $batch_id, 1, 'correct batch job id returned' );
 
-    dies_ok {
-        my $new_batch_id = $rpcapi->add_batch_job(
+
+    subtest 'a batch is already running for the user, new batch creation should not fail' => sub {
+        my $batch_id = $rpcapi->add_batch_job(
             {
                 %$user,
                 domains => \@domains,
                 test_params => $params
             }
         );
-    } 'a batch is already running for the user, new batch creation should fail' ;
-    my $res = $@;
-    is( $res->{message}, 'Batch job still running', 'correct error message' );
-    is( $res->{data}->{batch_id}, $batch_id, 'error returned current running batch id' );
-    ok( $res->{data}->{created_at}, 'error data contains batch creation time' );
+
+        is( $batch_id, 2, 'same user can create another batch' );
+    };
 
     subtest 'use another user' => sub {
         my $another_user = { username => 'another', api_key => 'token' };
@@ -281,7 +280,7 @@ subtest 'batch job still running' => sub {
             }
         );
 
-        is( $batch_id, 2, 'another_user can create another batch' );
+        is( $batch_id, 3, 'another_user can create another batch' );
     };
 };
 


### PR DESCRIPTION
## Purpose

There is an artificial restriction on multiple concurrent batches with the same user, i.e. the second batch cannot be created until the first has completed. It does not give any protection on overload since a batch user can create batch with a million zones, but not two concurrent batches with 1000 each. There can be good reasons to create multiple batches if the different batches should use profile or different settings.

This PR removes the restriction. It also adjusts the unit test.

The documentation is updated in https://github.com/zonemaster/zonemaster/pull/1178

## How to test this PR

Before this PR try with the following two commands, and the second will be refused (assuming batch is accepted and `USER` is a batch user with API key `KEY`):

```
zmb add_batch_job --username USER --api-key KEY --domain iis.se --domain arpa --domain com --domain info --domain se
```
Then repeat after this PR has been applied.
