### PR TITLE
Clean up “use” statements in database migration script for upcoming 11.2.0 version

### DIFF
--- a/share/patch/patch_db_zonemaster_backend_ver_11.2.0.pl
+++ b/share/patch/patch_db_zonemaster_backend_ver_11.2.0.pl
@@ -1,12 +1,6 @@
 use strict;
 use warnings;
 
-use List::MoreUtils qw(zip_unflatten);
-use JSON::PP;
-use Try::Tiny;
-use File::Temp qw(tempfile);
-use Encode qw(find_encoding);
-
 use Zonemaster::Backend::Config;
 use Zonemaster::Engine;
 


### PR DESCRIPTION
## Purpose

This PR ensures that the database migration script for the upcoming 11.2.0 release runs on Ubuntu 20.04 by cleaning up the

## Context

Review comment on #1166: see https://github.com/zonemaster/zonemaster-backend/pull/1166#issuecomment-2194757712

## Changes

Remove a handful of `use` statements from the script. None of these libraries are ever used.

## How to test this PR

Run the database migration script. Expect the script to run to completion.

**Note**: there is no need to have any test results in the database for the purpose of testing this PR.