### PR TITLE
use name normalization method

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -875,7 +875,7 @@ sub process_dead_test {
 sub _normalize_domain {
     my ( $domain ) = @_;
 
-    # Discard errors, at this point errors have already checked
+    # Discard errors, at this point errors have already been checked
     my ( $_errors, $normalized_domain ) = normalize_name( $domain );
 
     return $normalized_domain;

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -16,6 +16,7 @@ use POSIX qw( strftime );
 use Readonly;
 use Try::Tiny;
 
+use Zonemaster::Engine::Normalization;
 use Zonemaster::Backend::Errors;
 use Zonemaster::Engine::Logger::Entry;
 
@@ -874,10 +875,10 @@ sub process_dead_test {
 sub _normalize_domain {
     my ( $domain ) = @_;
 
-    $domain = lc( $domain );
-    $domain =~ s/\.$// unless $domain eq '.';
+    # Discard errors, at this point errors have already checked
+    my ( $_errors, $normalized_domain ) = normalize_name( $domain );
 
-    return $domain;
+    return $normalized_domain;
 }
 
 sub _project_params {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -875,8 +875,11 @@ sub process_dead_test {
 sub _normalize_domain {
     my ( $domain ) = @_;
 
-    # Discard errors, at this point errors have already been checked
-    my ( $_errors, $normalized_domain ) = normalize_name( $domain );
+    my ( $errors, $normalized_domain ) = normalize_name( $domain );
+
+    if ( scalar( @{$errors} ) ) {
+        die Zonemaster::Backend::Error::Internal->new( reason => "Normalizing domain returned errors.", data => $errors );
+    }
 
     return $normalized_domain;
 }

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -878,7 +878,7 @@ sub _normalize_domain {
     my ( $errors, $normalized_domain ) = normalize_name( $domain );
 
     if ( scalar( @{$errors} ) ) {
-        die Zonemaster::Backend::Error::Internal->new( reason => "Normalizing domain returned errors.", data => $errors );
+        die Zonemaster::Backend::Error::Internal->new( reason => "Normalizing domain returned errors.", data => [ map { $_->string } @{$errors} ] );
     }
 
     return $normalized_domain;

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -284,8 +284,8 @@ sub check_domain {
 
     my ( $errors, $_domain ) = normalize_name( $domain );
 
-    if ( @{$errors} != 0 ) {
-        return @{$errors}[0]->message;
+    if ( @{$errors} ) {
+        return $errors->[0]->message;
     }
 
     return undef

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -13,6 +13,7 @@ use Readonly;
 use Locale::TextDomain qw[Zonemaster-Backend];
 use Net::IP::XS;
 use Zonemaster::Engine::Logger::Entry;
+use Zonemaster::Engine::Normalization;
 use Zonemaster::LDNS;
 
 our @EXPORT_OK = qw(
@@ -281,35 +282,13 @@ sub check_domain {
         return N__ 'Domain name required';
     }
 
-    if ( $domain =~ m/[^[:ascii:]]+/ ) {
-        if ( Zonemaster::LDNS::has_idn() ) {
-            eval { $domain = Zonemaster::LDNS::to_idn( $domain ); };
-            if ( $@ ) {
-                return N__ 'The domain name is IDNA invalid';
-            }
-        }
-        else {
-            return N__ 'The domain name contains non-ascii characters and IDNA support is not installed';
-        }
+    my ( $errors, $_domain ) = normalize_name( $domain );
+
+    if ( @{$errors} != 0 ) {
+        return @{$errors}[0]->message;
     }
 
-    if ( $domain !~ m{^[a-z0-9_./-]+$}i ) {
-        return  N__ 'The domain name character(s) are not supported';
-    }
-
-    if ( $domain =~ m/\.\./i ) {
-        return  N__ 'The domain name contains consecutive dots';
-    }
-
-    my %levels = Zonemaster::Engine::Logger::Entry::levels();
-    my @res;
-    @res = Zonemaster::Engine::Test::Basic->basic00( $domain );
-    @res = grep { $_->numeric_level >= $levels{ERROR} } @res;
-    if ( @res != 0 ) {
-        return N__ 'The domain name or label is too long';
-    }
-
-    return undef;
+    return undef
 }
 
 =head2 check_language_tag($value, %locales)

--- a/share/patch/patch_db_zonemaster_backend_ver_11.0.3.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_11.0.3.pl
@@ -96,8 +96,8 @@ sub _update_data_nomalize_domains {
     my $progress = 0;
 
     while ( my $row = $sth1->fetchrow_hashref ) {
+        my $hash_id = $row->{hash_id};
         eval {
-            my $hash_id = $row->{hash_id};
             my $raw_params = decode_json($row->{params});
             my $domain = $raw_params->{domain};
 
@@ -112,7 +112,7 @@ sub _update_data_nomalize_domains {
             $db->dbh->do('UPDATE test_results SET domain = ?, params = ?, fingerprint = ? where hash_id = ?', undef, $domain, $params, $fingerprint, $hash_id);
         };
         if ($@) {
-            warn "Caught error while updating record, ignoring: $@\n";
+            warn "Caught error while updating record with hash id $hash_id, ignoring: $@\n";
         }
         $row_done += 1;
         my $new_progress = int(($row_done / $row_total) * 100);

--- a/t/db.t
+++ b/t/db.t
@@ -170,8 +170,8 @@ subtest 'encoding and fingerprint' => sub {
     };
 
     subtest 'IDN domain' => sub {
-        my $expected_encoded_params = encode_utf8( '{"domain":"café.example","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}' );
-        my $expected_fingerprint = '8c64f7feaa3f13b77e769720991f2a79';
+        my $expected_encoded_params = encode_utf8( '{"domain":"xn--caf-dma.example","ds_info":[],"ipv4":true,"ipv6":true,"nameservers":[],"profile":"default"}' );
+        my $expected_fingerprint = '8cb027ff2c175f48aed2623abad0cdd2';
 
         my %params = ( domain => "café.example" );
         $params{ipv4} = JSON::PP->true;

--- a/t/parameters_validation.t
+++ b/t/parameters_validation.t
@@ -218,7 +218,7 @@ subtest 'Test custom formats' => sub {
             },
             output => [{
                 path => '/my_domain',
-                message => 'The domain name character(s) are not supported'
+                message => 'Domain name has an ASCII label ("not a domain") with a character not permitted.'
             }]
         },
         {


### PR DESCRIPTION
## Purpose

Use new name normalization method instead of Basic00.

## Context

https://github.com/zonemaster/zonemaster-engine/pull/1040 introduce a new method to normalize domain names before testing. Let's use it.

It also fixes https://github.com/zonemaster/zonemaster-backend/issues/1032.

## Changes

* Normalize domain name before saving to database
* Use normalized domain for history search
* Normalize domain name before fetching data from parent (fixes issue that cause that method to not work for idna domains, see https://github.com/zonemaster/zonemaster-gui/issues/426)

**Note:** With this PR, domains are normalized before being saved to database, meaning that domains that contain ulabel will be converted to alabel before saving. That might break history for the affected domains. Should we provide a migration script to normalize all the domains in the database?

## How to test this PR

Test that the domain validation is working

```
% ./script/zmb --server http://127.0.0.1:5000 start_domain_test --domain '' | jq .error.data -c
[{"message":"Domain name is empty.","path":"/domain"}]

% ./script/zmb --server http://127.0.0.1:5000 start_domain_test --domain , | jq .error.data -c
[{"path":"/domain","message":"Domain name has an ASCII label (\",\") with a character not permitted."}]
```

Test that the validation is also working for nameserver

```
% ./script/zmb --server http://127.0.0.1:5000 start_domain_test --domain example.org --nameserver ':0.0.0.0' | jq .error.data -c
[{"path":"/nameservers/0/ns","message":"Domain name is empty."}]
```

Test that fetching data from parent is working for idna domains

```
% curl 'http://localhost:5000' --data '{"jsonrpc":"2.0","id":0,"method":"get_data_from_parent_zone","params":{"domain":"café.fr"}}'
{"jsonrpc":"2.0","result":{"ds_list":[],"ns_list":[{"ns":"ns1.parkingcrew.net","ip":"13.248.158.159"},{"ns":"ns2.parkingcrew.net","ip":"76.223.21.9"}]},"id":0}
```

* Try lauching a test using a GUI, check that it is working correctly.
* Then check history, check that is is working correctly.

