### PR TITLE
Avoid double UTF-8 encoding in zmb

### DIFF
--- a/script/zmb
+++ b/script/zmb
@@ -3,12 +3,11 @@ use strict;
 use warnings;
 use feature 'say';
 
+use Encode qw( decode_utf8 FB_CROAK );
 use Getopt::Long qw( GetOptionsFromArray :config require_order );
-
-use Pod::Usage;
-
-use JSON::PP;
+use JSON::PP qw( encode_json );
 use LWP::UserAgent;
+use Pod::Usage;
 
 =head1 NAME
 
@@ -32,6 +31,8 @@ This interface is unstable and will change in a future release.
 
 sub main {
     my @argv = @_;
+
+    @argv = map { decode_utf8( $_, FB_CROAK ) } @argv;
 
     my $opt_help;
     my $opt_verbose;


### PR DESCRIPTION
## Purpose

This PR fixes a problem in how zmb handles UTF-8 data in its arguments.

## Context

Fixes #1138.

## Changes

Arguments are received as octet string. Before this change each argument octet would be interpreted as a native character (e.g. per ISO 8859-1) and encoded into UTF-8 before being injected into the JSON-RPC request. If the arguments were already UTF-8 encoded this would result in double UTF-8 encoding. After this change the argument octets are injected in verbatim into the JSON-RPC request.

## How to test this PR

You should be able to specify domain names with U-label to zmb like this:

```sh
$ zmb start_domain_test --domain råttgift
```