### PR TITLE
Adds Slovenian language

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -49,6 +49,7 @@ share/locale/es/LC_MESSAGES/Zonemaster-Backend.mo
 share/locale/fi/LC_MESSAGES/Zonemaster-Backend.mo
 share/locale/fr/LC_MESSAGES/Zonemaster-Backend.mo
 share/locale/nb/LC_MESSAGES/Zonemaster-Backend.mo
+share/locale/sl/LC_MESSAGES/Zonemaster-Backend.mo
 share/locale/sv/LC_MESSAGES/Zonemaster-Backend.mo
 share/Makefile
 share/patch/patch_db_zonemaster_backend_ver_9.0.0.pl

--- a/share/backend_config.ini
+++ b/share/backend_config.ini
@@ -35,7 +35,7 @@ database_file = /var/lib/zonemaster/db.sqlite
 #enable_add_batch_job = no
 
 [LANGUAGE]
-locale = da_DK en_US es_ES fi_FI fr_FR nb_NO sv_SE
+locale = da_DK en_US es_ES fi_FI fr_FR nb_NO sl_SI sv_SE
 
 [PUBLIC PROFILES]
 #example_profile_1=/example/directory/test1_profile.json

--- a/t/test_validate_syntax.t
+++ b/t/test_validate_syntax.t
@@ -23,7 +23,7 @@ engine = SQLite
 database_file = $tempdir/zonemaster.sqlite
 
 [LANGUAGE]
-locale = en_US fr_FR da_DK fi_FI nb_NO sv_SE
+locale = en_US fr_FR da_DK fi_FI nb_NO sl_SI sv_SE
 EOF
 
 my $engine = Zonemaster::Backend::RPCAPI->new(


### PR DESCRIPTION
## Purpose

This PR adds Slovenian language to Backend. It depends on #1185 and https://github.com/zonemaster/zonemaster-cli/pull/384 to be merged first.

When #1185 has been merged, this PR should be rebased on top. This is kept as draft until then.

## Context

#1185 and https://github.com/zonemaster/zonemaster-cli/pull/384

## How to test this PR

Verify that it works to get Slovenian translation with `zmtest` (cannot be tested before the other PRs are merged).

CC: @bzwitt 