### PR TITLE
Synchronized claiming of jobs for processing

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -52,11 +52,48 @@ has 'dbhandle' => (
     required => 1,
 );
 
-Readonly our $TEST_WAITING   => 'waiting';
-Readonly our $TEST_RUNNING   => 'running';
+=head2 $TEST_WAITING
+
+The test is waiting to be processed.
+
+=cut
+
+Readonly our $TEST_WAITING => 'waiting';
+
+=head2 $TEST_RUNNING
+
+The test is currently being processed.
+
+=cut
+
+Readonly our $TEST_RUNNING => 'running';
+
+=head2 $TEST_COMPLETED
+
+The test was already processed.
+The Zonemaster Engine test terminated normally.
+
+=cut
+
 Readonly our $TEST_COMPLETED => 'completed';
-Readonly our $TEST_CRASHED   => 'crashed';
-Readonly our $TEST_LAPSED    => 'lapsed';
+
+=head2 $TEST_CRASHED
+
+The test was already processed.
+A critical error occurred while processing.
+
+=cut
+
+Readonly our $TEST_CRASHED => 'crashed';
+
+=head2 $TEST_LAPSED
+
+The test was already processed.
+The processing was cancelled because it took too long.
+
+=cut
+
+Readonly our $TEST_LAPSED => 'lapsed';
 
 our @EXPORT_OK = qw(
     $TEST_WAITING

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -262,7 +262,7 @@ an error occurs in the database interface
 sub test_progress {
     my ( $self, $test_id, $progress ) = @_;
 
-    if ( $progress ) {
+    if ( defined $progress ) {
         if ( $progress < 0 || 100 < $progress ) {
             die Zonemaster::Backend::Error::Internal->new( reason => "progress out of range" );
         } elsif ( $progress < 1 ) {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -94,22 +94,6 @@ The processing was cancelled because it took too long.
 
 Readonly our $TEST_COMPLETED => 'COMPLETED';
 
-=head2 $TEST_CRASHED
-
-The test was already processed.
-
-=cut
-
-Readonly our $TEST_CRASHED => 'crashed';
-
-=head2 $TEST_LAPSED
-
-The test was already processed.
-
-=cut
-
-Readonly our $TEST_LAPSED => 'lapsed';
-
 our @EXPORT_OK = qw(
     $TEST_WAITING
     $TEST_RUNNING

--- a/t/idn.t
+++ b/t/idn.t
@@ -75,7 +75,8 @@ subtest 'test IDN domain' => sub {
 };
 
 # run the test
-$db->claim_test( $test_id );
+$db->claim_test( $test_id )
+  or BAIL_OUT( "test needs to be claimed before calling run()" );
 $agent->run( $test_id ); # blocking call
 
 subtest 'test get_test_results' => sub {
@@ -96,7 +97,8 @@ subtest 'test IDN nameserver' => sub {
     };
 
     # run the test
-    $db->claim_test( $test_id );
+    $db->claim_test( $test_id )
+      or BAIL_OUT( "test needs to be claimed before calling run()" );
     $agent->run( $test_id ); # blocking call
 
     subtest 'test_results' => sub {

--- a/t/idn.t
+++ b/t/idn.t
@@ -75,6 +75,7 @@ subtest 'test IDN domain' => sub {
 };
 
 # run the test
+$db->claim_test( $test_id );
 $agent->run( $test_id ); # blocking call
 
 subtest 'test get_test_results' => sub {
@@ -95,6 +96,7 @@ subtest 'test IDN nameserver' => sub {
     };
 
     # run the test
+    $db->claim_test( $test_id );
     $agent->run( $test_id ); # blocking call
 
     subtest 'test_results' => sub {

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -77,19 +77,20 @@ subtest 'Everything but Test::NoWarnings' => sub {
 
         subtest 'Testid reuse' => sub {
             my $testid1 = $db->create_new_test( "zone1.rpcapi.example", {}, 10 );
+            is ref $testid1, '', 'create_new_test returns "testid" scalar';
+
             advance_time( 11 );
             my $testid2 = $db->create_new_test( "zone1.rpcapi.example", {}, 10 );
+            is $testid2, $testid1, 'reuse is determined from start time (as opposed to creation time)';
 
             $db->test_progress( $testid1, 1 );    # mark test as started
             advance_time( 10 );
 
             my $testid3 = $db->create_new_test( "zone1.rpcapi.example", {}, 10 );
+            is $testid3, $testid1, 'old testid is reused before it expires';
+
             advance_time( 1 );
             my $testid4 = $db->create_new_test( "zone1.rpcapi.example", {}, 10 );
-
-            is ref $testid1, '', 'start_domain_test returns "testid" scalar';
-            is $testid2,   $testid1, 'reuse is determined from start time (as opposed to creation time)';
-            is $testid3,   $testid1, 'old testid is reused before it expires';
             isnt $testid4, $testid1, 'a new testid is generated after the old one expires';
         };
 

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -132,6 +132,18 @@ subtest 'Everything but Test::NoWarnings' => sub {
             }
         };
 
+        subtest 'Progress' => sub {
+            my $testid1 = $db->create_new_test( "1.progress.test", {}, 10 );
+            is ref $testid1, '', "create_new_test should return 'testid' scalar";
+
+            is $db->test_progress( $testid1, 2 ), 2, "Setting a higher progress should be allowed,";
+            is $db->test_progress( $testid1 ),    2, "and it should persist at the new value.";
+            is $db->test_progress( $testid1, 2 ), 2, "Setting the same progress again should succeed.";
+
+            is $db->test_progress( $testid1, 100 ), 99, "Setting progress to 100 should succeed, but actual clamped value is returned,";
+            is $db->test_progress( $testid1 ),      99, "and it should persist at the clamped value.";
+        };
+
         subtest 'Testid reuse' => sub {
             my $testid1 = $db->create_new_test( "zone1.rpcapi.example", {}, 10 );
             is ref $testid1, '', 'create_new_test returns "testid" scalar';

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -92,14 +92,24 @@ subtest 'Everything but Test::NoWarnings' => sub {
                 {
                     old_state  => $TEST_WAITING,
                     transition => ['claim_test'],
-                    returns    => undef,
+                    returns    => 1,                # true
                     new_state  => $TEST_RUNNING,
+                },
+                {
+                    old_state  => $TEST_RUNNING,
+                    transition => ['claim_test'],
+                    returns    => '',               # false
                 },
                 {
                     old_state  => $TEST_RUNNING,
                     transition => [ 'store_results', '{}' ],
                     returns    => undef,
                     new_state  => $TEST_COMPLETED,
+                },
+                {
+                    old_state  => $TEST_COMPLETED,
+                    transition => ['claim_test'],
+                    returns    => '',                #false
                 },
                 {
                     old_state  => $TEST_COMPLETED,

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -174,6 +174,9 @@ subtest 'Everything but Test::NoWarnings' => sub {
             is $db->test_progress( $testid1 ),    2, "and it should persist at the new value.";
             is $db->test_progress( $testid1, 2 ), 2, "Setting the same progress again should succeed.";
 
+            throws_ok { $db->test_progress( $testid1, 0 ) } qr/illegal update/, "Setting a lower progress should throw an exception,";
+            is $db->test_progress( $testid1 ), 2, "and it should persist at the old value.";
+
             is $db->test_progress( $testid1, 100 ), 99, "Setting progress to 100 should succeed, but actual clamped value is returned,";
             is $db->test_progress( $testid1 ),      99, "and it should persist at the clamped value.";
 

--- a/t/queue.t
+++ b/t/queue.t
@@ -1,0 +1,86 @@
+use strict;
+use warnings;
+use 5.14.2;
+
+use Test::More tests => 2;
+use Test::NoWarnings;
+use Log::Any::Test;
+
+use File::Basename        qw( dirname );
+use File::Spec::Functions qw( rel2abs );
+use File::Temp            qw( tempdir );
+use Log::Any              qw( $log );
+use Test::Differences;
+use Test::Exception;
+use Zonemaster::Backend::Config;
+use Zonemaster::Backend::DB qw( $TEST_RUNNING );
+use Zonemaster::Engine;
+
+my $t_path;
+BEGIN {
+    $t_path = dirname( rel2abs( $0 ) );
+}
+use lib $t_path;
+use TestUtil;
+
+my $db_backend = TestUtil::db_backend();
+my $tempdir    = tempdir( CLEANUP => 1 );
+my $config     = Zonemaster::Backend::Config->parse( <<EOF );
+[DB]
+engine = $db_backend
+
+[MYSQL]
+host     = localhost
+user     = travis_zm
+password = travis_zonemaster
+database = travis_zonemaster
+
+[POSTGRESQL]
+host     = localhost
+user     = travis_zonemaster
+password = travis_zonemaster
+database = travis_zonemaster
+
+[SQLITE]
+database_file = $tempdir/zonemaster.sqlite
+
+[ZONEMASTER]
+age_reuse_previous_test = 10
+EOF
+
+subtest 'Everything but Test::NoWarnings' => sub {
+    lives_ok {    # Make sure we get to print log messages in case of errors.
+        my $db = TestUtil::init_db( $config );
+
+        subtest 'Claiming waiting tests for processing' => sub {
+            eq_or_diff
+              [ $db->get_test_request( undef ) ],
+              [ undef, undef ],
+              "An empty list is returned when queue is empty";
+
+            my $testid1 = $db->create_new_test( "1.claim.test", {}, 10 );
+            eq_or_diff
+              [ $db->get_test_request( undef ) ],
+              [ $testid1, undef ],
+              "A waiting test is returned if one is available";
+            eq_or_diff
+              [ $db->get_test_request( undef ) ],
+              [ undef, undef ],
+              "Claimed test is removed from queue";
+            is
+              $db->test_state( $testid1 ),
+              $TEST_RUNNING,
+              "Claimed test is in 'running' state";
+        };
+    };
+};
+
+for my $msg ( @{ $log->msgs } ) {
+    my $text = sprintf( "%s: %s", $msg->{level}, $msg->{message} );
+    if ( $msg->{level} =~ /trace|debug|info|notice/ ) {
+        note $text;
+    }
+    else {
+        diag $text;
+    }
+}

--- a/t/test01.t
+++ b/t/test01.t
@@ -210,7 +210,8 @@ subtest 'API calls' => sub {
 # start a second test with IPv6 disabled
 $params->{ipv6} = 0;
 $hash_id = $rpcapi->start_domain_test( $params );
-$rpcapi->{db}->claim_test( $hash_id );
+$rpcapi->{db}->claim_test( $hash_id )
+  or BAIL_OUT( "test needs to be claimed before calling run()" );
 diag "running the agent on test $hash_id";
 $agent->run($hash_id);
 
@@ -339,7 +340,8 @@ subtest 'check historic tests' => sub {
     foreach my $param ($params_un1, $params_un2, $params_dn1) {
         my $testid = $rpcapi->start_domain_test( $param );
         ok( $testid, "API start_domain_test ID OK" );
-        $rpcapi->{db}->claim_test( $testid );
+        $rpcapi->{db}->claim_test( $testid )
+          or BAIL_OUT( "test needs to be claimed before calling run()" );
         diag "running the agent on test $testid";
         $agent->run( $testid );
         is( $rpcapi->test_progress( { test_id => $testid } ), 100 , 'API test_progress -> Test finished' );

--- a/t/test01.t
+++ b/t/test01.t
@@ -210,6 +210,7 @@ subtest 'API calls' => sub {
 # start a second test with IPv6 disabled
 $params->{ipv6} = 0;
 $hash_id = $rpcapi->start_domain_test( $params );
+$rpcapi->{db}->claim_test( $hash_id );
 diag "running the agent on test $hash_id";
 $agent->run($hash_id);
 
@@ -338,6 +339,7 @@ subtest 'check historic tests' => sub {
     foreach my $param ($params_un1, $params_un2, $params_dn1) {
         my $testid = $rpcapi->start_domain_test( $param );
         ok( $testid, "API start_domain_test ID OK" );
+        $rpcapi->{db}->claim_test( $testid );
         diag "running the agent on test $testid";
         $agent->run( $testid );
         is( $rpcapi->test_progress( { test_id => $testid } ), 100 , 'API test_progress -> Test finished' );


### PR DESCRIPTION
## Purpose

Make it possible for multiple Test Agents to process the same queue without multiple workers running the same job.

In #1115 @matsduf said:
> When a large batch is to be tested, adding several Test Agents increases performance if the server has large capacity. Several servers could also be used. One limitation is that current code only allows one Test Agent per queue. All [jobs] in a batch always belong to the same queue.

## Meta

In this PR description I'm using the term "job" instead of the traditional term "test". Speaking of *the testing of jobs* is less confusing than speaking of *the testing of tests*.

However in the code changes I used the term "test" in anticipation of "the great renaming".

## Context

* Replaces #1115.

## Changes

#### Reviewing
The easiest way to review this is probably to do it commit by commit.

#### New constants
* `$TEST_{WAITING,RUNNING,COMPLETED`~`,CRASHED,LAPSED`~`}` are introduced to represent the different states of a job.

#### New methods
* `test_state()` is introduced to query the state of a job.
* `claim_test()` is introduced to transition jobs from "waiting" to "running".

#### Updated methods
* `get_test_request()` synchronizes its claiming of jobs.
* when `get_test_request()` finds a job that it then fails to claim, it immediately tries to find and claim another one.
* `test_progress()` is no longer able to update the state of a job.
* `test_progress()` is no longer able to update the progress value of a job that is not "running".
* `test_progress()` is no longer able to decrease the progress value of a job.
* `test_progress(0)` is now interpreted as a request to set the progress value to zero, rather than a request to read the current progress value.
* `store_results()` is no longer able to update a job that is not "running".

#### New test files
* `t/queue.t` is introduced to test the claiming of waiting jobs. The `t/lifecycle.t` already has some code to exercise reuse of jobs which is quite related. However I wanted to make sure the test database was clean for the claiming tests and this is what I ended up with. Maybe `t/lifecycle.t` should be reserved for testing individual jobs and `t/queue.t` could test the enqueuing and dequeuing of jobs.

## How to test this PR

* Run a large batch with one Test Agent and nothing should be changed.
* Run a large batch with two Test Agents (the same queue) and there should be no cases when the same job is run by more than one worker.