### PR TITLE
Redefines batch_status to replace get_batch_job_result

### DIFF
--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -767,16 +767,16 @@ sub get_batch_job_result {
 
 =head2 batch_status
 
-Returns number of tests per category (finnished, running, waiting) for the given
-batch, provided as "batch_id".
+Returns number of tests per category (finished, running, waiting) for the given
+batch, provided as C<batch_id>.
 
-If one or more of parameters "list_running_tests", "list_finished_tests" or
-"list_waiting_tests" are included with true value, the "hash_id" values for
+If one or more of parameters C<list_running_tests>, C<list_finished_tests> or
+C<list_waiting_tests> are included with true value, the C<hash_id> values for
 that category is also included.
 
 =cut
 
-# Standatd SQL, can be here
+# Standard SQL, can be here
 sub batch_status {
     my ( $self, $test_params ) = @_;
 

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -737,9 +737,11 @@ sub batch_create {
     return $result;
 }
 
+# Deprecated to be removed in v2025.2.
 $json_schemas{get_batch_job_result} = joi->object->strict->props(
     batch_id => $zm_validator->batch_id->required
 );
+# Deprecated to be removed in v2025.2.
 sub get_batch_job_result {
     my ( $self, $params ) = @_;
 
@@ -756,15 +758,29 @@ sub get_batch_job_result {
     return $result;
 }
 
-# Experimental
-$json_schemas{batch_status} = $json_schemas{get_batch_job_result};
+
+$json_schemas{batch_status} = {
+    type => 'object',
+    additionalProperties => 0,
+    required => [ 'batch_id' ],
+    properties => {
+        batch_id => $zm_validator->batch_id->required,
+        list_waiting_tests => joi->boolean->compile,
+        list_running_tests => joi->boolean->compile,
+        list_finished_tests => joi->boolean->compile,
+    }
+};
 sub batch_status {
-    my $result = get_batch_job_result( @_ );
-    return {
-        running_count    => $result->{nb_running},
-        finished_count   => $result->{nb_finished},
-        finished_job_ids => $result->{finished_job_ids},
+    my ( $self, $params ) = @_;
+
+    my $result;
+    eval {
+        $result = $self->{db}->batch_status($params);
     };
+    if ($@) {
+        handle_exception( $@ );
+    }
+    return $result;
 }
 
 sub _get_locale {

--- a/script/zmb
+++ b/script/zmb
@@ -618,9 +618,13 @@ sub cmd_get_batch_job_result {
 
  Options:
    --batch-id BATCH-ID|--bi BATCH-ID
-   --list-waiting-tests|--lw|--no-list-waiting-tests|--no-lw
-   --list-running-tests|--lr|--no-list-running-tests|--no-lr
-   --list-finished-tests|--lf|--no-list-finished-tests|--no-lf
+   --list-waiting-tests true|false|null
+   --list-running-tests true|false|null
+   --list-finished-tests true|false|null
+
+   --lw # Same as "--list-waiting-tests true"
+   --lr # Same as "--list-running-tests true"
+   --lf # Same as "--list-finished-tests true"
 
 "--batch-id" is mandatory.
 
@@ -629,9 +633,13 @@ test finished, respectively, for the batch.
 
 "--list-waiting-tests", "--list-running-tests" and "--list-finished-tests" are
 optional. If given the test IDs of tests waiting to be run, tests running
-and test finished, respectively, are listed. If those options are prefixed with
-"no-" then no test IDs will be listed for that category (the default behavior).
+and test finished, respectively, are listed.
 
+"--lw", "--lr" and "--lf" are option.
+
+"--lw" must not be combined with "--list-waiting-tests". "--lr" must not be
+combined with "--list-running-tests". "--lf" must not be combined with
+"--list-finished-tests".
 =cut
 
 sub cmd_batch_status {
@@ -639,22 +647,36 @@ sub cmd_batch_status {
 
     my $opt_batch_id;
     my $opt_list_waiting_tests;
+    my $opt_lw;
     my $opt_list_running_tests;
+    my $opt_lr;
     my $opt_list_finished_tests;
+    my $opt_lf;
 
     GetOptionsFromArray(
         \@opts,
-        'batch-id|bi=s'        => \$opt_batch_id,
-        'list-waiting-tests|lw!'  => \$opt_list_waiting_tests,
-        'list-running-tests|lr!'  => \$opt_list_running_tests,
-        'list-finished-tests|lf!' => \$opt_list_finished_tests,
+        'batch-id|bi=s'         => \$opt_batch_id,
+        'list-waiting-tests=s'  => \$opt_list_waiting_tests,
+        'lw'                    => \$opt_lw,
+        'list-running-tests=s'  => \$opt_list_running_tests,
+        'lr'                    => \$opt_lr,
+        'list-finished-tests=s' => \$opt_list_finished_tests,
+        'lf'                    => \$opt_lf,
     ) or pod2usage( 2 );
 
+    pod2usage( "'--lw' and '--list-waiting-test' must not be combined" )  if $opt_list_waiting_tests and $opt_lw;
+    pod2usage( "'--lr' and '--list-running-test' must not be combined" )  if $opt_list_running_tests and $opt_lr;
+    pod2usage( "'--lf' and '--list-finished-test' must not be combined" ) if $opt_list_finished_tests and $opt_lf;
+    
     my %params;
     $params{batch_id} = $opt_batch_id;
-    $params{list_waiting_tests} = json_0_or_1_to_boolean( $opt_list_waiting_tests ) if (defined $opt_list_waiting_tests);
-    $params{list_running_tests} = json_0_or_1_to_boolean( $opt_list_running_tests ) if (defined $opt_list_running_tests);
-    $params{list_finished_tests} = json_0_or_1_to_boolean( $opt_list_finished_tests ) if (defined $opt_list_finished_tests);
+    $params{list_waiting_tests} = json_tern( $opt_list_waiting_tests ) if $opt_list_waiting_tests and json_tern( $opt_list_waiting_tests );
+    $params{list_running_tests} = json_tern( $opt_list_running_tests ) if $opt_list_running_tests and json_tern( $opt_list_running_tests );
+    $params{list_finished_tests} = json_tern( $opt_list_finished_tests ) if $opt_list_finished_tests and json_tern( $opt_list_finished_tests );
+
+    $params{list_waiting_tests} = JSON::PP::true if $opt_lw;
+    $params{list_running_tests} = JSON::PP::true if $opt_lr;
+    $params{list_finished_tests} = JSON::PP::true if $opt_lf;
 
     return to_jsonrpc(
         id     => 1,

--- a/script/zmb
+++ b/script/zmb
@@ -618,10 +618,10 @@ sub cmd_get_batch_job_result {
  zmb [GLOBAL OPTIONS] batch_status [OPTIONS]
 
  Options:
-   --batch-id BATCH-ID
-   --list-waiting-tests
-   --list-running-tests
-   --list-finished-tests
+   --batch-id BATCH-ID|--bi BATCH-ID
+   --list-waiting-tests|--lw
+   --list-running-tests|--lr
+   --list-finished-tests|--lf
 
 "--batch-id" is mandatory.
 
@@ -644,10 +644,10 @@ sub cmd_batch_status {
 
     GetOptionsFromArray(
         \@opts,
-        'batch-id|i=s'        => \$opt_batch_id,
-        'list-waiting-tests'  => \$opt_list_waiting_tests,
-        'list-running-tests'  => \$opt_list_running_tests,
-        'list-finished-tests' => \$opt_list_finished_tests,
+        'batch-id|bi=s'        => \$opt_batch_id,
+        'list-waiting-tests|lw'  => \$opt_list_waiting_tests,
+        'list-running-tests|lr'  => \$opt_list_running_tests,
+        'list-finished-tests|lf' => \$opt_list_finished_tests,
     ) or pod2usage( 2 );
 
     my %params;

--- a/script/zmb
+++ b/script/zmb
@@ -584,8 +584,7 @@ sub cmd_add_batch_job {
     );
 }
 
-
-=head2 get_batch_job_result (** deprecated to be removed v2025.2 **)
+=head2 get_batch_job_result (** Deprecated to be removed in Zonemaster version v2025.2. Use C<batch_status> instead. **)
 
  zmb [GLOBAL OPTIONS] get_batch_job_result [OPTIONS]
 

--- a/script/zmb
+++ b/script/zmb
@@ -664,9 +664,9 @@ sub cmd_batch_status {
         'lf'                    => \$opt_lf,
     ) or pod2usage( 2 );
 
-    pod2usage( "'--lw' and '--list-waiting-test' must not be combined" )  if $opt_list_waiting_tests and $opt_lw;
-    pod2usage( "'--lr' and '--list-running-test' must not be combined" )  if $opt_list_running_tests and $opt_lr;
-    pod2usage( "'--lf' and '--list-finished-test' must not be combined" ) if $opt_list_finished_tests and $opt_lf;
+    pod2usage( "'--lw' and '--list-waiting-test' must not be combined" )  if defined $opt_list_waiting_tests and $opt_lw;
+    pod2usage( "'--lr' and '--list-running-test' must not be combined" )  if defined $opt_list_running_tests and $opt_lr;
+    pod2usage( "'--lf' and '--list-finished-test' must not be combined" ) if defined $opt_list_finished_tests and $opt_lf;
     
     my %params;
     $params{batch_id} = $opt_batch_id;
@@ -731,20 +731,6 @@ sub json_tern {
     }
     else {
         die 'Illegal value. Expects "true", "false" or "null" ';
-    }
-}
-
-sub json_0_or_1_to_boolean {
-    my $value = shift;
-
-    if ( $value == 1 ) {
-        return JSON::PP::true;
-    }
-    elsif ( $value == 0 ) {
-        return JSON::PP::false;
-    }
-    else {
-        die 'Illegal value. Expects 0 or 1 ';
     }
 }
 

--- a/script/zmb
+++ b/script/zmb
@@ -585,7 +585,7 @@ sub cmd_add_batch_job {
 }
 
 
-=head2 get_batch_job_result
+=head2 get_batch_job_result (** deprecated to be removed v2025.2 **)
 
  zmb [GLOBAL OPTIONS] get_batch_job_result [OPTIONS]
 
@@ -609,6 +609,58 @@ sub cmd_get_batch_job_result {
         params => {
             batch_id => $opt_batch_id,
         },
+    );
+}
+
+
+=head2 batch_status
+
+ zmb [GLOBAL OPTIONS] batch_status [OPTIONS]
+
+ Options:
+   --batch-id BATCH-ID
+   --list-waiting-tests
+   --list-running-tests
+   --list-finished-tests
+
+"--batch-id" is mandatory.
+
+The command provides the number of tests waiting to be run, tests running and
+test finished, respectively, for the batch.
+
+"--list-waiting-tests", "--list-running-tests" and "--list-finished-tests" are
+optional. If given the test IDs of tests waiting to be run, tests running
+and test finished, respectively, are listed.
+
+=cut
+
+sub cmd_batch_status {
+    my @opts = @_;
+
+    my $opt_batch_id;
+    my $opt_list_waiting_tests;
+    my $opt_list_running_tests;
+    my $opt_list_finished_tests;
+
+    GetOptionsFromArray(
+        \@opts,
+        'batch-id|i=s'        => \$opt_batch_id,
+        'list-waiting-tests'  => \$opt_list_waiting_tests,
+        'list-running-tests'  => \$opt_list_running_tests,
+        'list-finished-tests' => \$opt_list_finished_tests,
+    ) or pod2usage( 2 );
+
+    my %params;
+    $params{batch_id} = $opt_batch_id;
+
+    $params{list_waiting_tests} = "true" if $opt_list_waiting_tests;
+    $params{list_running_tests} = "true" if $opt_list_running_tests;
+    $params{list_finished_tests} = "true" if $opt_list_finished_tests;
+
+    return to_jsonrpc(
+        id     => 1,
+        method => 'batch_status',
+        params => \%params,
     );
 }
 

--- a/script/zmb
+++ b/script/zmb
@@ -651,10 +651,9 @@ sub cmd_batch_status {
 
     my %params;
     $params{batch_id} = $opt_batch_id;
-
-    $params{list_waiting_tests} = JSON->boolean( $opt_list_waiting_tests ) if defined $opt_list_waiting_tests;
-    $params{list_running_tests} = JSON->boolean( $opt_list_running_tests ) if defined $opt_list_running_tests;
-    $params{list_finished_tests} = JSON->boolean( $opt_list_finished_tests ) if defined $opt_list_finished_tests;
+    $params{list_waiting_tests} = json_tern( $opt_list_waiting_tests ) if (defined $opt_list_waiting_tests);
+    $params{list_running_tests} = json_tern( $opt_list_running_tests ) if (defined $opt_list_running_tests);
+    $params{list_finished_tests} = json_tern( $opt_list_finished_tests ) if (defined $opt_list_finished_tests);
 
     return to_jsonrpc(
         id     => 1,
@@ -694,12 +693,14 @@ sub get_commands {
       grep { $_ =~ /^cmd_/ } grep { defined &{"main\::$_"} } keys %{"main\::"};
 }
 
+
 sub json_tern {
     my $value = shift;
-    if ( $value eq 'true' ) {
+
+    if ( $value eq 'true' or $value == 1 ) {
         return JSON::PP::true;
     }
-    elsif ( $value eq 'false' ) {
+    elsif ( $value eq 'false' or $value == 0 ) {
         return JSON::PP::false;
     }
     elsif ( $value eq 'null' ) {

--- a/script/zmb
+++ b/script/zmb
@@ -645,17 +645,17 @@ sub cmd_batch_status {
     GetOptionsFromArray(
         \@opts,
         'batch-id|bi=s'        => \$opt_batch_id,
-        'list-waiting-tests|lw'  => \$opt_list_waiting_tests,
-        'list-running-tests|lr'  => \$opt_list_running_tests,
-        'list-finished-tests|lf' => \$opt_list_finished_tests,
+        'list-waiting-tests|lw!'  => \$opt_list_waiting_tests,
+        'list-running-tests|lr!'  => \$opt_list_running_tests,
+        'list-finished-tests|lf!' => \$opt_list_finished_tests,
     ) or pod2usage( 2 );
 
     my %params;
     $params{batch_id} = $opt_batch_id;
 
-    $params{list_waiting_tests} = "true" if $opt_list_waiting_tests;
-    $params{list_running_tests} = "true" if $opt_list_running_tests;
-    $params{list_finished_tests} = "true" if $opt_list_finished_tests;
+    $params{list_waiting_tests} = JSON->boolean( $opt_list_waiting_tests ) if defined $opt_list_waiting_tests;
+    $params{list_running_tests} = JSON->boolean( $opt_list_running_tests ) if defined $opt_list_running_tests;
+    $params{list_finished_tests} = JSON->boolean( $opt_list_finished_tests ) if defined $opt_list_finished_tests;
 
     return to_jsonrpc(
         id     => 1,

--- a/script/zmb
+++ b/script/zmb
@@ -618,9 +618,9 @@ sub cmd_get_batch_job_result {
 
  Options:
    --batch-id BATCH-ID|--bi BATCH-ID
-   --list-waiting-tests|--lw
-   --list-running-tests|--lr
-   --list-finished-tests|--lf
+   --list-waiting-tests|--lw|--no-list-waiting-tests|--no-lw
+   --list-running-tests|--lr|--no-list-running-tests|--no-lr
+   --list-finished-tests|--lf|--no-list-finished-tests|--no-lf
 
 "--batch-id" is mandatory.
 
@@ -629,7 +629,8 @@ test finished, respectively, for the batch.
 
 "--list-waiting-tests", "--list-running-tests" and "--list-finished-tests" are
 optional. If given the test IDs of tests waiting to be run, tests running
-and test finished, respectively, are listed.
+and test finished, respectively, are listed. If those options are prefixed with
+"no-" then no test IDs will be listed for that category (the default behavior).
 
 =cut
 
@@ -651,9 +652,9 @@ sub cmd_batch_status {
 
     my %params;
     $params{batch_id} = $opt_batch_id;
-    $params{list_waiting_tests} = json_tern( $opt_list_waiting_tests ) if (defined $opt_list_waiting_tests);
-    $params{list_running_tests} = json_tern( $opt_list_running_tests ) if (defined $opt_list_running_tests);
-    $params{list_finished_tests} = json_tern( $opt_list_finished_tests ) if (defined $opt_list_finished_tests);
+    $params{list_waiting_tests} = json_0_or_1_to_boolean( $opt_list_waiting_tests ) if (defined $opt_list_waiting_tests);
+    $params{list_running_tests} = json_0_or_1_to_boolean( $opt_list_running_tests ) if (defined $opt_list_running_tests);
+    $params{list_finished_tests} = json_0_or_1_to_boolean( $opt_list_finished_tests ) if (defined $opt_list_finished_tests);
 
     return to_jsonrpc(
         id     => 1,
@@ -697,10 +698,10 @@ sub get_commands {
 sub json_tern {
     my $value = shift;
 
-    if ( $value eq 'true' or $value == 1 ) {
+    if ( $value eq 'true' ) {
         return JSON::PP::true;
     }
-    elsif ( $value eq 'false' or $value == 0 ) {
+    elsif ( $value eq 'false' ) {
         return JSON::PP::false;
     }
     elsif ( $value eq 'null' ) {
@@ -708,6 +709,20 @@ sub json_tern {
     }
     else {
         die 'Illegal value. Expects "true", "false" or "null" ';
+    }
+}
+
+sub json_0_or_1_to_boolean {
+    my $value = shift;
+
+    if ( $value == 1 ) {
+        return JSON::PP::true;
+    }
+    elsif ( $value == 0 ) {
+        return JSON::PP::false;
+    }
+    else {
+        die 'Illegal value. Expects 0 or 1 ';
     }
 }
 

--- a/script/zonemaster_backend_rpcapi.psgi
+++ b/script/zonemaster_backend_rpcapi.psgi
@@ -169,12 +169,12 @@ my $router = router {
         action => "domain_history"
     };
 
+    # Deprecated to be removed v2025.2
     connect "get_batch_job_result" => {
         handler => $handler,
         action => "get_batch_job_result"
     };
 
-    # Experimental
     connect "batch_status" => {
         handler => $handler,
         action => "batch_status"

--- a/t/batches.t
+++ b/t/batches.t
@@ -249,7 +249,7 @@ subtest 'batch with several domains' => sub {
     is( $res->{waiting_count}, scalar @domains, 'correct number of runninng tests' );
     is( $res->{running_count}, 0, 'correct number of finished tests' );
     is( $res->{finished_count}, 0, 'correct number of finished tests' );
-    eq_or_diff( $res->{waiting_tests}, \@domains, 'correct contents of waiting_tests' );
+    is( scalar @{ $res->{waiting_tests} }, scalar @domains, 'correct number of elements in waiting_tests' );
     ok( !$res->{running_tests}, 'list of running tests expected to be absent' );
     ok( !$res->{finished_tests}, 'list of finished tests expected to be absent' );
 

--- a/t/batches.t
+++ b/t/batches.t
@@ -249,7 +249,7 @@ subtest 'batch with several domains' => sub {
     is( $res->{waiting_count}, scalar @domains, 'correct number of runninng tests' );
     is( $res->{running_count}, 0, 'correct number of finished tests' );
     is( $res->{finished_count}, 0, 'correct number of finished tests' );
-    eg_or_diff( $res->{waiting_tests}, \@domains, 'correct contents of waiting_tests' );
+    eq_or_diff( $res->{waiting_tests}, \@domains, 'correct contents of waiting_tests' );
     ok( !$res->{running_tests}, 'list of running tests expected to be absent' );
     ok( !$res->{finished_tests}, 'list of finished tests expected to be absent' );
 

--- a/t/batches.t
+++ b/t/batches.t
@@ -150,7 +150,8 @@ subtest 'RPCAPI add_batch_job' => sub {
     };
 };
 
-subtest 'RPCAPI get_batch_job_result' => sub {
+subtest 'RPCAPI get_batch_job_result and batch_status' => sub {
+    # "get_batch_job_result deprecated to be removed by v2025.2
     my $config = Zonemaster::Backend::Config->parse( $config );
     my $rpcapi = init_backend( $config );
     subtest 'batch job exists' => sub {
@@ -170,12 +171,33 @@ subtest 'RPCAPI get_batch_job_result' => sub {
 
         is( $res->{nb_running}, @domains, 'correct number of runninng tests' );
         is( $res->{nb_finished}, 0, 'correct number of finished tests' );
+
+        my $res = $rpcapi->batch_status( { batch_id => $batch_id } );
+
+        is( $res->{waiting_count}, @domains, 'correct number of runninng tests' );
+        is( $res->{running_count}, 0, 'correct number of finished tests' );
+        is( $res->{finished_count}, 0, 'correct number of finished tests' );
+        is( $res->{waiting_tests}, undef, 'correct undefined list of waiting tests' );
+        is( $res->{running_tests}, undef, 'correct undefined list of running tests' );
+        is( $res->{finished_tests}, undef, 'correct undefined list of finished tests' );
+
     };
 
-    subtest 'unknown batch' => sub {
+    subtest 'unknown batch (get_batch_job_result)' => sub {
         my $unknown_batch = 10;
         dies_ok {
             $rpcapi->get_batch_job_result( { batch_id => $unknown_batch } );
+        } 'getting results for an unknown batch_id should die';
+        my $res = $@;
+        is( $res->{error}, 'Zonemaster::Backend::Error::ResourceNotFound', 'correct error type' );
+        is( $res->{message}, 'Unknown batch', 'correct error message' );
+        is( $res->{data}->{batch_id}, $unknown_batch, 'correct data type returned' );
+    };
+
+    subtest 'unknown batch (batch_status)' => sub {
+        my $unknown_batch = 10;
+        dies_ok {
+            $rpcapi->batch_status( { batch_id => $unknown_batch } );
         } 'getting results for an unknown batch_id should die';
         my $res = $@;
         is( $res->{error}, 'Zonemaster::Backend::Error::ResourceNotFound', 'correct error type' );
@@ -201,11 +223,33 @@ subtest 'batch with several domains' => sub {
 
     is( $res, 1, 'correct batch job id returned' );
 
+    # "get_batch_job_result deprecated to be removed by v2025.2
     $res = $rpcapi->get_batch_job_result( { batch_id => 1 } );
 
     is( $res->{nb_running}, @domains, 'correct number of runninng tests' );
     is( $res->{nb_finished}, 0, 'correct number of finished tests' );
+    
+    # No lists of test IDs requested
+    $res = $rpcapi->batch_status( { batch_id => 1 } );
 
+    is( $res->{waiting_count}, @domains, 'correct number of runninng tests' );
+    is( $res->{running_count}, 0, 'correct number of finished tests' );
+    is( $res->{finished_count}, 0, 'correct number of finished tests' );
+    is( $res->{waiting_tests}, undef, 'correct undefined list of waiting tests' );
+    is( $res->{running_tests}, undef, 'correct undefined list of running tests' );
+    is( $res->{finished_tests}, undef, 'correct undefined list of finished tests' );
+
+    # List of waiting test IDs requested
+    $res = $rpcapi->batch_status( { batch_id => 1, list_waiting_tests => 1 } );
+
+    is( $res->{waiting_count}, @domains, 'correct number of runninng tests' );
+    is( $res->{running_count}, 0, 'correct number of finished tests' );
+    is( $res->{finished_count}, 0, 'correct number of finished tests' );
+    is( scalar @{ $res->{waiting_tests} }, scalar @domains, 'correct number of waiting tests in list' );
+    is( $res->{running_tests}, undef, 'correct undefined list of running tests' );
+    is( $res->{finished_tests}, undef, 'correct undefined list of finished tests' );
+
+    
     subtest 'table "test_results" contains 2 entries' => sub {
         my ( $count ) = $dbh->selectrow_array( q[ SELECT count(*) FROM test_results ] );
         is( $count, @domains, 'two rows in table' );

--- a/t/batches.t
+++ b/t/batches.t
@@ -171,7 +171,7 @@ subtest 'RPCAPI get_batch_job_result and batch_status' => sub {
         {
             my $res = $rpcapi->get_batch_job_result( { batch_id => $batch_id } );
 
-            is( $res->{nb_running}, @domains, 'correct number of runninng tests' );
+            is( $res->{nb_running}, scalar @domains, 'correct number of runninng tests' );
             is( $res->{nb_finished}, 0, 'correct number of finished tests' );
         }
 
@@ -181,9 +181,9 @@ subtest 'RPCAPI get_batch_job_result and batch_status' => sub {
             is( $res->{waiting_count}, scalar @domains, 'correct number of runninng tests' );
             is( $res->{running_count}, 0, 'correct number of finished tests' );
             is( $res->{finished_count}, 0, 'correct number of finished tests' );
-            ok( !$res->{waiting_tests}, 'list of waiting tests expected to be absent' );
-            ok( !$res->{running_tests}, 'list of running tests expected to be absent' );
-            ok( !$res->{finished_tests}, 'list of finished tests to be absent' );
+            ok( !exists $res->{waiting_tests}, 'list of waiting tests expected to be absent' );
+            ok( !exists $res->{running_tests}, 'list of running tests expected to be absent' );
+            ok( !exists $res->{finished_tests}, 'list of finished tests to be absent' );
         }
     };
 
@@ -239,9 +239,9 @@ subtest 'batch with several domains' => sub {
     is( $res->{waiting_count}, scalar @domains, 'correct number of running tests' );
     is( $res->{running_count}, 0, 'correct number of finished tests' );
     is( $res->{finished_count}, 0, 'correct number of finished tests' );
-    ok( !$res->{waiting_tests}, 'list of waiting tests expected to be absent' );
-    ok( !$res->{running_tests}, 'list of running tests expected to be absent' );
-    ok( !$res->{finished_tests}, 'list of finished tests expected to be absent' );
+    ok( !exists $res->{waiting_tests}, 'list of waiting tests expected to be absent' );
+    ok( !exists $res->{running_tests}, 'list of running tests expected to be absent' );
+    ok( !exists $res->{finished_tests}, 'list of finished tests expected to be absent' );
 
     # List of waiting test IDs requested
     $res = $rpcapi->batch_status( { batch_id => 1, list_waiting_tests => 1 } );
@@ -250,8 +250,8 @@ subtest 'batch with several domains' => sub {
     is( $res->{running_count}, 0, 'correct number of finished tests' );
     is( $res->{finished_count}, 0, 'correct number of finished tests' );
     is( scalar @{ $res->{waiting_tests} }, scalar @domains, 'correct number of elements in waiting_tests' );
-    ok( !$res->{running_tests}, 'list of running tests expected to be absent' );
-    ok( !$res->{finished_tests}, 'list of finished tests expected to be absent' );
+    ok( !exists $res->{running_tests}, 'list of running tests expected to be absent' );
+    ok( !exists $res->{finished_tests}, 'list of finished tests expected to be absent' );
 
     subtest 'table "test_results" contains 2 entries' => sub {
         my ( $count ) = $dbh->selectrow_array( q[ SELECT count(*) FROM test_results ] );


### PR DESCRIPTION
## Purpose

This PR implements the RPCAPI update in zonemaster/zonemaster/pull/1304.

## Changes

`batch_status` was defined as an alias to `get_batch_job_result`. Now it redefined to be a smarter replacement of the old API.

## How to test this PR

Prepare a small batch (10-15 domain names) in a text file. Set down `number_of_processes_for_frontend_testing` and `number_of_processes_for_batch_testing` to a low value (e.g. 2). Start the batch with `zmb` and read the batch status with `zmb`. Read the status with various values of the optional options.
