### PR TITLE
Formal states in tables

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,16 @@
 Release history for Zonemaster component Zonemaster-Backend
 
+v12.2.0 YYYY-MM-DD (part of Zonemaster v2026.2 release)
+
+ [Release information]
+ - Migration of the database is required by this release to add
+   the test state column. Follow the instructions in the
+   Zonemaster-Backend upgrade guide to upgrade to version 12.2.0.
+
+ [Features]
+ - Adds formal test states (waiting, running, completed, cancelled,
+   crashed) to the database (#1246)
+
 
 v12.1.1 2026-07-22 (part of Zonemaster v2026.1.1 release)
 

--- a/MANIFEST
+++ b/MANIFEST
@@ -54,6 +54,7 @@ share/locale/sl/LC_MESSAGES/Zonemaster-Backend.mo
 share/locale/sv/LC_MESSAGES/Zonemaster-Backend.mo
 share/Makefile
 share/patch/patch_db_schema_version_1.pl
+share/patch/patch_db_schema_version_2.pl
 share/patch/patch_db_zonemaster_backend_ver_11.1.0.pl
 share/patch/patch_db_zonemaster_backend_ver_11.2.0.pl
 share/patch/patch_db_zonemaster_backend_ver_9.0.0.pl

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -1067,7 +1067,7 @@ and mark test with $hash_id as COMPLETED.
 =cut
 
 sub force_end_test {
-    my ( $self, $hash_id, $msg ,$state) = @_;
+    my ( $self, $hash_id, $msg , $state ) = @_;
 
     $self->add_result_entries( $hash_id, $msg );
     $self->set_test_completed( $hash_id, $state);

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -618,8 +618,8 @@ sub select_test_results {
         unless defined $result;
 
     $result->{created_at} = $self->to_iso8601( $result->{created_at} );
-    $result->{started_at} = $self->to_iso8601( $result->{started_at} );
-    $result->{ended_at}   = $self->to_iso8601( $result->{endded_at} );
+    $result->{started_at} = $self->to_iso8601( $result->{started_at} ) if defined $result->{started_at};
+    $result->{ended_at}   = $self->to_iso8601( $result->{ended_at} )   if defined $result->{ended_at};
 
     return $result;
 }

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -917,11 +917,11 @@ sub select_unfinished_tests {
             SELECT hash_id, results
             FROM test_results
             WHERE started_at < ?
-            AND progress > 0
-            AND progress < 100
+            AND state = ?
             AND queue = ?" );
         $sth->execute(    #
             $self->format_time( time() - $test_run_timeout ),
+            $TEST_RUNNING,
             $queue_label,
         );
         return $sth;
@@ -931,10 +931,10 @@ sub select_unfinished_tests {
             SELECT hash_id, results
             FROM test_results
             WHERE started_at < ?
-            AND progress > 0
-            AND progress < 100" );
+            AND state = ?" );
         $sth->execute(    #
             $self->format_time( time() - $test_run_timeout ),
+            $TEST_RUNNING,
         );
         return $sth;
     }

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -487,6 +487,8 @@ sub select_test_results {
             SELECT
                 hash_id,
                 created_at,
+                started_at,
+                ended_at,
                 params
             FROM test_results
             WHERE hash_id = ?

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -447,7 +447,9 @@ sub test_state {
 }
 
 sub set_test_completed {
-    my ( $self, $test_id ) = @_;
+    my ( $self, $test_id, $state) = @_;
+
+    $state //= $TEST_COMPLETED;
 
     my $current_state = $self->test_state( $test_id );
 
@@ -466,7 +468,7 @@ sub set_test_completed {
               AND progress < 100
         ],
         undef,
-        $TEST_COMPLETED,
+        $state,
         $self->format_time( time() ),
         $test_id,
     );
@@ -893,7 +895,7 @@ sub process_unfinished_tests {
         }
     );
     while ( my $h = $sth1->fetchrow_hashref ) {
-        $self->force_end_test($h->{hash_id}, $msg);
+        $self->force_end_test($h->{hash_id}, $msg, $TEST_CANCELLED);
     }
 }
 
@@ -943,10 +945,10 @@ and mark test with $hash_id as COMPLETED.
 =cut
 
 sub force_end_test {
-    my ( $self, $hash_id, $msg ) = @_;
+    my ( $self, $hash_id, $msg ,$state) = @_;
 
     $self->add_result_entries( $hash_id, $msg );
-    $self->set_test_completed( $hash_id );
+    $self->set_test_completed( $hash_id, $state);
 }
 
 =head2 process_dead_test($hash_id)
@@ -968,7 +970,7 @@ sub process_dead_test {
             timestamp => $self->get_relative_start_time($hash_id)
         }
     );
-    $self->force_end_test($hash_id, $msg);
+    $self->force_end_test($hash_id, $msg, $TEST_CRASHED);
 }
 
 # Converts the domain to lowercase and if the domain is not the root ('.')

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -568,11 +568,19 @@ sub set_test_completed {
 
     $state //= $TEST_COMPLETED;
 
+    unless (
+      defined $state
+      && grep { $_ eq $state } ( $TEST_COMPLETED, $TEST_CANCELLED, $TEST_CRASHED )
+    ) {
+      die Zonemaster::Backend::Error::Internal->new(reason => 'invalid terminal state',);
+    }
+
     my $current_state = $self->test_state( $test_id );
 
     if ( $current_state ne $TEST_RUNNING ) {
         die Zonemaster::Backend::Error::Internal->new( reason => 'illegal transition to terminal state (COMPLETED/CANCELLED/CRASHED)' );
     }
+
 
     my $rows_affected = $self->dbh->do(
         q[

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -718,7 +718,7 @@ sub get_test_history {
             created_at,
             undelegated
         FROM test_results
-        WHERE progress = 100 AND domain = ? AND ( ? IS NULL OR undelegated = ? )
+        WHERE state IN('completed', 'cancelled', 'crashed') AND domain = ? AND ( ? IS NULL OR undelegated = ? )
         ORDER BY created_at DESC
         LIMIT ?
         OFFSET ?];

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -70,7 +70,7 @@ A positive integer. The database schema version that this module is compatible w
 
 =cut
 
-Readonly our $REQUIRED_SCHEMA_VERSION => 1;
+Readonly our $REQUIRED_SCHEMA_VERSION => 2;
 
 =head2 $TEST_WAITING
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -579,13 +579,13 @@ sub set_test_completed {
                 state = ?,
                 ended_at = ?
             WHERE hash_id = ?
-              AND 0 < progress
-              AND progress < 100
+              AND state = ?
         ],
         undef,
         $state,
         $self->format_time( time() ),
         $test_id,
+        $TEST_RUNNING,
     );
 
     if ( $rows_affected == 0 ) {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -128,6 +128,8 @@ Each test in the database is always in exactly one of five formal states. The
 state is stored in the C<state> column of the C<test_results> table and is
 enforced by a C<CHECK> constraint.
 
+The complete state model is documented in C<docs/formal-test-states.md>.
+
 =over 4
 
 =item B<waiting>
@@ -939,7 +941,10 @@ sub get_test_params {
 =head2 batch_status
 
 Returns number of tests per category (finished, running, waiting) for the given
-batch, provided as C<batch_id>.
+batch, provided as C<batch_id>. The categories are determined from the formal
+test state: C<waiting> and C<running> retain their respective categories, and
+all terminal states (C<completed>, C<cancelled> and C<crashed>) are counted as
+finished.
 
 If one or more of parameters C<list_running_tests>, C<list_finished_tests> or
 C<list_waiting_tests> are included with true value, the C<hash_id> values for
@@ -964,7 +969,7 @@ sub batch_status {
     $result{finished_count} = 0;
 
     my $query = "
-        SELECT hash_id, progress
+        SELECT hash_id, state
         FROM test_results
         WHERE batch_id=?";
 
@@ -972,17 +977,17 @@ sub batch_status {
     $sth1->execute( $batch_id );
 
     while ( my $h = $sth1->fetchrow_hashref ) {
-        if ( $h->{progress} eq '0' ) {
+        if ( $h->{state} eq $TEST_WAITING ) {
             $result{waiting_count}++;
             push(@{$result{waiting_tests}}, $h->{hash_id}) if $test_params->{list_waiting_tests};
         }
-        elsif ( $h->{progress} eq '100' ) {
-            $result{finished_count}++;
-            push(@{$result{finished_tests}}, $h->{hash_id}) if $test_params->{list_finished_tests};
-        }
-        else {
+        elsif ( $h->{state} eq $TEST_RUNNING ) {
             $result{running_count}++;
             push(@{$result{running_tests}}, $h->{hash_id}) if $test_params->{list_running_tests};
+        }
+        else {
+            $result{finished_count}++;
+            push(@{$result{finished_tests}}, $h->{hash_id}) if $test_params->{list_finished_tests};
         }
     }
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -395,12 +395,13 @@ sub test_progress {
                 UPDATE test_results
                 SET progress = ?
                 WHERE hash_id = ?
-                  AND 1 <= progress
+                  AND state = ?
                   AND progress <= ?
             ],
             undef,
             $progress,
             $test_id,
+            $TEST_RUNNING,
             $progress,
         );
         if ( $rows_affected == 0 ) {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -298,11 +298,12 @@ sub create_new_test {
                     created_at,
                     priority,
                     queue,
+                    state,
                     fingerprint,
                     params,
                     domain,
                     undelegated
-                ) VALUES (?,?,?,?,?,?,?,?,?)
+                ) VALUES (?,?,?,?,?,?,?,?,?,?)
             ],
             undef,
             $hash_id,
@@ -310,6 +311,7 @@ sub create_new_test {
             $self->format_time( time() ),
             $priority,
             $queue_label,
+            $TEST_WAITING,
             $fingerprint,
             $encoded_params,
             encode_utf8( $test_params->{domain} ),

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -427,31 +427,21 @@ sub test_progress {
 sub test_state {
     my ( $self, $test_id ) = @_;
 
-    my ( $progress ) = $self->dbh->selectrow_array(
+    my ( $state ) = $self->dbh->selectrow_array(
         q[
-            SELECT progress
+            SELECT state
             FROM test_results
             WHERE hash_id = ?
         ],
         undef,
         $test_id,
     );
-    if ( !defined $progress ) {
+
+    if ( !defined $state ) {
         die Zonemaster::Backend::Error::Internal->new( reason => 'job not found' );
     }
 
-    if ( $progress == 0 ) {
-        return $TEST_WAITING;
-    }
-    elsif ( 0 < $progress && $progress < 100 ) {
-        return $TEST_RUNNING;
-    }
-    elsif ( $progress == 100 ) {
-        return $TEST_COMPLETED;
-    }
-    else {
-        die Zonemaster::Backend::Error::Internal->new( reason => 'state could not be determined' );
-    }
+    return $state;
 }
 
 sub set_test_completed {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -773,13 +773,16 @@ sub claim_test {
         q[
             UPDATE test_results
             SET progress = 1,
+                state = ?,
                 started_at = ?
             WHERE hash_id = ?
-              AND progress = 0
+              AND state = ?
         ],
         undef,
+        $TEST_RUNNING,
         $self->format_time( time() ),
         $test_id,
+        $TEST_WAITING,
     );
 
     return $rows_affected == 1;

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -62,6 +62,8 @@ has 'dbhandlepid' => (
     required => 0,
 );
 
+=head1 CONSTANTS
+
 =head2 $REQUIRED_SCHEMA_VERSION
 
 A positive integer. The database schema version that this module is compatible with.
@@ -118,6 +120,65 @@ our @EXPORT_OK = qw(
     $TEST_CANCELLED
     $TEST_CRASHED
 );
+
+
+=head1 TEST STATES
+
+Each test in the database is always in exactly one of five formal states. The
+state is stored in the C<state> column of the C<test_results> table and is
+enforced by a C<CHECK> constraint.
+
+=over 4
+
+=item B<waiting>
+
+The test has been created but is waiting to be picked up for processing.
+This is the initial state set by C<create_new_test()>.
+In this state C<progress> is C<0> and C<started_at> is C<NULL>.
+
+=item B<running>
+
+The test has been claimed by a worker and is currently being processed.
+This state is entered through C<claim_test()>.
+In this state C<progress> is in the range 1-99 inclusive and
+C<started_at> is set.
+
+=item B<completed>
+
+The test finished normally.
+This state is entered through C<set_test_completed()> or C<store_results()>.
+In this state C<progress> is C<100> and C<ended_at> is set.
+
+=item B<cancelled>
+
+The test was terminated because it exceeded the configured maximum execution
+time.
+This state is entered through C<process_unfinished_tests()>.
+In this state C<progress> is C<100> and C<ended_at> is set.
+The result entries include a C<BACKEND_TEST_AGENT:UNABLE_TO_FINISH_TEST>
+message.
+
+=item B<crashed>
+
+The test worker crashed while processing the test.
+This state is entered through C<process_dead_test()>.
+In this state C<progress> is C<100> and C<ended_at> is set.
+The result entries include a C<BACKEND_TEST_AGENT:TEST_DIED> message.
+
+=back
+
+=head2 State transitions
+
+The only legal state transitions are:
+
+  waiting -> running
+  running -> completed
+  running -> cancelled
+  running -> crashed
+
+Any other state change is illegal and causes an error.
+
+=cut
 
 
 =head2 get_db_class
@@ -427,6 +488,28 @@ sub test_progress {
     return $result;
 }
 
+=head2 test_state( $test_id )
+
+Get the state of the test associated with C<$test_id>.
+
+Returns one of the state constants documented in L</TEST STATES>.
+
+Dies when:
+
+=over 2
+
+=item
+
+attempting to access a test that does not exist
+
+=item
+
+an error occurs in the database interface
+
+=back
+
+=cut
+
 sub test_state {
     my ( $self, $test_id ) = @_;
 
@@ -446,6 +529,37 @@ sub test_state {
 
     return $state;
 }
+
+=head2 set_test_completed( $test_id, [$state] )
+
+Transition a test from the C<running> state to a terminal state.
+
+C<$state> is optional and defaults to C<completed>.
+It must be one of the terminal states documented in L</TEST STATES>
+(C<completed>, C<cancelled> or C<crashed>).
+
+In the database the test is updated with C<progress> set to 100, the given
+C<state> and C<ended_at> set to the current time.
+
+Dies when:
+
+=over 2
+
+=item
+
+attempting to access a test that does not exist
+
+=item
+
+attempting to update a test that is not in the C<running> state
+
+=item
+
+an error occurs in the database interface
+
+=back
+
+=cut
 
 sub set_test_completed {
     my ( $self, $test_id, $state) = @_;

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -618,6 +618,8 @@ sub select_test_results {
         unless defined $result;
 
     $result->{created_at} = $self->to_iso8601( $result->{created_at} );
+    $result->{started_at} = $self->to_iso8601( $result->{started_at} );
+    $result->{ended_at}   = $self->to_iso8601( $result->{endded_at} );
 
     return $result;
 }

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -459,12 +459,14 @@ sub set_test_completed {
         q[
             UPDATE test_results
             SET progress = 100,
+                state = ?,
                 ended_at = ?
             WHERE hash_id = ?
               AND 0 < progress
               AND progress < 100
         ],
         undef,
+        $TEST_COMPLETED,
         $self->format_time( time() ),
         $test_id,
     );

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -511,16 +511,18 @@ sub store_results {
         q[
             UPDATE test_results
             SET progress = 100,
+                state = ?,
                 ended_at = ?,
                 results = ?
             WHERE hash_id = ?
-              AND 0 < progress
-              AND progress < 100
+              AND state = ?
         ],
         undef,
+        $TEST_COMPLETED,
         $self->format_time( time() ),
         $new_results,
         $test_id,
+        $TEST_RUNNING,
     );
 
     if ( $rows_affected == 0 ) {

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -1062,7 +1062,7 @@ sub select_unfinished_tests {
 =head2 force_end_test($hash_id, $msg)
 
 Store the L<Zonemaster::Engine::Logger::Entry> $msg log entry into the database
-and mark test with $hash_id as COMPLETED.
+and mark test with $hash_id as COMPLETED / CANCELLED / CRASHED.
 
 =cut
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -720,13 +720,14 @@ sub get_test_request {
                     SELECT hash_id,
                            batch_id
                     FROM test_results
-                    WHERE progress = 0
+                    WHERE state = ?
                       AND queue = ?
                     ORDER BY priority DESC,
                              id ASC
                     LIMIT 1
                 ],
                 undef,
+                $TEST_WAITING,
                 $queue_label,
             );
         }
@@ -736,11 +737,13 @@ sub get_test_request {
                     SELECT hash_id,
                            batch_id
                     FROM test_results
-                    WHERE progress = 0
+                    WHERE state = ?
                     ORDER BY priority DESC,
                              id ASC
                     LIMIT 1
                 ],
+                undef,
+                $TEST_WAITING,
             );
         }
 

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -562,7 +562,7 @@ an error occurs in the database interface
 =cut
 
 sub set_test_completed {
-    my ( $self, $test_id, $state) = @_;
+    my ( $self, $test_id, $state ) = @_;
 
     $state //= $TEST_COMPLETED;
 
@@ -1067,10 +1067,10 @@ and mark test with $hash_id as COMPLETED.
 =cut
 
 sub force_end_test {
-    my ( $self, $hash_id, $msg , $state ) = @_;
+    my ( $self, $hash_id, $msg, $state ) = @_;
 
     $self->add_result_entries( $hash_id, $msg );
-    $self->set_test_completed( $hash_id, $state);
+    $self->set_test_completed( $hash_id, $state );
 }
 
 =head2 process_dead_test($hash_id)

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -569,7 +569,7 @@ sub set_test_completed {
     my $current_state = $self->test_state( $test_id );
 
     if ( $current_state ne $TEST_RUNNING ) {
-        die Zonemaster::Backend::Error::Internal->new( reason => 'illegal transition to COMPLETED' );
+        die Zonemaster::Backend::Error::Internal->new( reason => 'illegal transition to terminal state (COMPLETED/CANCELLED/CRASHED)' );
     }
 
     my $rows_affected = $self->dbh->do(

--- a/lib/Zonemaster/Backend/DB.pm
+++ b/lib/Zonemaster/Backend/DB.pm
@@ -76,7 +76,7 @@ The test is waiting to be processed.
 
 =cut
 
-Readonly our $TEST_WAITING => 'WAITING';
+Readonly our $TEST_WAITING => 'waiting';
 
 =head2 $TEST_RUNNING
 
@@ -84,38 +84,39 @@ The test is currently being processed.
 
 =cut
 
-Readonly our $TEST_RUNNING => 'RUNNING';
+Readonly our $TEST_RUNNING => 'running';
 
 =head2 $TEST_COMPLETED
 
 The test was already processed.
 
-This state encompasses all of the following:
+=cut
 
-=over 2
+Readonly our $TEST_COMPLETED => 'completed';
 
-=item
+=head2 $TEST_CANCELLED
 
-The Zonemaster Engine test terminated normally.
-
-=item
-
-A critical error occurred while processing.
-
-=item
-
-The processing was cancelled because it took too long.
-
-=back
+The test was cancelled.
 
 =cut
 
-Readonly our $TEST_COMPLETED => 'COMPLETED';
+Readonly our $TEST_CANCELLED => 'cancelled';
+
+=head2 $TEST_CRASHED
+
+The test crashed.
+
+=cut
+
+Readonly our $TEST_CRASHED => 'crashed';
+
 
 our @EXPORT_OK = qw(
     $TEST_WAITING
     $TEST_RUNNING
     $TEST_COMPLETED
+    $TEST_CANCELLED
+    $TEST_CRASHED
 );
 
 

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -73,12 +73,14 @@ sub create_schema {
             priority integer DEFAULT 10,
             queue integer DEFAULT 0,
             progress integer DEFAULT 0,
+            state VARCHAR(20) NOT NULL DEFAULT "waiting",
             fingerprint character varying(32),
             params blob NOT NULL,
             results mediumblob DEFAULT NULL,
             undelegated integer NOT NULL DEFAULT 0,
 
-            UNIQUE (hash_id)
+            UNIQUE (hash_id),
+            CHECK (state IN ("waiting", "running", "completed", "cancelled", "crashed"))
         ) ENGINE=InnoDB
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'test_results' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/MySQL.pm
+++ b/lib/Zonemaster/Backend/DB/MySQL.pm
@@ -73,14 +73,14 @@ sub create_schema {
             priority integer DEFAULT 10,
             queue integer DEFAULT 0,
             progress integer DEFAULT 0,
-            state VARCHAR(20) NOT NULL DEFAULT "waiting",
+            state VARCHAR(20) NOT NULL DEFAULT \'waiting\',
             fingerprint character varying(32),
             params blob NOT NULL,
             results mediumblob DEFAULT NULL,
             undelegated integer NOT NULL DEFAULT 0,
 
             UNIQUE (hash_id),
-            CHECK (state IN ("waiting", "running", "completed", "cancelled", "crashed"))
+            CHECK (state IN (\'waiting\', \'running\', \'completed\', \'cancelled\', \'crashed\'))
         ) ENGINE=InnoDB
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "MySQL error, could not create 'test_results' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -70,14 +70,14 @@ sub create_schema {
                 priority integer DEFAULT 10,
                 queue integer DEFAULT 0,
                 progress integer DEFAULT 0,
-                state VARCHAR(20) NOT NULL DEFAULT "waiting",
+                state VARCHAR(20) NOT NULL DEFAULT \'waiting\',
                 fingerprint varchar(32),
                 params json NOT NULL,
                 undelegated integer NOT NULL DEFAULT 0,
                 results json,
 
                 UNIQUE (hash_id),
-                CHECK (state IN ("waiting", "running", "completed", "cancelled", "crashed"))
+                CHECK (state IN (\'waiting\', \'running\', \'completed\', \'cancelled\', \'crashed\'))
             )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'test_results' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/PostgreSQL.pm
+++ b/lib/Zonemaster/Backend/DB/PostgreSQL.pm
@@ -70,12 +70,14 @@ sub create_schema {
                 priority integer DEFAULT 10,
                 queue integer DEFAULT 0,
                 progress integer DEFAULT 0,
+                state VARCHAR(20) NOT NULL DEFAULT "waiting",
                 fingerprint varchar(32),
                 params json NOT NULL,
                 undelegated integer NOT NULL DEFAULT 0,
                 results json,
 
-                UNIQUE (hash_id)
+                UNIQUE (hash_id),
+                CHECK (state IN ("waiting", "running", "completed", "cancelled", "crashed"))
             )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "PostgreSQL error, could not create 'test_results' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/DB/SQLite.pm
+++ b/lib/Zonemaster/Backend/DB/SQLite.pm
@@ -73,12 +73,14 @@ sub create_schema {
                  priority integer DEFAULT 10,
                  queue integer DEFAULT 0,
                  progress integer DEFAULT 0,
+                 state VARCHAR(20) NOT NULL DEFAULT "waiting",
                  fingerprint character varying(32),
                  params text NOT NULL,
                  results text DEFAULT NULL,
                  undelegated boolean NOT NULL DEFAULT false,
 
-                 UNIQUE (hash_id)
+                 UNIQUE (hash_id),
+                 CHECK (state IN ("waiting", "running", "completed", "cancelled", "crashed"))
            )
         '
     ) or die Zonemaster::Backend::Error::Internal->new( reason => "SQLite error, could not create 'test_results' table", data => $dbh->errstr() );

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -375,7 +375,7 @@ sub job_status {
         $params->{test_id} = delete $params->{job_id};
         my $test_id = $params->{test_id};
 
-	my $job_results = $self->{db}->select_test_results( $test_id );
+        my $job_results = $self->{db}->select_test_results( $test_id );
 
         $result = {
             state => $self->{db}->test_state( $test_id ),

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -375,20 +375,22 @@ sub job_status {
         $params->{test_id} = delete $params->{job_id};
         my $test_id = $params->{test_id};
 
+	my $job_results = $self->{db}->select_test_results( $test_id );
+
         $result = {
             state => $self->{db}->test_state( $test_id ),
-            created_at => $self->{db}->select_test_results( $test_id )->{created_at},
+            created_at => $job_results->{created_at},
         };
 
         if ( $result->{state} ne $TEST_WAITING ) {
-            $result->{started_at} = $self->{db}->select_test_results( $test_id )->{started_at};
+            $result->{started_at} = $job_results->{started_at};
             $result->{progress}   = $self->{db}->test_progress( $test_id );
         }
 
         if ( $result->{state} eq $TEST_COMPLETED
             || $result->{state} eq $TEST_CANCELLED
             || $result->{state} eq $TEST_CRASHED ) {
-                $result->{ended_at} = $self->{db}->select_test_results( $test_id )->{ended_at};
+                $result->{ended_at} = $job_results->{ended_at};
         }
     };
     if ($@) {

--- a/lib/Zonemaster/Backend/RPCAPI.pm
+++ b/lib/Zonemaster/Backend/RPCAPI.pm
@@ -18,6 +18,7 @@ use Log::Any           qw( $log );
 use Mojo::JSON::Pointer;
 use POSIX        qw( setlocale );
 use Scalar::Util qw( blessed );
+use Zonemaster::Backend::DB qw( $TEST_WAITING $TEST_RUNNING $TEST_COMPLETED $TEST_CANCELLED $TEST_CRASHED );
 use Zonemaster::Backend::Errors;
 use Zonemaster::Backend::TLD_URL;
 use Zonemaster::Backend::Translator;
@@ -353,16 +354,47 @@ sub test_progress {
 }
 
 # Experimental
-$json_schemas{job_status} = joi->object->strict->props(    #
+# {
+#     "state": state,          // in all states
+#     "created_at": timestamp, // in all states
+#     "started_at": timestamp, // only in states "running", "completed", "cancelled" and "crashed"
+#     "ended_at": timestamp,   // only in states "completed", "cancelled" and "crashed"
+#     "progress": int          // only in states "running", "completed", "cancelled" and "crashed"
+# }
+
+$json_schemas{job_status} = joi->object->strict->props(
     job_id => $zm_validator->test_id->required
 );
 
 sub job_status {
     my ( $self, $params ) = @_;
 
-    $params->{test_id} = delete $params->{job_id};
 
-    my $result = { progress => $self->test_progress( $params ) };
+    my $result;
+    eval {
+        $params->{test_id} = delete $params->{job_id};
+        my $test_id = $params->{test_id};
+
+        $result = {
+            state => $self->{db}->test_state( $test_id ),
+            created_at => $self->{db}->select_test_results( $test_id )->{created_at},
+        };
+
+        if ( $result->{state} ne $TEST_WAITING ) {
+            $result->{started_at} = $self->{db}->select_test_results( $test_id )->{started_at};
+            $result->{progress}   = $self->{db}->test_progress( $test_id );
+        }
+
+        if ( $result->{state} eq $TEST_COMPLETED
+            || $result->{state} eq $TEST_CANCELLED
+            || $result->{state} eq $TEST_CRASHED ) {
+                $result->{ended_at} = $self->{db}->select_test_results( $test_id )->{ended_at};
+        }
+    };
+    if ($@) {
+        handle_exception( $@ );
+    }
+
     return $result;
 }
 

--- a/script/zmb
+++ b/script/zmb
@@ -314,6 +314,32 @@ sub cmd_get_test_params {
     );
 }
 
+=head2 job_status
+
+ zmb [GLOBAL OPTIONS] job_status [OPTIONS]
+
+ Options:
+   --job-id JOB_ID
+
+=cut
+
+sub cmd_job_status {
+    my @opts = @_;
+
+    my $opt_job_id;
+    GetOptionsFromArray(    #
+        \@opts,
+        'job-id|t=s' => \$opt_job_id,
+    ) or pod2usage( 2 );
+
+    return to_jsonrpc(
+        id     => 1,
+        method => 'job_status',
+        params => {
+            job_id => $opt_job_id,
+        },
+    );
+}
 
 =head2 get_test_results
 

--- a/share/patch/patch_db_schema_version_2.pl
+++ b/share/patch/patch_db_schema_version_2.pl
@@ -1,0 +1,88 @@
+use 5.14.2;
+use strict;
+use warnings;
+
+use Readonly;
+use Zonemaster::Backend::Config;
+
+Readonly my $TARGET_SCHEMA_VERSION   => 2;
+Readonly my $EXPECTED_SCHEMA_VERSION => $TARGET_SCHEMA_VERSION - 1;
+
+my $config = Zonemaster::Backend::Config->load_config();
+say "Configured database engine: ", $config->DB_engine;
+
+my $db               = $config->new_DB();
+my $detected_version = $db->get_schema_version();
+say "Target database schema version: ",        $TARGET_SCHEMA_VERSION;
+say "Expected pre-migration schema version: ", $EXPECTED_SCHEMA_VERSION;
+say "Detected database schema version: ",      $detected_version;
+
+if ( $detected_version eq $TARGET_SCHEMA_VERSION ) {
+    say "Schema already at target version.";
+    exit 0;
+}
+elsif ( $detected_version ne $EXPECTED_SCHEMA_VERSION ) {
+    say "Schema version requirement not met!";
+    exit 2;
+}
+
+say "Starting database migration";
+
+my $dbh    = $db->dbh;
+my $engine = $config->DB_engine;
+
+my $success = eval {
+    $dbh->begin_work;
+
+    if ( $engine eq 'MySQL' || $engine eq 'PostgreSQL' ) {
+        $dbh->do(
+            'ALTER TABLE test_results ADD COLUMN state VARCHAR(20) NOT NULL DEFAULT \'waiting\''
+        );
+        $dbh->do(
+            'ALTER TABLE test_results ADD CONSTRAINT test_results_state_check CHECK (state IN (\'waiting\', \'running\', \'completed\', \'cancelled\', \'crashed\'))'
+        );
+    }
+    elsif ( $engine eq 'SQLite' ) {
+        # SQLite does not reliably support adding a CHECK constraint via ALTER TABLE,
+        # so recreate the table using the current schema definition.
+        $dbh->do( 'ALTER TABLE test_results RENAME TO test_results_old' );
+
+        $db->create_schema();
+
+        $dbh->do( '
+            INSERT INTO test_results (
+                id, hash_id, domain, batch_id, created_at, started_at, ended_at,
+                priority, queue, progress, state, fingerprint, params, results, undelegated
+            )
+            SELECT
+                id, hash_id, domain, batch_id, created_at, started_at, ended_at,
+                priority, queue, progress, \'waiting\', fingerprint, params, results, undelegated
+            FROM test_results_old
+        ' );
+
+        $dbh->do( 'DROP TABLE test_results_old' );
+    }
+    else {
+        die "Unsupported database engine: $engine";
+    }
+
+    # Back-fill state for existing rows based on progress.
+    $dbh->do( "UPDATE test_results SET state = 'completed' WHERE progress = 100" );
+    $dbh->do( "UPDATE test_results SET state = 'running' WHERE progress > 0 AND progress < 100" );
+
+    # Update schema version.
+    $dbh->do( "UPDATE schema_version SET version = ? WHERE id = 1", {}, $TARGET_SCHEMA_VERSION );
+
+    $dbh->commit;
+    1;
+};
+
+
+if ( !$success ) {
+    my $error = $@;
+    eval { $dbh->rollback };
+    die "Migration failed: $error";
+}
+else {
+    say "Migration done";
+}

--- a/t/batches.t
+++ b/t/batches.t
@@ -175,6 +175,24 @@ subtest 'RPCAPI batch_status' => sub {
         ok( !exists $res->{running_tests}, 'list of running tests expected to be absent' );
         ok( !exists $res->{finished_tests}, 'list of finished tests to be absent' );
 
+        my ( $test_id ) = $rpcapi->{db}->dbh->selectrow_array(
+            'SELECT hash_id FROM test_results WHERE batch_id = ?',
+            undef,
+            $batch_id,
+        );
+
+        ok( $rpcapi->{db}->claim_test( $test_id ), 'batch test enters running state' );
+        $res = $rpcapi->batch_status( { batch_id => $batch_id } );
+        is( $res->{waiting_count}, 0, 'running test is not counted as waiting' );
+        is( $res->{running_count}, 1, 'running test is counted as running' );
+        is( $res->{finished_count}, 0, 'running test is not counted as finished' );
+
+        $rpcapi->{db}->store_results( $test_id, '{}' );
+        $res = $rpcapi->batch_status( { batch_id => $batch_id } );
+        is( $res->{waiting_count}, 0, 'completed test is not counted as waiting' );
+        is( $res->{running_count}, 0, 'completed test is not counted as running' );
+        is( $res->{finished_count}, 1, 'completed test is counted as finished' );
+
     };
 
     subtest 'unknown batch (batch_status)' => sub {

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -73,6 +73,26 @@ sub count_died_messages {
     return scalar grep { $_->{tag} eq 'TEST_DIED' } @{ $results->{results} };
 }
 
+sub assert_state_timestamps {
+    my ( $db, $test_id, $state ) = @_;
+    my $result = $db->select_test_results( $test_id );
+
+    ok defined $result->{created_at}, "$state test has a creation timestamp";
+
+    if ( $state eq $TEST_WAITING ) {
+        ok !defined $result->{started_at}, "Waiting test has no start timestamp";
+        ok !defined $result->{ended_at},   "Waiting test has no end timestamp";
+    }
+    elsif ( $state eq $TEST_RUNNING ) {
+        ok defined $result->{started_at}, "Running test has a start timestamp";
+        ok !defined $result->{ended_at},  "Running test has no end timestamp";
+    }
+    else {
+        ok defined $result->{started_at}, "Terminal $state test has a start timestamp";
+        ok defined $result->{ended_at},   "Terminal $state test has an end timestamp";
+    }
+}
+
 subtest 'Everything but Test::NoWarnings' => sub {
     lives_ok {    # Make sure we get to print log messages in case of errors.
         my $db = TestUtil::init_db( $config );
@@ -82,6 +102,7 @@ subtest 'Everything but Test::NoWarnings' => sub {
             is ref $testid1, '', "create_new_test should return 'testid' scalar";
             my $current_state = $db->test_state( $testid1 );
             is $current_state, $TEST_WAITING, "New test starts out in 'waiting' state.";
+            assert_state_timestamps( $db, $testid1, $TEST_WAITING );
 
             my @cases = (
                 {
@@ -138,6 +159,7 @@ subtest 'Everything but Test::NoWarnings' => sub {
                         is $current_state,
                           $case->{new_state},
                           "and it should move the test to '$case->{new_state}' state.";
+                        assert_state_timestamps( $db, $testid1, $case->{new_state} );
                     }
                     else {
                         $current_state = $db->test_state( $testid1 );
@@ -233,6 +255,8 @@ subtest 'Everything but Test::NoWarnings' => sub {
             is $db->test_progress( $testid2 ), 100, 'terminate test AFTER its timeout';
             is $db->test_state( $testid3 ), $TEST_RUNNING, 'test at timeout remains running';
             is $db->test_state( $testid2 ), $TEST_CANCELLED, 'test after timeout is cancelled';
+            assert_state_timestamps( $db, $testid3, $TEST_RUNNING );
+            assert_state_timestamps( $db, $testid2, $TEST_CANCELLED );
 
             is count_cancellation_messages( $db->test_results( $testid3 ) ), 0, 'no cancellation message present AT timeout';
             is count_cancellation_messages( $db->test_results( $testid2 ) ), 1, 'one cancellation message present AFTER timeout';
@@ -246,6 +270,7 @@ subtest 'Everything but Test::NoWarnings' => sub {
 
             is $db->test_progress( $testid4 ), 100, 'terminates test';
             is $db->test_state( $testid4 ), $TEST_CRASHED, 'terminated test is marked as crashed';
+            assert_state_timestamps( $db, $testid4, $TEST_CRASHED );
 
             is count_died_messages( $db->test_results( $testid4 ) ), 1, 'one died message present after crash';
         };

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -174,6 +174,7 @@ subtest 'Everything but Test::NoWarnings' => sub {
             # Logically progress is 0 entering the 'running' state, but because
             # of implementation details we're clamping it to the range 1-99
             # inclusive.
+            is $db->test_state( $testid1 ), $TEST_RUNNING, "Claimed test should be in 'running' state.";
             is $db->test_progress( $testid1 ), 1, "Progress should be 1 entering the 'running' state.";
 
             is $db->test_progress( $testid1, 0 ), 1, "Setting progress to 0 should succeed, but actual clamped value is returned,";
@@ -189,9 +190,11 @@ subtest 'Everything but Test::NoWarnings' => sub {
 
             is $db->test_progress( $testid1, 100 ), 99, "Setting progress to 100 should succeed, but actual clamped value is returned,";
             is $db->test_progress( $testid1 ),      99, "and it should persist at the clamped value.";
+            is $db->test_state( $testid1 ), $TEST_RUNNING, "Progress updates should not leave the 'running' state.";
 
             $db->store_results( $testid1, '{}' );
 
+            is $db->test_state( $testid1 ), $TEST_COMPLETED, "Stored results should put the test in 'completed' state.";
             throws_ok { $db->test_progress( $testid1, 100 ) } qr/illegal update/, "Setting progress should throw an exception in 'completed' state.";
         };
 
@@ -228,6 +231,8 @@ subtest 'Everything but Test::NoWarnings' => sub {
 
             is $db->test_progress( $testid3 ), 1,   'leave test alone AT its timeout';
             is $db->test_progress( $testid2 ), 100, 'terminate test AFTER its timeout';
+            is $db->test_state( $testid3 ), $TEST_RUNNING, 'test at timeout remains running';
+            is $db->test_state( $testid2 ), $TEST_CANCELLED, 'test after timeout is cancelled';
 
             is count_cancellation_messages( $db->test_results( $testid3 ) ), 0, 'no cancellation message present AT timeout';
             is count_cancellation_messages( $db->test_results( $testid2 ) ), 1, 'one cancellation message present AFTER timeout';
@@ -240,6 +245,7 @@ subtest 'Everything but Test::NoWarnings' => sub {
             $db->process_dead_test( $testid4 );
 
             is $db->test_progress( $testid4 ), 100, 'terminates test';
+            is $db->test_state( $testid4 ), $TEST_CRASHED, 'terminated test is marked as crashed';
 
             is count_died_messages( $db->test_results( $testid4 ) ), 1, 'one died message present after crash';
         };

--- a/t/lifecycle.t
+++ b/t/lifecycle.t
@@ -30,7 +30,7 @@ use TestUtil;
 
 use Zonemaster::Engine;
 use Zonemaster::Backend::Config;
-use Zonemaster::Backend::DB qw( $TEST_WAITING $TEST_RUNNING $TEST_COMPLETED );
+use Zonemaster::Backend::DB qw( $TEST_WAITING $TEST_RUNNING $TEST_COMPLETED $TEST_CANCELLED $TEST_CRASHED);
 
 sub advance_time {
     my ( $delta ) = @_;


### PR DESCRIPTION
## Purpose

Introduce a formal state column to the test_results table, replacing the implicit state inference from the progress integer with explicit, well-defined lifecycle states.

## Context

https://github.com/zonemaster/zonemaster-backend/issues/960

Previously, the state of a test was derived from the progress value (0 = waiting, 1-99 = running, 100 = completed). This made it impossible to distinguish between different terminal states (e.g., completed normally vs. cancelled vs. crashed). This PR adds a proper state column with five formal states.

## Changes

- Database schema (MySQL, PostgreSQL, SQLite): Added state VARCHAR(20) NOT NULL DEFAULT "waiting" column with a CHECK constraint limiting values to waiting, running, completed, cancelled, crashed.

- State constants (DB.pm): Lowercased existing constants (WAITING → waiting, RUNNING → running, COMPLETED → completed) and added two new ones: $TEST_CANCELLED and $TEST_CRASHED.


## How to test this PR
- Run the existing test suite to verify all state transitions work correctly.
- Verify database schema creation includes the new state column and CHECK constraint on all three backends (MySQL, PostgreSQL, SQLite).
- Confirm that cancelled and crashed tests are properly distinguished in the state column.
