### PR TITLE
Check MANIFEST when PR is created

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -73,4 +73,8 @@
 
 # Avoid MYMETA files
 ^MYMETA\.
+
+# Avoid MANIFEST test
+t/manifest.t
+
 #!end included /usr/share/perl/5.20/ExtUtils/MANIFEST.SKIP

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -43,7 +43,7 @@ test_requires 'DBD::SQLite' => 1.66;
 test_requires 'Test::Differences';
 test_requires 'Test::Exception';
 test_requires 'Time::Local' => 1.26;
-test_requires 'Test::NoWarnings';
+test_requires 'Test::NoWarnings' => 0;
 
 recommends 'DBD::mysql';
 recommends 'DBD::Pg';

--- a/t/manifest.t
+++ b/t/manifest.t
@@ -1,0 +1,37 @@
+#!perl
+use v5.14.2;
+use strict;
+use warnings;
+use utf8;
+use Test::More tests => 2;
+use Test::NoWarnings;
+
+use File::Basename qw( dirname );
+
+chdir dirname( dirname( __FILE__ ) ) or BAIL_OUT( "chdir: $!" );
+
+my $makebin = 'make';
+
+sub make {
+    my @make_args = @_;
+
+    undef $ENV{MAKEFLAGS};
+
+    my $command = join( ' ', $makebin, '-s', @make_args );
+    my $output = `$command 2>&1`;
+
+    if ( $? == -1 ) {
+        BAIL_OUT( "failed to execute: $!" );
+    }
+    elsif ( $? & 127 ) {
+        BAIL_OUT( "child died with signal %d, %s coredump\n", ( $? & 127 ), ( $? & 128 ) ? 'with' : 'without' );
+    }
+
+    return $output, $? >> 8;
+}
+
+subtest "distcheck" => sub {
+    my ( $output, $status ) = make "distcheck";
+    is $status, 0,  $makebin . ' distcheck exits with value 0';
+    is $output, "", $makebin . ' distcheck gives empty output';
+};


### PR DESCRIPTION
## Purpose

Run 'make distcheck' in tests.
I followed what was done in "https://github.com/zonemaster/zonemaster-engine/pull/903"
It's the same as "https://github.com/zonemaster/zonemaster-ldns/pull/195"

## Context

Fixes #765 

## How to test this PR

Make sure we don't interfere with the release process:

```
git clean -dfx   # Start out with a clean repository
perl Makefile.PL # Generate the top-level Makefile
make all         # Generate MO files and modules.txt
make distcheck   # Verify that distcheck doesn't report any missing or unrecognized files
```

Run the unit tests in the source directory:

```
make distcheck     # Make sure distcheck doesn't report any missing or unrecognized files
prove t/manifest.t # Verify the new test passes
touch new.file  # Create a file but don't add it to MANIFEST
prove t/manifest.t # Verify the new test fails
echo "new.file" >> MANIFEST.SKIP 
prove t/manifest.t # Verify the new test passes
```

Run the unit tests in the dist file:

```
make distcheck                               # Make sure your repo is clean
make dist                                    # Create the dist file
cpanm --test-only Zonemaster-Backend-*.tar.gz # Run the tests included in the dist file
```
