### PR TITLE
Sort historic tests by creation date and not ID

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -521,7 +521,7 @@ sub get_test_history {
             undelegated
         FROM test_results
         WHERE progress = 100 AND domain = ? AND ( ? IS NULL OR undelegated = ? )
-        ORDER BY id DESC
+        ORDER BY created_at DESC
         LIMIT ?
         OFFSET ?];
 


### PR DESCRIPTION
## Purpose

This PR changes hos historic tests are sorted. Instead of sorting by ID in the database, sorting is done by creation date of the record. If tests are never deleted or if MariaDB/MySQL is used as database the change will not create any change in sorting.

If Postgresql is used and old tests are removed, then this change will affect sorting. With this change it will be correct.

## Context

Fixes #1211

## How to test this PR

Before applying this PR:

1. Install Backend with Postgresql.
2. Create some tests of the same domain name.
3. Remove a few of the oldest.
4. Do some more tests of the same domain name.
5. Look at historic tests, and the sorting order will be wrong.

After applying this PR:

1. Install Backend with Postgresql.
2. Create some tests of the same domain name.
3. Remove a few of the oldest.
4. Do some more tests of the same domain name.
5. Look at historic tests, and the sorting order will be correct.

