### PR TITLE
Make job_status report proper percentages

### DIFF
--- a/lib/Zonemaster/Backend/TestAgent.pm
+++ b/lib/Zonemaster/Backend/TestAgent.pm
@@ -117,8 +117,7 @@ sub run {
 
                 if ( $entry->{tag} and $entry->{tag} eq 'TEST_CASE_END' ) {
                     $nbr_testcases_finished++;
-                    # limit to max 99%, 100% is reached when data is stored in database
-                    my $progress_percent = int( 99 * $nbr_testcases_finished /  $nbr_testcases_planned );
+                    my $progress_percent = int( 100 * $nbr_testcases_finished /  $nbr_testcases_planned );
                     $self->{_db}->test_progress( $test_id, $progress_percent );
                 }
             }


### PR DESCRIPTION
## Purpose

This PR makes job_status and test_progress return proper percentages (instead of 1/99ths).

## Context

This PR should not be merged before the v2023.2 release.

Fixes zonemaster/zonemaster#1176.

## Changes

TestAgent is made to set progress to proper percentages. Because DB::test_progress() clams the progress value to a maximum of 99, this change will not interfere with the state semantics of the progress value even when TestAgent requests a progress value of 100.

## How to test this PR

Run a job using zmtest and verify that the job finishes out at 100 percent progress with all the results included, just like it should.