### PR TITLE
Uppdates CI/Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,14 @@ addons:
       - build-essential
       - cpanminus
       - libclone-perl
+      - libextutils-pkgconfig-perl
       - libfile-sharedir-perl
       - libfile-slurp-perl
       - libidn2-dev
       - libintl-perl
       - libio-socket-inet6-perl
       - libjson-pp-perl
+      - liblist-compare-perl
       - liblist-moreutils-perl
       - liblocale-msgfmt-perl
       - libmail-rfc822-address-perl


### PR DESCRIPTION
## Purpose

Dependency for Engine added by zonemaster/zonemaster#1307 and zonemaster/zonemaster#1314 must be included for CI, or else Travis will fail. This PR fixes that.

## How to test this PR

Review and unit tests must pass.