### PR TITLE
Fix message strings in test reports after migration

### DIFF
--- a/share/patch/patch_db_zonemaster_backend_ver_11.0.3.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_11.0.3.pl
@@ -180,11 +180,18 @@ sub patch_db_postgresql {
                 SELECT
                     test_results.hash_id,
                     COALESCE(res->'args', '{}') AS args,
-                    res->>'module' AS module,
+                    CASE res->>'module'
+                        WHEN 'DNSSEC' THEN res->>'module'
+                        ELSE initcap(res->>'module')
+                      END AS module,
                     log_level.value AS level,
                     res->>'tag' AS tag,
                     (res->>'timestamp')::real AS timestamp,
-                    COALESCE(res->>'testcase', '') AS testcase
+                    CASE
+                        WHEN res->>'testcase' IS NULL THEN ''
+                        WHEN res->>'testcase' LIKE 'DNSSEC%' THEN res->>'testcase'
+                        ELSE initcap(res->>'testcase')
+                      END AS testcase
                 FROM test_results,
                      json_array_elements(results) as res
                      LEFT JOIN log_level ON (res->>'level' = log_level.level)

--- a/share/patch/patch_db_zonemaster_backend_ver_11.0.3.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_11.0.3.pl
@@ -32,8 +32,10 @@ else {
     die "Unknown database engine configured: $db_engine\n";
 }
 
+# depending on the resources available to select all data in database
+# update $row_count to your needs
 sub _update_data_result_entries {
-    my ( $dbh ) = @_;
+    my ( $dbh, $row_count ) = @_;
 
     my $json = JSON::PP->new->allow_blessed->convert_blessed->canonical;
 
@@ -43,9 +45,6 @@ sub _update_data_result_entries {
 
     my %levels = Zonemaster::Engine::Logger::Entry->levels();
 
-    # depending on the resources available to select all data in database
-    # update $row_count to your needs
-    my $row_count = 50000;
     my $row_done = 0;
     while ( $row_done < $row_total ) {
         print "Progress update: $row_done / $row_total\n";
@@ -147,7 +146,7 @@ sub patch_db_mysql {
         $db->create_schema();
 
         print( "\n-> (1/2) Populating new result_entries table\n" );
-        _update_data_result_entries( $dbh );
+        _update_data_result_entries( $dbh, 50000 );
 
         print( "\n-> (2/2) Normalizing domain names\n" );
         _update_data_nomalize_domains( $db );
@@ -224,7 +223,7 @@ sub patch_db_sqlite {
         $db->create_schema();
 
         print( "\n-> (1/2) Populating new result_entries table\n" );
-        _update_data_result_entries( $dbh );
+        _update_data_result_entries( $dbh, 142 );
 
         print( "\n-> (2/2) Normalizing domain names\n" );
         _update_data_nomalize_domains( $db );


### PR DESCRIPTION
## Purpose

This PR fixes translation of message strings in reports of test results that have been migrated from the previous version of the database schema.

## Context

This problem was found while release testing v2023.2. The problem is described as item 3 in https://github.com/zonemaster/zonemaster-backend/pull/1092#issuecomment-1892265157.

## Changes

The migration script is updated to save module and test case names the way zm-rpcapi expects to find them.

## How to test this PR

1. Create dist tarballs for Zonemaster-LDNS, Zonemaster-Engine and Zonemaster-Backend from both the master branch and the develop branch (or the PR branch in case it hasn't been merged) and place them in the $HOME/old and $HOME/new directories.
2. Using the master branch dist tarballs, follow the installation instructions for Engine and Backend up to but excluding the "Database engine installation" section.
3. Set `age_reuse_previous_test = 60` for good measure.
4. Take a snapshot of the machine and name it "old-before-db" (to be restored in later steps).
5. For each DB engine as $db:
    1. Complete Backend installation using $db.
    2. Run `zmtest nu > $HOME/$db-nu.old.result` and save the test id as $test_id_nu.
    5. Run `zmtest SE. > $HOME/$db-se.old.result` and save the test id as $test_id_se.
    6. Take a snapshot of the machine and name it "old-$db" (in case we need get back here).
    7. Run `sudo systemctl stop zm-rpcapi zm-testagent`.
    8. Run `sudo cpanm --notest $HOME/new/*`.
    9. Run `sudo perl $(perl -MFile::ShareDir=dist_dir -E 'say dist_dir("Zonemaster-Backend")')/patch/patch_db_zonemaster_backend_ver_11.0.3.pl`.
    10. Run `sudo systemctl start zm-rpcapi zm-testagent`.
    11. Run `zmb get_test_results --lang en --test-id $test_id_nu | jq -S > $HOME/$db-nu.migrated.result`.
    12. Run `zmb get_test_results --lang en --test-id $test_id_se | jq -S > $HOME/$db-se.migrated.result`.
    13. Run `zmtest nu > $HOME/$db-nu.new.result`.
    14. Run `zmtest SE. > $HOME/$db-se.new.result`.
    15. Verify that the $HOME/$db-nu.* files are essentially identical.
    16. Verify that the $HOME/$db-se.* files are essentially identical.
    17. Take a snapshot of the machine and name it "new-$db" (in case we need get back here).
    18. Restore the "old-before-db" snapshot.