### PR TITLE
Make room for other database engines

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -514,7 +514,6 @@ sub get_test_history {
             (SELECT count(*) FROM result_entries WHERE result_entries.hash_id = test_results.hash_id AND level = ?) AS nb_critical,
             (SELECT count(*) FROM result_entries WHERE result_entries.hash_id = test_results.hash_id AND level = ?) AS nb_error,
             (SELECT count(*) FROM result_entries WHERE result_entries.hash_id = test_results.hash_id AND level = ?) AS nb_warning,
-            id,
             hash_id,
             created_at,
             undelegated

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -519,7 +519,7 @@ sub get_test_history {
             undelegated
         FROM test_results
         WHERE progress = 100 AND domain = ? AND ( ? IS NULL OR undelegated = ? )
-        ORDER BY id DESC
+        ORDER BY created_at DESC
         LIMIT ?
         OFFSET ?];
 
@@ -642,7 +642,7 @@ sub get_test_request {
                     WHERE progress = 0
                       AND queue = ?
                     ORDER BY priority DESC,
-                             id ASC
+                             created_at ASC
                     LIMIT 1
                 ],
                 undef,
@@ -657,7 +657,7 @@ sub get_test_request {
                     FROM test_results
                     WHERE progress = 0
                     ORDER BY priority DESC,
-                             id ASC
+                             created_at ASC
                     LIMIT 1
                 ],
             );

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -582,14 +582,14 @@ sub user_authorized {
     my ( $self, $user, $api_key ) = @_;
 
     my $dbh = $self->dbh;
-    my ( $id ) = $dbh->selectrow_array(
-        "SELECT id FROM users WHERE username = ? AND api_key = ?",
+    my ( $count ) = $dbh->selectrow_array(
+        "SELECT count(*) FROM users WHERE username = ? AND api_key = ?",
         undef,
         $user,
         $api_key
     );
 
-    return $id;
+    return $count;
 }
 
 sub batch_exists_in_db {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -511,9 +511,9 @@ sub get_test_history {
     my @results;
     my $query = q[
         SELECT
-            (SELECT count(*) FROM result_entries WHERE result_entries.hash_id = test_results.hash_id AND level = ?) AS nb_critical,
-            (SELECT count(*) FROM result_entries WHERE result_entries.hash_id = test_results.hash_id AND level = ?) AS nb_error,
-            (SELECT count(*) FROM result_entries WHERE result_entries.hash_id = test_results.hash_id AND level = ?) AS nb_warning,
+            (SELECT count(*) FROM result_entries JOIN test_results ON result_entries.hash_id = test_results.hash_id AND level = ?) AS nb_critical,
+            (SELECT count(*) FROM result_entries JOIN test_results ON result_entries.hash_id = test_results.hash_id AND level = ?) AS nb_error,
+            (SELECT count(*) FROM result_entries JOIN test_results ON result_entries.hash_id = test_results.hash_id AND level = ?) AS nb_warning,
             hash_id,
             created_at,
             undelegated

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -249,7 +249,7 @@ sub add_batch_job {
 
     my $dbh = $self->dbh;
 
-    if ( $self->user_authorized( $params->{username}, $params->{api_key} ) ) {
+    if ( 1 == $self->user_authorized( $params->{username}, $params->{api_key} ) ) {
         $batch_id = $self->create_new_batch_job( $params->{username} );
 
         my $test_params = $params->{test_params};

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -89,9 +89,9 @@ sub create_schema {
     # retrieve all indexes by key name
     my $indexes = $dbh->selectall_hashref( 'SHOW INDEXES FROM test_results', 'Key_name' );
 
-    if ( not exists($indexes->{test_results__hash_id}) ) {
+    if ( not exists($indexes->{test_results__hash_id_created_at}) ) {
         $dbh->do(
-            'CREATE INDEX test_results__hash_id ON test_results (hash_id)'
+            'CREATE INDEX test_results__hash_id_created_at ON test_results (hash_id, created_at)'
         );
     }
     if ( not exists($indexes->{test_results__fingerprint}) ) {
@@ -257,7 +257,7 @@ sub add_batch_job {
         my $queue_label = $test_params->{queue};
 
         $dbh->{AutoCommit} = 0;
-        eval {$dbh->do( "DROP INDEX test_results__hash_id ON test_results" );};
+        eval {$dbh->do( "DROP INDEX test_results__hash_id_created_at ON test_results" );};
         eval {$dbh->do( "DROP INDEX test_results__fingerprint ON test_results" );};
         eval {$dbh->do( "DROP INDEX test_results__batch_id_progress ON test_results" );};
         eval {$dbh->do( "DROP INDEX test_results__progress ON test_results" );};
@@ -298,7 +298,7 @@ sub add_batch_job {
                 $undelegated,
             );
         }
-        $dbh->do( "CREATE INDEX test_results__hash_id ON test_results (hash_id, created_at)" );
+        $dbh->do( "CREATE INDEX test_results__hash_id_created_at ON test_results (hash_id, created_at)" );
         $dbh->do( "CREATE INDEX test_results__fingerprint ON test_results (fingerprint)" );
         $dbh->do( "CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)" );
         $dbh->do( "CREATE INDEX test_results__progress ON test_results (progress)" );

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -222,7 +222,7 @@ sub add_batch_job {
 
     my $dbh = $self->dbh;
 
-    if ( $self->user_authorized( $params->{username}, $params->{api_key} ) ) {
+    if ( 1 == $self->user_authorized( $params->{username}, $params->{api_key} ) ) {
         $batch_id = $self->create_new_batch_job( $params->{username} );
 
         my $test_params = $params->{test_params};

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -81,7 +81,7 @@ sub create_schema {
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'test_results' table", data => $dbh->errstr() );
 
     $dbh->do(
-        'CREATE INDEX IF NOT EXISTS test_results__hash_id ON test_results (hash_id)'
+        'CREATE INDEX IF NOT EXISTS test_results__hash_id_created_at ON test_results (hash_id, created_at)'
     );
     $dbh->do(
         'CREATE INDEX IF NOT EXISTS test_results__fingerprint ON test_results (fingerprint)'
@@ -234,7 +234,7 @@ sub add_batch_job {
 
         $dbh->begin_work();
         $dbh->do( "ALTER TABLE test_results DROP CONSTRAINT IF EXISTS test_results_pkey" );
-        $dbh->do( "DROP INDEX IF EXISTS test_results__hash_id" );
+        $dbh->do( "DROP INDEX IF EXISTS test_results__hash_id_created_at" );
         $dbh->do( "DROP INDEX IF EXISTS test_results__fingerprint" );
         $dbh->do( "DROP INDEX IF EXISTS test_results__batch_id_progress" );
         $dbh->do( "DROP INDEX IF EXISTS test_results__progress" );
@@ -271,7 +271,7 @@ sub add_batch_job {
         }
         $dbh->pg_putcopyend();
         $dbh->do( "ALTER TABLE test_results ADD PRIMARY KEY (id)" );
-        $dbh->do( "CREATE INDEX test_results__hash_id ON test_results (hash_id, created_at)" );
+        $dbh->do( "CREATE INDEX test_results__hash_id_created_at ON test_results (hash_id, created_at)" );
         $dbh->do( "CREATE INDEX test_results__fingerprint ON test_results (fingerprint)" );
         $dbh->do( "CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)" );
         $dbh->do( "CREATE INDEX test_results__progress ON test_results (progress)" );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -84,7 +84,7 @@ sub create_schema {
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'test_results' table", data => $dbh->errstr() );
 
     $dbh->do(
-        'CREATE INDEX IF NOT EXISTS test_results__hash_id ON test_results (hash_id)'
+        'CREATE INDEX IF NOT EXISTS test_results__hash_id_created_at ON test_results (hash_id, created_at)'
     );
     $self->dbh->do(
         'CREATE INDEX IF NOT EXISTS test_results__fingerprint ON test_results (fingerprint)'
@@ -218,7 +218,7 @@ sub add_batch_job {
         my $queue_label = $test_params->{queue};
 
         $dbh->{AutoCommit} = 0;
-        eval {$dbh->do( "DROP INDEX IF EXISTS test_results__hash_id " );};
+        eval {$dbh->do( "DROP INDEX IF EXISTS test_results__hash_id_created_at " );};
         eval {$dbh->do( "DROP INDEX IF EXISTS test_results__fingerprint " );};
         eval {$dbh->do( "DROP INDEX IF EXISTS test_results__batch_id_progress " );};
         eval {$dbh->do( "DROP INDEX IF EXISTS test_results__progress " );};
@@ -257,7 +257,7 @@ sub add_batch_job {
                 $undelegated,
             );
         }
-        $dbh->do( "CREATE INDEX test_results__hash_id ON test_results (hash_id, created_at)" );
+        $dbh->do( "CREATE INDEX test_results__hash_id_created_at ON test_results (hash_id, created_at)" );
         $dbh->do( "CREATE INDEX test_results__fingerprint ON test_results (fingerprint)" );
         $dbh->do( "CREATE INDEX test_results__batch_id_progress ON test_results (batch_id, progress)" );
         $dbh->do( "CREATE INDEX test_results__progress ON test_results (progress)" );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -210,7 +210,7 @@ sub add_batch_job {
 
     my $dbh = $self->dbh;
 
-    if ( $self->user_authorized( $params->{username}, $params->{api_key} ) ) {
+    if ( 1 == $self->user_authorized( $params->{username}, $params->{api_key} ) ) {
         $batch_id = $self->create_new_batch_job( $params->{username} );
 
         my $test_params = $params->{test_params};


### PR DESCRIPTION
## Purpose

This PR removes the need to have a primary key defined within the database. For instance Clickhouse does not support it. So some specific code is needed. With this PR, such specific code could be removed and the same SQL queries could be used.

Also it appears that when running batches, the indexes are dropped and create again. But one index was not created as intended and included the `created_at` field. However with this PR, an index using the `created_at` field is necessary to keep good performance. So the initial index is updated (instead of updating the index in the batch method).

## Context

This was initially part of #1094, and moved to another PR to avoid changing internal while integrating an experimental feature.

## Changes

* compute the user existence by count (and not by returning its id)
* order the entries using the `created_at` field and not the `id` field
* use an explicit JOIN clause 

## How to test this PR

* Unit tests should pass
