### PR TITLE
Adds missing files in MANIFEST

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -76,10 +76,12 @@ t/00-load.t
 t/batches.t
 t/config.t
 t/db.t
+t/db_ddl.t
 t/idn.data
 t/idn.t
 t/lifecycle.t
 t/parameters_validation.t
+t/queue.t
 t/rpc_validation.t
 t/test01.data
 t/test01.t


### PR DESCRIPTION
## Purpose

Make MANIFEST clean.

## Context

The files were added by #1092 and #1121, respectively, but not added to MANIFEST.

## How to test this PR

Building should not complain on missing files in MANIFEST.