### PR TITLE
Ensure Backend’s messages stay translated

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -784,7 +784,7 @@ sub process_unfinished_tests {
     my $msg = Zonemaster::Engine::Logger::Entry->new(
         {
             level     => "CRITICAL",
-            module    => "Backend_Test_Agent",
+            module    => "Backend",
             testcase  => "",
             tag       => "UNABLE_TO_FINISH_TEST",
             args      => { max_execution_time => $test_run_timeout },
@@ -860,7 +860,7 @@ sub process_dead_test {
     my $msg = Zonemaster::Engine::Logger::Entry->new(
         {
             level     => "CRITICAL",
-            module    => "Backend_Test_Agent",
+            module    => "Backend",
             testcase  => "",
             tag       => "TEST_DIED",
             args      => {},

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -784,7 +784,7 @@ sub process_unfinished_tests {
     my $msg = Zonemaster::Engine::Logger::Entry->new(
         {
             level     => "CRITICAL",
-            module    => "BACKEND_TEST_AGENT",
+            module    => "Backend_Test_Agent",
             testcase  => "",
             tag       => "UNABLE_TO_FINISH_TEST",
             args      => { max_execution_time => $test_run_timeout },
@@ -860,7 +860,7 @@ sub process_dead_test {
     my $msg = Zonemaster::Engine::Logger::Entry->new(
         {
             level     => "CRITICAL",
-            module    => "BACKEND_TEST_AGENT",
+            module    => "Backend_Test_Agent",
             testcase  => "",
             tag       => "TEST_DIED",
             args      => {},

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -41,12 +41,14 @@ sub translate_tag {
     my ( $self, $hashref ) = @_;
 
     my $entry = Zonemaster::Engine::Logger::Entry->new( { %{ $hashref } } );
-    my $octets = Zonemaster::Engine::Translator::translate_tag( $self, $entry );
 
-    return decode_utf8( $octets );
+    return decode_utf8( $self->SUPER::translate_tag( $entry ) );
 }
 
 sub test_case_description {
-    return decode_utf8(Zonemaster::Engine::Translator::test_case_description(@_));
+    my ( $self, $test_name ) = @_;
+
+    return decode_utf8( $self->SUPER::test_case_description( $test_name ) );
 }
+
 1;

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -30,8 +30,10 @@ Readonly my %TAG_DESCRIPTIONS => (
 );
 
 sub _build_all_tag_descriptions {
+    my ( $class ) = @_;
+
     my $all_tag_descriptions = Zonemaster::Engine::Translator::_build_all_tag_descriptions();
-    $all_tag_descriptions->{BACKEND_TEST_AGENT} = \%TAG_DESCRIPTIONS;
+    $all_tag_descriptions->{Backend_Test_Agent} = \%TAG_DESCRIPTIONS;
     return $all_tag_descriptions;
 }
 

--- a/lib/Zonemaster/Backend/Translator.pm
+++ b/lib/Zonemaster/Backend/Translator.pm
@@ -33,7 +33,7 @@ sub _build_all_tag_descriptions {
     my ( $class ) = @_;
 
     my $all_tag_descriptions = Zonemaster::Engine::Translator::_build_all_tag_descriptions();
-    $all_tag_descriptions->{Backend_Test_Agent} = \%TAG_DESCRIPTIONS;
+    $all_tag_descriptions->{Backend} = \%TAG_DESCRIPTIONS;
     return $all_tag_descriptions;
 }
 

--- a/share/patch/patch_db_zonemaster_backend_ver_11.2.0.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_11.2.0.pl
@@ -1,0 +1,38 @@
+use strict;
+use warnings;
+
+use List::MoreUtils qw(zip_unflatten);
+use JSON::PP;
+use Try::Tiny;
+use File::Temp qw(tempfile);
+use Encode qw(find_encoding);
+
+use Zonemaster::Backend::Config;
+use Zonemaster::Engine;
+
+my $config = Zonemaster::Backend::Config->load_config();
+
+my $db_engine = $config->DB_engine;
+print "Configured database engine: $db_engine\n";
+
+if ( $db_engine =~ /^(MySQL|PostgreSQL|SQLite)$/ ) {
+    print( "Starting database migration\n" );
+
+    _update_result_entries( $config->new_DB()->dbh() );
+
+    print( "\nMigration done\n" );
+}
+else {
+    die "Unknown database engine configured: $db_engine\n";
+}
+
+
+sub _update_result_entries {
+    my ( $dbh ) = @_;
+
+    $dbh->do(<<SQL) or die 'Migration failed';
+        UPDATE result_entries
+           SET module = 'Backend_Test_Agent'
+         WHERE module = 'BACKEND_TEST_AGENT';
+SQL
+}

--- a/share/patch/patch_db_zonemaster_backend_ver_11.2.0.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_11.2.0.pl
@@ -32,7 +32,7 @@ sub _update_result_entries {
 
     $dbh->do(<<SQL) or die 'Migration failed';
         UPDATE result_entries
-           SET module = 'Backend_Test_Agent'
-         WHERE module = 'BACKEND_TEST_AGENT';
+           SET module = 'Backend'
+         WHERE upper(module) = 'BACKEND_TEST_AGENT';
 SQL
 }

--- a/t/translator.t
+++ b/t/translator.t
@@ -73,7 +73,7 @@ like $translation, qr/cass\x{e9}e/,
 ###
 
 $message = {
-    module => 'Backend_Test_Agent',
+    module => 'Backend',
     testcase => '',
     timestamp => '59',
     level => 'CRITICAL',

--- a/t/translator.t
+++ b/t/translator.t
@@ -16,12 +16,9 @@ isa_ok 'Zonemaster::Backend::Translator', 'Zonemaster::Engine::Translator';
 
 my $translator;
 
-# FIXME: the new() method is deprecated but the instance() method does not
-# work; the following should be changed once Zonemaster::Engine::Translator
-# (Engine, not Backend) is fixed.
-$translator = Zonemaster::Backend::Translator->new();
+$translator = Zonemaster::Backend::Translator->instance();
 isa_ok $translator, 'Zonemaster::Backend::Translator',
-    "Zonemaster::Backend::Translator->new()";
+    "Zonemaster::Backend::Translator->instance()";
 
 ###
 ### Change locale

--- a/t/translator.t
+++ b/t/translator.t
@@ -1,0 +1,97 @@
+#!/usr/bin/env perl
+
+use v5.16;
+use warnings;
+use utf8;
+
+use Test::More;
+
+###
+### Basic tests
+###
+
+BEGIN { use_ok 'Zonemaster::Backend::Translator'; }
+
+isa_ok 'Zonemaster::Backend::Translator', 'Zonemaster::Engine::Translator';
+
+my $translator;
+
+# FIXME: the new() method is deprecated but the instance() method does not
+# work; the following should be changed once Zonemaster::Engine::Translator
+# (Engine, not Backend) is fixed.
+$translator = Zonemaster::Backend::Translator->new();
+isa_ok $translator, 'Zonemaster::Backend::Translator',
+    "Zonemaster::Backend::Translator->new()";
+
+###
+### Change locale
+###
+
+my $locale = 'fr_FR.UTF-8';
+ok( $translator->locale($locale), "Setting locale to '$locale' works" );
+
+###
+### Testing some translations
+###
+
+my $message;
+my $translation;
+
+$message = {
+    module => 'System',
+    testcase => 'Unspecified',
+    timestamp => '0.000778913497924805',
+    level => 'INFO',
+    tag => 'GLOBAL_VERSION',
+    args => { version => 'v5.0.0' }
+};
+$translation = $translator->translate_tag($message);
+like $translation, qr/\AUtilisation de la version .* du moteur Zonemaster\.\Z/,
+    'Translating a GLOBAL_VERSION message tag works';
+
+###
+### Test a message translation from Engine with non-ASCII strings
+###
+
+$message = {
+    module => 'Basic',
+    testcase => 'Basic02',
+    timestamp => '4.085114956678410350',
+    level => 'ERROR',
+    tag => 'B02_NS_BROKEN',
+    args => { ns => 'ns1.example' }
+};
+$translation = $translator->translate_tag($message);
+
+like $translation, qr/\ARéponse cassée du serveur de noms /,
+    'Translating a B02_NS_BROKEN message works';
+like $translation, qr/cass\x{e9}e/,
+    'Translation is a string of Unicode codepoints, not bytes';
+
+###
+### Test a Backend-specific translation
+###
+
+$message = {
+    module => 'Backend_Test_Agent',
+    testcase => '',
+    timestamp => '59',
+    level => 'CRITICAL',
+    tag => 'TEST_DIED',
+    args => {}
+};
+$translation = $translator->translate_tag($message);
+
+like $translation, qr/\AUne erreur est survenue /,
+    'Translating a backend-specific TEST_DIED message tag works';
+
+###
+### Test a test case translation with non-ASCII strings
+###
+
+$translation = $translator->test_case_description( 'Consistency01' );
+
+like $translation, qr/\ACoh\x{e9}rence du num\x{e9}ro de s\x{e9}rie/,
+    'Translating Consistency01 gives a string of Unicode codepoints';
+
+done_testing;


### PR DESCRIPTION
## Purpose

This PR adds unit tests for `Zonemaster::Backend::Translator` and addresses an oversight in Backend caused by storing the module’s names as mixed case instead of uppercase.

## Context

Submitting PR https://github.com/zonemaster/zonemaster-engine/pull/1346 made it clear that `Zonemaster::Backend::Translator` lacked appropriate unit tests. When adding them, I found more bugs, now addressed in the same PR. I also noticed that all Backend-generated messages suddenly became untranslated.

## Changes

- Add unit tests;
- Make sure future backend errors are stored as module `Backend_Test_Agent`;
- Introduce a DB migration script to fix existing entries that were missed between Backend version 11.0 (Zonemaster release 2023.2) and the next release.

## How to test this PR

**Prerequisite**: PR https://github.com/zonemaster/zonemaster-engine/pull/1346 must be merged beforehand in Zonemaster-Engine. Alternatively, install a local copy Zonemaster-Engine from a local development branch with this PR merged. If not, one of the newly-added unit tests will fail.

**Before merging this PR locally**: run a test on a domain name that causes Zonemaster to time out, such as `pool.ntp.org`, using `zmtest`. Note the test ID. Wait for the test to time out. Notice that the UNABLE_TO_FINISH_TEST message is untranslated (i.e., only the message tag is visible).

**After merging this PR locally**: run the unit tests. Ideally, make sure that the tests in `t/translator.t` have been executed.

Run the database migration script. Then use `zmb get_test_results --test-id $TEST_ID` where `$TEST_ID` is the test ID of `pool.ntp.org` that was run before merging the PR locally. Expect the UNABLE_TO_FINISH_TEST message to be translated.

Run the same test again on `pool.ntp.org` using `zmtest`; wait for it to time out. Expect the UNABLE_TO_FINISH_TEST message to be translated as well.