### PR TITLE
Fix ns argument

### DIFF
--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -404,7 +404,7 @@ sub get_test_results {
         my $test_info = $self->{db}->test_results( $params->{id} );
         foreach my $test_res ( @{ $test_info->{results} } ) {
             my $res;
-            if ( $test_res->{module} eq 'NAMESERVER' ) {
+            if ( $test_res->{module} eq 'Nameserver' ) {
                 $res->{ns} = ( $test_res->{args}->{ns} ) ? ( $test_res->{args}->{ns} ) : ( 'All' );
             }
             elsif ($test_res->{module} eq 'SYSTEM'


### PR DESCRIPTION
## Purpose

This PR fixes a bug in get_test_results. The RPCAPI reference specifies that `ns` arguments should sometimes be included in the results, but this functionality was broken since last release. 

## Context

The bug was introduced in #1092 and discovered while testing #1145.
The cause of the bug is that the database schema was changed to use capitalized names instead of uppercase module names, and get_test_results was not updated accordingly.

## Changes

This PR updates get_test_results to understand the new database schema.

## How to test this PR

Run `zmtest se` and see that all entries from the `Nameserver` module include an `ns` argument.