### PR TITLE
Bump DBD::SQLite to 1.66

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,7 +39,7 @@ requires
   'Zonemaster::Engine'              => 5.000000,  # v5.0.0
   ;
 
-test_requires 'DBD::SQLite' => 1.4702;
+test_requires 'DBD::SQLite' => 1.66;
 test_requires 'Test::Differences';
 test_requires 'Test::Exception';
 test_requires 'Time::Local' => 1.26;
@@ -47,7 +47,7 @@ test_requires 'Test::NoWarnings';
 
 recommends 'DBD::mysql';
 recommends 'DBD::Pg';
-recommends 'DBD::SQLite';
+recommends 'DBD::SQLite' => 1.66;
 
 install_share;
 


### PR DESCRIPTION
## Purpose

This PR ensures that zm-testagent doesn't fail at runtime trying to store larger test results in the database, and that the unit tests don't fail, because of a limitation in a dependency.

## Context

Fixes #1172.

On Rocky 8 and Ubuntu 20.04 the OS-provided DBD::SQLite is older than 1.66. On such systems cpanm will reject the OS package and instead pull the latest version from CPAN. The current installation instructions for Rocky and Ubuntu prescribes installing OS-packaged versions of DBD::SQLite.

We should consider what to do with the Rocky and Ubuntu installation instructions for Rocky. We have a few options, each with its own drawbacks.
1. Leave the installation instruction untouched. Users on Rocky 8 and Ubuntu 20.04 will get two versions of DBD::SQLite but only the newer one will be used.
2. Always install DBD::SQLite from CPAN. Quality control will be lower than needed for users on Ubuntu 22.04, 24.04 and Rocky 9.
3. Install DBD::SQLite from CPAN on Rocky 8 and Ubuntu 20.04 and from the OS on the others. This will raise the complexity of the installation instruction yet another step.

## Changes

Bumps DBD::SQLite to 1.66 in Makefile.PL.

## How to test this PR

1. Create a dist tarball including this change.
2. Install Zonemaster Engine.
3. Install dependencies for Zonemaster Backend.
4. Run `cpanm --test-only $DIST_TARBALL`.