### PR TITLE
Adapt to changed Engine API

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -16,8 +16,8 @@ use POSIX qw( strftime );
 use Readonly;
 use Try::Tiny;
 
-use Zonemaster::Engine::Normalization;
 use Zonemaster::Backend::Errors;
+use Zonemaster::Engine::Normalization qw( normalize_name trim_space );
 use Zonemaster::Engine::Logger::Entry;
 
 requires qw(
@@ -875,7 +875,7 @@ sub process_dead_test {
 sub _normalize_domain {
     my ( $domain ) = @_;
 
-    my ( $errors, $normalized_domain ) = normalize_name( $domain );
+    my ( $errors, $normalized_domain ) = normalize_name( trim_space( $domain ) );
 
     if ( scalar( @{$errors} ) ) {
         die Zonemaster::Backend::Error::Internal->new( reason => "Normalizing domain returned errors.", data => [ map { $_->string } @{$errors} ] );

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -22,7 +22,7 @@ use Encode;
 
 # Zonemaster Modules
 use Zonemaster::Engine;
-use Zonemaster::Engine::Normalization;
+use Zonemaster::Engine::Normalization qw( normalize_name trim_space );
 use Zonemaster::Engine::Profile;
 use Zonemaster::Engine::Recursor;
 use Zonemaster::Backend;
@@ -224,7 +224,7 @@ sub get_data_from_parent_zone {
     my $result = eval {
         my %result;
         my $domain = $params->{domain};
-        my ( $_errors, $normalized_domain ) = normalize_name( $domain );
+        my ( $_errors, $normalized_domain ) = normalize_name( trim_space ( $domain ) );
 
         my @ns_list;
         my @ns_names;

--- a/lib/Zonemaster/Backend/Validator.pm
+++ b/lib/Zonemaster/Backend/Validator.pm
@@ -13,7 +13,7 @@ use Readonly;
 use Locale::TextDomain qw[Zonemaster-Backend];
 use Net::IP::XS;
 use Zonemaster::Engine::Logger::Entry;
-use Zonemaster::Engine::Normalization;
+use Zonemaster::Engine::Normalization qw( normalize_name trim_space );
 use Zonemaster::LDNS;
 
 our @EXPORT_OK = qw(
@@ -282,7 +282,7 @@ sub check_domain {
         return N__ 'Domain name required';
     }
 
-    my ( $errors, $_domain ) = normalize_name( $domain );
+    my ( $errors, $_domain ) = normalize_name( trim_space( $domain ) );
 
     if ( @{$errors} ) {
         return $errors->[0]->message;


### PR DESCRIPTION
## Purpose

This PR adapts Backend to the API change in zonemaster/zonemaster-engine#1316.

## Context

Should be merged together with zonemaster/zonemaster-engine#1316.

## Changes

trim_space() is now invoked before normalize_name(). Prior to zonemaster/zonemaster-engine#1316 normalize_name() handled the space trimming itself.

## How to test this PR

You should still be able to include surrounding space in domain name parameters to RPCAPI calls.
```
$ zmb start_domain_test --domain ' example.com '
```