### PR TITLE
CI: update dependency and Perl versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ jobs:
     - env: TARGET=PostgreSQL ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_postgresql_backend_config.ini
       services: postgresql
     # Cover supported Perl versions with SQLite
-    - perl: "5.36"
-      env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
     - perl: "5.30"
       env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
     - perl: "5.26"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ jobs:
     - perl: "5.30"
       env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
     - perl: "5.26"
-      dist: focal
       env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: focal
+dist: jammy
 
 language: perl
 
@@ -24,7 +24,7 @@ jobs:
     - perl: "5.30"
       env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
     - perl: "5.26"
-      dist: bionic
+      dist: focal
       env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: focal
 
 language: perl
 
-perl: "5.32"
+perl: "5.36"
 
 stages:
   - test
@@ -19,11 +19,11 @@ jobs:
     - env: TARGET=PostgreSQL ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_postgresql_backend_config.ini
       services: postgresql
     # Cover supported Perl versions with SQLite
-    - perl: "5.30.2"
+    - perl: "5.36"
+      env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
+    - perl: "5.30"
       env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
     - perl: "5.26"
-      env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
-    - perl: "5.16"
       dist: bionic
       env: TARGET=SQLite ZONEMASTER_RECORD=0 ZONEMASTER_BACKEND_CONFIG_FILE=./share/travis_sqlite_backend_config.ini
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ addons:
       - liblist-moreutils-perl
       - liblocale-msgfmt-perl
       - libmail-rfc822-address-perl
+      - libmail-spf-perl
       - libmodule-find-perl
       - libnet-ip-xs-perl
       - libpod-coverage-perl


### PR DESCRIPTION
## Purpose

This PR adds a missing dependency and updates the Perl versions for Travis CI.

## Context

https://github.com/zonemaster/zonemaster-engine/pull/1305
https://github.com/zonemaster/zonemaster-engine/pull/1287

## Changes

* Test against Perl 5.36, 5.30 and 5.26 instead of 5.30, 5.26 and 5.16;

## How to test this PR

Travis should pass.
