### PR TITLE
Makes zmb and zmtest unexperimental plus adds file function to batch creation

### DIFF
--- a/script/zmb
+++ b/script/zmb
@@ -512,6 +512,7 @@ sub cmd_add_batch_job {
         while( <$fh> ) {
             chomp;
             s/\s+$//;
+            s/^\s+//;
             next if /^#/ or /^$/;
             push( @opt_domains, decode_utf8( $_ ) );
         };

--- a/script/zmb
+++ b/script/zmb
@@ -464,7 +464,7 @@ sub cmd_add_api_user {
     ignored. Trailing white space is ignored.
 
  "--file" and "--domain" can be combined. Domains specified
-    by any "--domain" are added before thoes specified in the
+    by any "--domain" are added before those specified in the
     file, if any.
 
  DS_INFO is a comma separated list of key-value pairs. The expected pairs are:

--- a/script/zmb
+++ b/script/zmb
@@ -513,7 +513,7 @@ sub cmd_add_batch_job {
             chomp;
             s/\s+$//;
             next if /^#/ or /^$/;
-            push( @opt_domains, $_ );
+            push( @opt_domains, decode_utf8( $_ ) );
         };
     };
 

--- a/script/zmb
+++ b/script/zmb
@@ -19,8 +19,6 @@ Zmb is meant to be pronounced I<Zimba>.
 
 zmb [GLOBAL OPTIONS] COMMAND [OPTIONS]
 
-This interface is unstable and will change in a future release.
-
 =head1 GLOBAL OPTIONS
 
  --help         Show usage
@@ -454,10 +452,20 @@ sub cmd_add_api_user {
     --client-version CLIENT_VERSION
     --profile PROFILE_NAME
     --queue QUEUE
+    --file FILENAME
 
  "--domain" is repeated for each domain to be tested.
  "--nameserver" can be repeated for each name server.
  "--ds-info" can be repeated for each DS record.
+
+ "--file" points at a file with a list of domain names
+    to test, one name per line. Lines starting with "#",
+    empty lines and lines with white space only are
+    ignored. Trailing white space is ignored.
+
+ "--file" and "--domain" can be combined. Domains specified
+    by any "--domain" are added before thoes specified in the
+    file, if any.
 
  DS_INFO is a comma separated list of key-value pairs. The expected pairs are:
 
@@ -475,6 +483,7 @@ sub cmd_add_batch_job {
     my $opt_api_key;
     my @opt_nameserver;
     my @opt_domains;
+    my $opt_file;
     my $opt_client_id;
     my $opt_client_version;
     my @opt_ds_info;
@@ -495,8 +504,18 @@ sub cmd_add_batch_job {
         'ipv6=s'           => \$opt_ipv6,
         'profile=s'        => \$opt_profile,
         'queue=s'          => \$opt_queue,
+        'file=s'           => \$opt_file,
     ) or pod2usage( 2 );
 
+    if ($opt_file) {
+        open( my $fh, "<", $opt_file ) or die "Can't open < $opt_file: $!";
+        while( <$fh> ) {
+            chomp;
+            s/\s+$//;
+            next if /^#/ or /^$/;
+            push( @opt_domains, $_ );
+        };
+    };
 
     my %params = ( domains => \@opt_domains );
 

--- a/script/zmtest
+++ b/script/zmtest
@@ -11,8 +11,6 @@ usage () {
     [ -n "$message" ] && printf "%s\n" "${message}" >&2
     echo "Usage: zmtest [OPTIONS] DOMAIN" >&2
     echo >&2
-    echo "This interface is unstable and may change in a future release." >&2
-    echo >&2
     echo "Options:" >&2
     echo "  -h --help             Show usage (this documentation)." >&2
     echo "  -s URL --server URL   Zonemaster Backend to query. Default is http://localhost:5000/" >&2


### PR DESCRIPTION
Both `zmb` and `zmtest` are useful and have been around for several years, but being stated as experimental. Still they are referred to in documentation. Documentation update in https://github.com/zonemaster/zonemaster/pull/1303 depends heavily on them and also the installation document depend on them. Now it is high time to make then not experimental. If they will need a larger change, new script with new names can be created.

`zmb` can be used to create a batch, but the domain names have to be specified one by one with a `--domain` statement. This PR adds a file function so that the domain names in the batch can be listed in a file.

## Context

https://github.com/zonemaster/zonemaster/pull/1303, and it will be updated with the file function when this PR has been merged.

## How to test this PR

Run `zmtest zonemaster.net` and register any abnormalities (no change to the script).

1. Create a list of three domain names, one domain name per line.
2. For every domain name add one line starting with "#" and one empty line.
3. Create a batch by `zmb add_batch_job --username myuser --api-key mykey --file batchfile.txt | jq` and take note of the batch ID.
4. With `zmb get_batch_job_result --batch-id XX | jq` (where "XX" is the batch ID) verify that that the batch consists of three tests.
5. When the batch is completed, repeat `zmb get_test_results` for every test IDs to verify that all domain names in your list file have been tested.

